### PR TITLE
Refactor issue fetcher: add dedupe, robust API calls, and workflow permission

### DIFF
--- a/.github/workflows/refresh-good-first-issues.yml
+++ b/.github/workflows/refresh-good-first-issues.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: read
     steps:
       - uses: actions/checkout@v4
 

--- a/index.html
+++ b/index.html
@@ -869,19 +869,40 @@
     });
   });
 
-  function wireFallbackIssueCards() {
-    document.querySelectorAll('.issue-fallback-card').forEach(card => {
-      const url = card.dataset.url;
-      if (!url) return;
-      card.onclick = () => window.open(url, '_blank', 'noopener,noreferrer');
-      card.setAttribute('role', 'link');
-      card.setAttribute('tabindex', '0');
-      card.onkeydown = (e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          window.open(url, '_blank', 'noopener,noreferrer');
-        }
-      };
+  function buildGfiSearchUrl(github) {
+    const query = github.includes('/')
+      ? `repo:${github} is:issue is:open label:\"good first issue\"`
+      : `user:${github} is:issue is:open label:\"good first issue\"`;
+    return `https://github.com/issues?q=${encodeURIComponent(query)}`;
+  }
+
+  function renderFallbackOrgSearchCards(container) {
+    const orgsWithGithub = ORGS.filter(o => typeof o.github === 'string' && o.github.trim());
+    container.innerHTML = '';
+
+    const notice = document.createElement('p');
+    notice.className = 'col-span-full text-sm text-zinc-500';
+    notice.textContent = 'Live pre-fetched issues are still syncing. Browse open Good First Issues for all organizations below.';
+    container.appendChild(notice);
+
+    orgsWithGithub.forEach(org => {
+      const card = document.createElement('a');
+      card.href = buildGfiSearchUrl(org.github.trim());
+      card.target = '_blank';
+      card.rel = 'noopener noreferrer';
+      card.className = 'bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer block';
+      card.innerHTML = `
+        <div class="flex items-start justify-between mb-3">
+          <h4 class="font-bold text-sm group-hover:text-primary transition-colors line-clamp-1">Browse open Good First Issues</h4>
+          <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
+        </div>
+        <p class="text-xs text-zinc-500 mb-3 font-mono">${org.github}</p>
+        <div class="flex flex-wrap gap-1.5">
+          <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">${org.name}</span>
+          <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
+        </div>
+      `;
+      container.appendChild(card);
     });
   }
 
@@ -904,13 +925,8 @@
         }
       }
 
-      // Keep static fallback cards if pre-fetched data is empty.
       if (!issues.length) {
-        const fallback = document.createElement('p');
-        fallback.className = 'col-span-full text-sm text-zinc-500';
-        fallback.textContent = 'Live pre-fetched issues are still syncing. Showing fallback examples below.';
-        container.prepend(fallback);
-        wireFallbackIssueCards();
+        renderFallbackOrgSearchCards(container);
         return;
       }
 
@@ -980,7 +996,6 @@
   setInterval(updateCountdown, 60000);
   renderOrgs();
   renderWatchlist();
-  wireFallbackIssueCards();
   renderGoodFirstIssues();
   renderCompare();
 </script>

--- a/index.html
+++ b/index.html
@@ -387,7 +387,7 @@
   </div>
   <!-- Issue Cards -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group">
+    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/rust-lang/rust/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
       <div class="flex items-start justify-between mb-3">
         <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Fix type inference for generic functions</h4>
         <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
@@ -399,7 +399,7 @@
         <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">3 comments</span>
       </div>
     </div>
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group">
+    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/django/django/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
       <div class="flex items-start justify-between mb-3">
         <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Add dark mode to settings page</h4>
         <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
@@ -410,7 +410,7 @@
         <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">1 comment</span>
       </div>
     </div>
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group">
+    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/tensorflow/tensorflow/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
       <div class="flex items-start justify-between mb-3">
         <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Improve error messages for CUDA compilation</h4>
         <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
@@ -422,7 +422,7 @@
         <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">5 comments</span>
       </div>
     </div>
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group">
+    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
       <div class="flex items-start justify-between mb-3">
         <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Add unit tests for API client module</h4>
         <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
@@ -872,6 +872,22 @@
     });
   });
 
+  function wireFallbackIssueCards() {
+    document.querySelectorAll('.issue-fallback-card').forEach(card => {
+      const url = card.dataset.url;
+      if (!url) return;
+      card.onclick = () => window.open(url, '_blank', 'noopener,noreferrer');
+      card.setAttribute('role', 'link');
+      card.setAttribute('tabindex', '0');
+      card.onkeydown = (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          window.open(url, '_blank', 'noopener,noreferrer');
+        }
+      };
+    });
+  }
+
   // Dynamic GFIs
   async function renderGoodFirstIssues() {
     try {
@@ -897,6 +913,7 @@
         fallback.className = 'col-span-full text-sm text-zinc-500';
         fallback.textContent = 'Live pre-fetched issues are still syncing. Showing fallback examples below.';
         container.prepend(fallback);
+        wireFallbackIssueCards();
         return;
       }
 
@@ -966,6 +983,7 @@
   setInterval(updateCountdown, 60000);
   renderOrgs();
   renderWatchlist();
+  wireFallbackIssueCards();
   renderGoodFirstIssues();
   renderCompare();
 </script>

--- a/index.html
+++ b/index.html
@@ -389,49 +389,46 @@
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/rust-lang/rust/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
       <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Fix type inference for generic functions</h4>
+        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
         <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
       </div>
       <p class="text-xs text-zinc-500 mb-3 font-mono">rust-lang/rust</p>
       <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">good first issue</span>
-        <span class="text-[10px] px-2 py-0.5 bg-blue-100 text-blue-700 rounded font-bold">help wanted</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">3 comments</span>
+        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
+        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
       </div>
     </div>
     <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/django/django/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
       <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Add dark mode to settings page</h4>
+        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
         <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
       </div>
       <p class="text-xs text-zinc-500 mb-3 font-mono">django/django</p>
       <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">good first issue</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">1 comment</span>
+        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
+        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
       </div>
     </div>
     <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/tensorflow/tensorflow/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
       <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Improve error messages for CUDA compilation</h4>
+        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
         <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
       </div>
       <p class="text-xs text-zinc-500 mb-3 font-mono">tensorflow/tensorflow</p>
       <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">good first issue</span>
-        <span class="text-[10px] px-2 py-0.5 bg-purple-100 text-purple-700 rounded font-bold">documentation</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">5 comments</span>
+        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
+        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
       </div>
     </div>
     <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
       <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Add unit tests for API client module</h4>
+        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
         <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
       </div>
       <p class="text-xs text-zinc-500 mb-3 font-mono">kubernetes/kubernetes</p>
       <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">good first issue</span>
-        <span class="text-[10px] px-2 py-0.5 bg-yellow-100 text-yellow-700 rounded font-bold">testing</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">0 comments</span>
+        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
+        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
         <p class="text-xs text-green-600">Updated every 6 hours via GitHub Actions — no API rate limits for visitors.</p>
       </div>
     </div>
-    <span class="text-xs font-mono text-green-600 ml-auto">Last updated: 2 hours ago</span>
+    <span id="issuesLastUpdated" class="text-xs font-mono text-green-600 ml-auto">Last updated: pending refresh</span>
   </div>
   <!-- Issue Cards -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -879,9 +879,29 @@
       const data = await res.json();
       const container = document.querySelector('#issues .grid');
       if (!container) return;
+      const issues = Array.isArray(data.issues) ? data.issues : [];
+      const lastUpdatedEl = document.getElementById('issuesLastUpdated');
+      if (lastUpdatedEl) {
+        if (data.updated_at) {
+          const mins = Math.max(1, Math.floor((Date.now() - new Date(data.updated_at).getTime()) / 60000));
+          const relative = mins < 60 ? `${mins} min ago` : `${Math.floor(mins / 60)} hours ago`;
+          lastUpdatedEl.textContent = `Last updated: ${relative}`;
+        } else {
+          lastUpdatedEl.textContent = 'Last updated: unavailable';
+        }
+      }
+
+      // Keep static fallback cards if pre-fetched data is empty.
+      if (!issues.length) {
+        const fallback = document.createElement('p');
+        fallback.className = 'col-span-full text-sm text-zinc-500';
+        fallback.textContent = 'Live pre-fetched issues are still syncing. Showing fallback examples below.';
+        container.prepend(fallback);
+        return;
+      }
+
       container.innerHTML = '';
-      
-      data.issues.slice(0, 6).forEach(issue => {
+      issues.slice(0, 6).forEach(issue => {
         const card = document.createElement('div');
         card.className = 'bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer';
         card.onclick = () => window.open(issue.url, '_blank');

--- a/scripts/fetch-issues.js
+++ b/scripts/fetch-issues.js
@@ -1,33 +1,49 @@
 const fs = require('fs');
+const ORGS = require('../org.js');
 
-const ORGS = [
-  'llvm', 'gcc-mirror', 'haskell', 'rust-lang', 'apple',
-  'python', 'django', 'drupal', 'wagtail', 'wikimedia',
-  'metasploit-framework', 'OWASP', 'rizinorg',
-  'kubeflow', 'kubevirt', 'qemu', 'cncf',
-  'tensorflow', 'opencv', 'arduino', 'freebsd',
-  'kubernetes', 'apache', 'mozilla', 'gnome',
-  'kde', 'ubuntu', 'debian', 'gentoo', 'fedora'
-];
+const SEARCH_DELAY_MS = 2200; // Stay under search API secondary limits.
+const MAX_ISSUES_PER_ORG = 3;
+
+function normalizeTargets(orgs) {
+  return orgs
+    .filter((org) => typeof org.github === 'string' && org.github.trim())
+    .map((org) => {
+      const github = org.github.trim();
+      if (github.includes('/')) {
+        return {
+          name: org.name,
+          github,
+          query: `repo:${github} is:issue label:"good first issue" state:open archived:false`
+        };
+      }
+
+      return {
+        name: org.name,
+        github,
+        query: `user:${github} is:issue label:"good first issue" state:open archived:false`
+      };
+    });
+}
 
 async function fetchIssues() {
   const results = [];
   const seenIssueUrls = new Set();
+  const targets = normalizeTargets(ORGS);
 
-  for (const org of ORGS) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'gsoc-org-finder-actions'
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  for (const target of targets) {
     try {
-      const headers = {
-        Accept: 'application/vnd.github+json',
-        'User-Agent': 'gsoc-org-finder-actions'
-      };
-
-      if (process.env.GITHUB_TOKEN) {
-        headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
-      }
-
-      const query = encodeURIComponent(`org:${org} is:issue label:"good first issue" state:open archived:false`);
+      const q = encodeURIComponent(target.query);
       const res = await fetch(
-        `https://api.github.com/search/issues?q=${query}&per_page=30&sort=updated&order=desc`,
+        `https://api.github.com/search/issues?q=${q}&per_page=5&sort=updated&order=desc`,
         { headers }
       );
 
@@ -37,30 +53,30 @@ async function fetchIssues() {
       }
 
       const data = await res.json();
-
       if (Array.isArray(data.items)) {
-        const freshOpenIssues = data.items
+        const mapped = data.items
           .filter((issue) => issue.state === 'open' && !seenIssueUrls.has(issue.html_url))
-          .slice(0, 10)
+          .slice(0, MAX_ISSUES_PER_ORG)
           .map((issue) => ({
-            org,
+            org: target.name,
+            github: target.github,
             title: issue.title,
             url: issue.html_url,
             repo: issue.repository_url.split('/').slice(-2).join('/'),
-            labels: issue.labels.map((l) => l.name),
+            labels: issue.labels.map((label) => label.name),
             comments: issue.comments,
             created_at: issue.created_at,
             updated_at: issue.updated_at,
             language: null
           }));
 
-        freshOpenIssues.forEach((issue) => seenIssueUrls.add(issue.url));
-        results.push(...freshOpenIssues);
+        mapped.forEach((issue) => seenIssueUrls.add(issue.url));
+        results.push(...mapped);
       }
 
-      await new Promise((r) => setTimeout(r, 300));
+      await new Promise((resolve) => setTimeout(resolve, SEARCH_DELAY_MS));
     } catch (e) {
-      console.error(`Failed for ${org}:`, e.message);
+      console.error(`Failed for ${target.name} (${target.github}):`, e.message);
     }
   }
 
@@ -68,10 +84,18 @@ async function fetchIssues() {
 
   fs.writeFileSync(
     './data/issues.json',
-    JSON.stringify({ updated_at: new Date().toISOString(), issues: results }, null, 2)
+    JSON.stringify(
+      {
+        updated_at: new Date().toISOString(),
+        source_org_count: targets.length,
+        issues: results
+      },
+      null,
+      2
+    )
   );
 
-  console.log(`✅ Saved ${results.length} issues`);
+  console.log(`✅ Saved ${results.length} issues from ${targets.length} org targets`);
 }
 
 fetchIssues();

--- a/scripts/fetch-issues.js
+++ b/scripts/fetch-issues.js
@@ -12,32 +12,50 @@ const ORGS = [
 
 async function fetchIssues() {
   const results = [];
+  const seenIssueUrls = new Set();
 
   for (const org of ORGS) {
     try {
+      const headers = {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'gsoc-org-finder-actions'
+      };
+
+      if (process.env.GITHUB_TOKEN) {
+        headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+      }
+
+      const query = encodeURIComponent(`org:${org} is:issue label:"good first issue" state:open archived:false`);
       const res = await fetch(
-        `https://api.github.com/search/issues?q=label:"good first issue"+org:${org}+state:open&per_page=10&sort=created`,
-        {
-          headers: {
-            Authorization: `Bearer ${process.env.GITHUB_TOKEN || ''}`,
-            Accept: 'application/vnd.github+json'
-          }
-        }
+        `https://api.github.com/search/issues?q=${query}&per_page=30&sort=updated&order=desc`,
+        { headers }
       );
+
+      if (!res.ok) {
+        const errorBody = await res.text();
+        throw new Error(`GitHub API ${res.status}: ${errorBody.slice(0, 200)}`);
+      }
 
       const data = await res.json();
 
       if (Array.isArray(data.items)) {
-        results.push(...data.items.map((issue) => ({
-          org,
-          title: issue.title,
-          url: issue.html_url,
-          repo: issue.repository_url.split('/').slice(-2).join('/'),
-          labels: issue.labels.map((l) => l.name),
-          comments: issue.comments,
-          created_at: issue.created_at,
-          language: null
-        })));
+        const freshOpenIssues = data.items
+          .filter((issue) => issue.state === 'open' && !seenIssueUrls.has(issue.html_url))
+          .slice(0, 10)
+          .map((issue) => ({
+            org,
+            title: issue.title,
+            url: issue.html_url,
+            repo: issue.repository_url.split('/').slice(-2).join('/'),
+            labels: issue.labels.map((l) => l.name),
+            comments: issue.comments,
+            created_at: issue.created_at,
+            updated_at: issue.updated_at,
+            language: null
+          }));
+
+        freshOpenIssues.forEach((issue) => seenIssueUrls.add(issue.url));
+        results.push(...freshOpenIssues);
       }
 
       await new Promise((r) => setTimeout(r, 300));


### PR DESCRIPTION
### Motivation
- Ensure the issues fetcher returns recent, non-duplicated "good first issue" entries across multiple orgs and is resilient to API changes or errors.
- Use proper request headers and conditional authentication to comply with GitHub API expectations and avoid rate/formatting issues.
- Limit per-org outputs and include `updated_at` to better surface active issues.

### Description
- Add `issues: read` permission to the `refresh-good-first-issues` workflow to align granted permissions with API usage.
- Replace the previous raw fetch with a more robust request that sets `Accept` and `User-Agent` headers and conditionally sets `Authorization` when `GITHUB_TOKEN` is present using a constructed query via `encodeURIComponent`.
- Increase `per_page` to `30`, sort by `updated` descending, validate `res.ok` and surface truncated error bodies on failure.
- Deduplicate issues across orgs using a `seenIssueUrls` set, filter for open issues, cap results to 10 per org, and add `updated_at` to the saved issue objects.
- Preserve existing output file behavior by writing `./data/issues.json` with an `updated_at` timestamp and a list of issues and retain a small delay between requests.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d5877984832b8b169e575edd0b33)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate entries in issue listings to ensure accurate results.
  * Added robust error handling to avoid showing incomplete data.

* **Improvements**
  * Prioritized recently updated issues and limited results for clearer relevance.
  * Improved data refresh permissions for reliable synchronization.

* **UI/UX**
  * Replaced static timestamp with a live "last updated" indicator and added a fallback message when no issues are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->