### PR TITLE
feat: add copy link button next to Project Ideas URL in modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -1174,6 +1174,29 @@
 
     document.getElementById('mIdeasBtn').href = org.ideas;
     document.getElementById('mRepoBtn').href = `https://github.com/${org.github}`;
+
+// Copy link button
+const oldCopy = document.getElementById('mIdeasCopyBtn');
+if(oldCopy) oldCopy.remove();
+if(org.ideas){
+  const copyBtn = document.createElement('button');
+  copyBtn.id = 'mIdeasCopyBtn';
+  copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">content_copy</span> Copy Link';
+  copyBtn.className = 'modal-cta modal-repo-link flex items-center justify-center gap-2';
+  copyBtn.onclick = function(){
+    navigator.clipboard.writeText(org.ideas).then(()=>{
+      copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">check_circle</span> Copied!';
+      copyBtn.style.background = '#dcfce7';
+      copyBtn.style.color = '#166534';
+      setTimeout(()=>{
+        copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">content_copy</span> Copy Link';
+        copyBtn.style.background = '';
+        copyBtn.style.color = '';
+      }, 2000);
+    });
+  };
+  document.getElementById('mIdeasBtn').after(copyBtn);
+}
     
     document.getElementById('orgModal').classList.add('open');
     document.body.style.overflow = 'hidden';


### PR DESCRIPTION
## 📝 Description  
Adds a **Copy Link button** next to the Project Ideas URL inside the organization detail modal. This improves user experience by allowing quick copying of the ideas link without manual selection.

## 🔗 Related Issue  
Closes #76  

## 🔄 Type of Change  
- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [ ] 🔍 SEO improvement  
- [ ] 🎨 Style / UI improvement  
- [ ] ♿ Accessibility improvement  
- [ ] 📝 Documentation  
- [ ] ⚙️ CI / configuration  
- [ ] 🧹 Refactor / cleanup  

## 🧪 How to Test  
1. Open `index.html` in a browser  
2. Open the organization detail modal  
3. Check if the **Copy Link** button appears for orgs with a Project Ideas URL  
4. Click the button → URL should be copied to clipboard  
5. Verify button text changes to **"Copied!"** for 2 seconds  
6. Ensure button disappears for orgs without an ideas link  

## ✅ Checklist  
- [x] My code follows the project's existing style  
- [x] I have tested my changes in a browser  
- [x] I have linked the related issue above  
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)  