### PR TITLE
fix: load cached issues on page open without manual click

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -849,9 +849,26 @@ const ISSUES_PAGE_SIZE=40;
 let issuesFetching=false;
 
 function openIssuesPage(){
+  loadCachedIssues();
   document.getElementById('issuesPage').classList.add('open');
   document.body.style.overflow='hidden';
 }
+
+async function loadCachedIssues() {
+  if (allIssues.length > 0 || issuesFetching) return;
+  try {
+    const res = await fetch('/data/issues.json');
+    if (!res.ok) return;
+    const data = await res.json();
+    if (data && Array.isArray(data.issues)) {
+      allIssues = data.issues;
+      filterIssues();
+    }
+  } catch (err) {
+    console.warn('Failed to load cached issues:', err);
+  }
+}
+
 function closeIssuesPage(){
   document.getElementById('issuesPage').classList.remove('open');
   document.body.style.overflow='';


### PR DESCRIPTION
## 📝 Description

Fixes the issue where the Good First Issues page was not loading pre-seeded issues automatically. Now the page fetches data from `/data/issues.json` on load and displays issues instantly without requiring a manual button click.

## 🔗 Related Issue

Closes #131

## 🔄 Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 🔍 SEO improvement
* [ ] 🎨 Style / UI improvement
* [ ] ♿ Accessibility improvement
* [ ] 📝 Documentation
* [ ] ⚙️ CI / configuration
* [ ] 🧹 Refactor / cleanup

## 🧪 How to Test

1. Open `index.html` in a browser or run `npx serve .`
2. Navigate to the Good First Issues page
3. Verify that issues load automatically without clicking "Load Issues"
4. Click "Load Issues" button and confirm it still fetches live data

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

* [x] My code follows the project's existing style
* [x] I have tested my changes in a browser
* [x] I have linked the related issue above
* [x] My PR title follows Conventional Commits format
