### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   lint-javascript:
     name: 🔍 Lint JavaScript


### PR DESCRIPTION
Potential fix for [https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/security/code-scanning/3](https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/code-quality.yml` so all jobs inherit least-privilege token access.  
Best fix without changing functionality: set:

- `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout@v4` and the lint-only jobs shown. Place it near the top of the workflow (after `on:` or before `jobs:`) so it applies uniformly to `lint-javascript`, `lint-css`, and `lint-html` without duplicating config per job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
