### PR TITLE
fix: enable Vercel deployment by replacing [skip ci] with [skip actions]

### DIFF
--- a/.github/workflows/refresh-good-first-issues.yml
+++ b/.github/workflows/refresh-good-first-issues.yml
@@ -29,7 +29,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 
         #v8.1.1
         with:
-          commit-message: 'chore: refresh good first issues [skip ci]'
+          commit-message: 'chore: refresh good first issues [skip actions]'
           title: 'chore: refresh good first issues'
           body: 'Automated refresh of good first issues'
           branch: refresh-issues


### PR DESCRIPTION
## 📝 Description
Fixes the issue where Vercel deployment was not triggering due to the [skip ci] flag in the workflow commit message.

Replaced [skip ci] with [skip actions] to ensure deployments run correctly while preventing workflow loops.

## 🔗 Related Issue
Closes #120

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [x] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Trigger the refresh-good-first-issues workflow
2. Verify that Vercel deployment runs after commit
3. Confirm updated data reflects on live site

## 📸 Screenshots (if applicable)

## ✅ Checklist
- [x] My code follows the project's existing style
- [ ] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format