### PR TITLE
Fix: add a timestamp query param to force a fresh fetch every page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -1340,7 +1340,7 @@ if(org.ideas){
   // Dynamic GFIs
   async function renderGoodFirstIssues() {
     try {
-      const res = await fetch('data/issues.json?v=${Date.now()}`);
+      const res = await fetch('data/issues.json?v=' + Date.now());
       const data = await res.json();
       const container = document.querySelector('#issues .grid');
       if (!container) return;

--- a/index.html
+++ b/index.html
@@ -1340,7 +1340,7 @@ if(org.ideas){
   // Dynamic GFIs
   async function renderGoodFirstIssues() {
     try {
-      const res = await fetch('data/issues.json');
+      const res = await fetch('data/issues.json?v=${Date.now()}`);
       const data = await res.json();
       const container = document.querySelector('#issues .grid');
       if (!container) return;


### PR DESCRIPTION
## 📝 Description
<!-- Describe what this PR does and why -->
This forces the browser and CDN to always fetch the latest version of the file every time the page loads, so users always see the freshest GFI data after each automated refresh PR is merged.

## 🔗 Related Issue
Closes #<!-- issue number -->
N/A

## 🔄 Type of Change
<!-- Check all that apply -->
- [*] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
<!-- Steps to verify your change works correctly -->
1. Open `index.html` in a browser
2. ...

## 📸 Screenshots (if applicable)
<!-- Before and after screenshots for UI changes -->
N/A

## ✅ Checklist
- [*] My code follows the project's existing style
- [ ] I have tested my changes in a browser
- [ ] I have linked the related issue above
- [*] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)