### PR TITLE
Create PR in issues-refresh workflow, enhance SEO/OG metadata, and allow crawling bots in robots.txt

### DIFF
--- a/.github/workflows/refresh-good-first-issues.yml
+++ b/.github/workflows/refresh-good-first-issues.yml
@@ -26,7 +26,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 
+        #v8.1.1
         with:
           commit-message: 'chore: refresh good first issues [skip ci]'
           title: 'chore: refresh good first issues'

--- a/.github/workflows/refresh-good-first-issues.yml
+++ b/.github/workflows/refresh-good-first-issues.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
       issues: read
     steps:
       - uses: actions/checkout@v4
@@ -24,11 +25,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit & push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/issues.json
-          git diff --staged --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: refresh good first issues [skip ci]"
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: 'chore: refresh good first issues [skip ci]'
+          title: 'chore: refresh good first issues'
+          body: 'Automated refresh of good first issues'
+          branch: refresh-issues
+          delete-branch: true
+          add-paths: |
+            data/issues.json

--- a/.github/workflows/refresh-good-first-issues.yml
+++ b/.github/workflows/refresh-good-first-issues.yml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: 'chore: refresh good first issues [skip ci]'
           title: 'chore: refresh good first issues'

--- a/index.html
+++ b/index.html
@@ -3,9 +3,35 @@
 <head>
   <meta charset="utf-8" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-  <title>FindMyGSoC — GSoC 2026 Org Finder</title>
-  <meta name="description" content="Find your perfect GSoC 2026 organization. Filter by language, category, competition level, and live GitHub activity. Land your summer internship." />
+  <title>Live GSoC 2026 Org Finder & Good First Issue Tracker | FindMyGSoC</title>
+  <meta name="description" content="Live GSoC 2026 Org Finder & Good First Issue Tracker. Discover organizations, compare project fit, and track beginner-friendly GitHub issues in real time." />
   <link rel="canonical" href="https://findmygsoc.vercel.app/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="FindMyGSoC" />
+  <meta property="og:title" content="Live GSoC 2026 Org Finder & Good First Issue Tracker" />
+  <meta property="og:description" content="Discover Google Summer of Code 2026 organizations and track live good first issues across GitHub." />
+  <meta property="og:url" content="https://findmygsoc.vercel.app/" />
+  <meta property="og:image" content="https://findmygsoc.vercel.app/og-image.jpeg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Live GSoC 2026 Org Finder & Good First Issue Tracker" />
+  <meta name="twitter:description" content="Find your best-fit GSoC 2026 org and track beginner-friendly GitHub issues." />
+  <meta name="twitter:image" content="https://findmygsoc.vercel.app/og-image.jpeg" />
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "FindMyGSoC",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Web",
+      "url": "https://findmygsoc.vercel.app/",
+      "description": "Live GSoC 2026 organization finder and good first issue tracker for student contributors.",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      }
+    }
+  </script>
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,13 @@
 User-agent: *
 Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
 Sitemap: https://findmygsoc.vercel.app/sitemap.xml


### PR DESCRIPTION
### Motivation
- Automate publishing of refreshed "good first issues" data via a pull request instead of direct pushes so changes can be reviewed before merging.
- Improve site discoverability and social sharing by adding richer page metadata, Open Graph, Twitter cards, and a `SoftwareApplication` JSON-LD entry in `index.html`.
- Allow selected crawlers to index the site by explicitly whitelisting bots in `robots.txt`.

### Description
- Updated `.github/workflows/refresh-good-first-issues.yml` to grant `pull-requests: write` permission and replace the manual commit/push steps with `peter-evans/create-pull-request@v5`, creating a `refresh-issues` branch and PR that adds `data/issues.json` with the commit message `chore: refresh good first issues [skip ci]`.
- Enhanced `index.html` by changing the page `title` and `meta` `description`, adding Open Graph and Twitter card tags, and embedding a JSON-LD `SoftwareApplication` schema and OG image URL for improved sharing and SEO.
- Extended `robots.txt` to explicitly allow `GPTBot`, `Google-Extended`, and `PerplexityBot`, and included the sitemap URL.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e60c8b15e4832bbe250a5aabdc65f9)