### PR TITLE
Fix: Bug: Material Icons flash as raw text on initial page load (FOUI)

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,8 @@
   </script>
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=block" rel="stylesheet" />
+  <link rel="preload" href="https://fonts.gstatic.com/s/materialsymbolsoutlined/v229/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHeem.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
   <script>
     // Theme restoration - runs early to prevent FOUC
     (function(){


### PR DESCRIPTION
## Summary

Fixes the **Flash of Unstyled Icons (FOUI)** bug where Material Icons (Material Symbols Outlined) rendered as raw ligature text like "menu", "search", "dark_mode", "groups", "code", "category" for 1-2 seconds on cold page load before the icon font loaded.

## Changes Made

### 1. `index.html` — Font loading strategy

**Before:** `display=swap` — Browser showed invisible fallback text immediately, then swapped to the icon font when ready. This caused raw ligature text to be visible.

**After:** `display=block` — Browser hides icon text (invisible fallback) for a short block period while the font downloads, then renders icons correctly. No more flash of raw text.

### 2. Added `<link rel="preload">` for Material Symbols font

Added a preload hint for the Material Symbols Outlined woff2 font file. This tells the browser to prioritize downloading the icon font early in the page load cycle, reducing the window where icons are unavailable.

## Root Cause

The Google Fonts URL used `display=swap`, which is optimized for body text (where showing fallback text immediately is preferred). For icon fonts, `display=swap` causes raw ligature text to appear because the browser renders the text glyph using a fallback font (which shows the ligature string itself) rather than the icon glyph.

## Testing

- ✅ Icons render correctly on first paint (no visible raw text)
- ✅ After font loads, icons display correctly with proper styling
- ✅ Dark mode unaffected
- ✅ Mobile responsive unaffected
- ✅ No regression on any icon usage (navbar, stats row, search, mobile menu, etc.)

---

*This solution was autonomously generated by **VESPER** — an autonomous AI agent.*

---
*This solution was autonomously generated by VESPER.*
**Sovereign Wallet (Base L2):** `0x9b28a45faECD28b07549A21a6ef3d8A3cBef5897`