### PR TITLE
fix: add logo field to issues for frontend rendering

### DIFF
--- a/agent/scripts/fetch-issues.js
+++ b/agent/scripts/fetch-issues.js
@@ -57,18 +57,22 @@ async function fetchIssues() {
         const mapped = data.items
           .filter((issue) => issue.state === 'open' && !seenIssueUrls.has(issue.html_url))
           .slice(0, MAX_ISSUES_PER_ORG)
-          .map((issue) => ({
-            org: target.name,
-            github: target.github,
-            title: issue.title,
-            url: issue.html_url,
-            repo: issue.repository_url.split('/').slice(-2).join('/'),
-            labels: issue.labels.map((label) => label.name),
-            comments: issue.comments,
-            created_at: issue.created_at,
-            updated_at: issue.updated_at,
-            language: null
-          }));
+          .map((issue) => {
+            const orgName = target.github.split('/')[0];
+            return {
+              org: target.name,
+              github: target.github,
+              logo: `https://avatars.githubusercontent.com/${orgName}`,
+              title: issue.title,
+              url: issue.html_url,
+              repo: issue.repository_url.split('/').slice(-2).join('/'),
+              labels: issue.labels.map((label) => label.name),
+              comments: issue.comments,
+              created_at: issue.created_at,
+              updated_at: issue.updated_at,
+              language: null
+            };
+          });
 
         mapped.forEach((issue) => seenIssueUrls.add(issue.url));
         results.push(...mapped);


### PR DESCRIPTION
## 📝 Description

Adds a missing `logo` field to each issue object in the fetch script. This ensures that org logos are correctly displayed when the frontend reads data/issues.json.

## 🔗 Related Issue

Closes #135

## 🔄 Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 🔍 SEO improvement
* [ ] 🎨 Style / UI improvement
* [ ] ♿ Accessibility improvement
* [ ] 📝 Documentation
* [ ] ⚙️ CI / configuration
* [ ] 🧹 Refactor / cleanup

## 🧪 How to Test

1. Run or review `fetch-issues.js`
2. Verify each issue object includes a `logo` field
3. Confirm the logo URL format is correct (`https://avatars.githubusercontent.com/<org>`)
4. Ensure no errors occur

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

* [x] My code follows the project's existing style
* [x] I have tested my changes
* [x] I have linked the related issue above
* [x] My PR title follows Conventional Commits format
