### PR TITLE
fix: filter stale issues older than 12 months

### DIFF
--- a/agent/scripts/fetch-issues.js
+++ b/agent/scripts/fetch-issues.js
@@ -30,6 +30,9 @@ async function fetchIssues() {
   const seenIssueUrls = new Set();
   const targets = normalizeTargets(ORGS);
 
+  const oneYearAgo = new Date();
+  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
   const headers = {
     Accept: 'application/vnd.github+json',
     'User-Agent': 'gsoc-org-finder-actions'
@@ -55,7 +58,7 @@ async function fetchIssues() {
       const data = await res.json();
       if (Array.isArray(data.items)) {
         const mapped = data.items
-          .filter((issue) => issue.state === 'open' && !seenIssueUrls.has(issue.html_url))
+          .filter((issue) => issue.state === 'open' && !seenIssueUrls.has(issue.html_url) && new Date(issue.updated_at) >= oneYearAgo)
           .slice(0, MAX_ISSUES_PER_ORG)
           .map((issue) => ({
             org: target.name,


### PR DESCRIPTION
## 📝 Description

Adds a recency filter to the issue fetching script to exclude stale issues older than 12 months. This ensures only relevant and active issues are included in data/issues.json.

## 🔗 Related Issue

Closes #134

## 🔄 Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 🔍 SEO improvement
* [ ] 🎨 Style / UI improvement
* [ ] ♿ Accessibility improvement
* [ ] 📝 Documentation
* [ ] ⚙️ CI / configuration
* [ ] 🧹 Refactor / cleanup

## 🧪 How to Test

1. Run the fetch script or inspect logic in `fetch-issues.js`
2. Verify issues older than 12 months (based on `updated_at`) are excluded
3. Ensure recent issues are still included
4. Confirm no errors occur during execution

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

* [x] My code follows the project's existing style
* [x] I have tested my changes
* [x] I have linked the related issue above
* [x] My PR title follows Conventional Commits format
