### PR TITLE
feat: add friendly empty state for zero filter results (#75)

### DIFF
--- a/index.html
+++ b/index.html
@@ -527,6 +527,16 @@
     </div>
   </div>
 
+  <!-- Empty State -->
+  <div id="emptyState" class="hidden py-20 text-center animate-fade-up">
+    <div class="text-6xl mb-4">🔍</div>
+    <h3 class="text-2xl font-bold text-zinc-900 dark:text-white mb-2">No organizations match your current filters.</h3>
+    <p class="text-zinc-500 dark:text-zinc-400 mb-8">Try adjusting your search or clearing some filters.</p>
+    <button onclick="clearAllFilters()" class="px-8 py-3 bg-primary text-white rounded-xl font-bold hover:bg-orange-600 transition-colors shadow-lg shadow-primary/20">
+      Clear All Filters
+    </button>
+  </div>
+
   <div class="mt-12 flex justify-center" id="loadMoreContainer" style="display:none">
     <button id="loadMoreBtn" class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2">
       View More Organizations <span class="material-symbols-outlined text-lg">expand_more</span>
@@ -1077,9 +1087,21 @@
 
   function renderOrgs(reset = true) {
     const grid = document.getElementById('orgGrid');
+    const emptyState = document.getElementById('emptyState');
     if (reset) {
       grid.innerHTML = '';
       visibleCount = 12;
+    }
+
+    if (filteredOrgs.length === 0) {
+      grid.classList.add('hidden');
+      if (emptyState) emptyState.classList.remove('hidden');
+      document.getElementById('orgCount').textContent = '0';
+      document.getElementById('loadMoreContainer').style.display = 'none';
+      return;
+    } else {
+      grid.classList.remove('hidden');
+      if (emptyState) emptyState.classList.add('hidden');
     }
     
     const slice = filteredOrgs.slice(visibleCount - 12, visibleCount);
@@ -1323,6 +1345,23 @@ if(org.ideas){
 
     renderOrgs(true);
   }
+
+  window.clearAllFilters = function() {
+    document.getElementById('searchInput').value = '';
+    document.getElementById('categoryFilter').value = 'all';
+    document.getElementById('complexityFilter').value = 'all';
+    const heroSearch = document.getElementById('hero-search');
+    if (heroSearch) heroSearch.value = '';
+    
+    // Reset chips
+    document.querySelectorAll('.filter-chip').forEach(chip => {
+      chip.classList.remove('bg-orange-600', 'text-white');
+      chip.classList.add('bg-surface-container-highest');
+    });
+
+    filteredOrgs = [...ORGS];
+    renderOrgs(true);
+  };
 
   document.getElementById('searchInput').addEventListener('input', applyFilters);
   document.getElementById('categoryFilter').addEventListener('change', applyFilters);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -589,10 +589,18 @@ function renderGfiBadge(gh){
   if(gh?.gfi===null||gh?.gfi===undefined)return '';
   return `<span class="gh-s">🟢 <b>${fmt(gh.gfi)} GFI</b></span>`;
 }
-
 function renderGrid(orgs){
   const g=document.getElementById('orgGrid');
-  if(!orgs.length){g.innerHTML=`<div class="empty"><div class="empty-icon">🔍</div><h3>No matches found</h3><p>Try removing some filters.</p></div>`;return}
+  if(!orgs.length){
+    g.innerHTML=`
+      <div class="empty">
+        <div class="empty-icon">🔍</div>
+        <h3>No organizations match your current filters.</h3>
+        <p>Try adjusting your search or clearing some filters.</p>
+        <button onclick="resetFilters()" class="btn-clear-filters">Clear All Filters</button>
+      </div>`;
+    return;
+  }
   g.innerHTML=orgs.map((o,i)=>{
     const act=o._gh?.activity||null;
     const tags=o.tags.slice(0,5).map(t=>`<span class="tag">${t}</span>`).join('');

--- a/src/styles.css
+++ b/src/styles.css
@@ -283,6 +283,9 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 .empty{grid-column:1/-1;text-align:center;padding:70px 20px;color:var(--muted)}
 .empty-icon{font-size:44px;margin-bottom:14px}
 .empty h3{font-family:'Playfair Display',serif;font-size:21px;color:var(--ink);margin-bottom:8px}
+.empty p{font-size:14px;margin-bottom:24px}
+.btn-clear-filters{display:inline-flex;align-items:center;gap:8px;padding:10px 22px;background:var(--ink);color:var(--bg);border:none;border-radius:10px;font-size:13px;font-weight:700;cursor:pointer;transition:all .18s;font-family:'Plus Jakarta Sans',sans-serif}
+.btn-clear-filters:hover{background:var(--orange);color:white;transform:translateY(-1px);box-shadow:0 4px 12px rgba(244,107,14,.2)}
 
 /* ── MODAL ── */
 .modal-bg{position:fixed;inset:0;z-index:100;background:rgba(28,16,8,.5);backdrop-filter:blur(8px);display:none;align-items:center;justify-content:center;padding:20px}

--- a/src/styles.css
+++ b/src/styles.css
@@ -285,7 +285,7 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 .empty h3{font-family:'Playfair Display',serif;font-size:21px;color:var(--ink);margin-bottom:8px}
 .empty p{font-size:14px;margin-bottom:24px}
 .btn-clear-filters{display:inline-flex;align-items:center;gap:8px;padding:10px 22px;background:var(--ink);color:var(--bg);border:none;border-radius:10px;font-size:13px;font-weight:700;cursor:pointer;transition:all .18s;font-family:'Plus Jakarta Sans',sans-serif}
-.btn-clear-filters:hover{background:var(--orange);color:white;transform:translateY(-1px);box-shadow:0 4px 12px rgba(244,107,14,.2)}
+.btn-clear-filters:hover{background:var(--orange);color:white;transform:translateY(-1px);box-shadow:0 4px 12px rgb(244 107 14 / 0.2)}
 
 /* ── MODAL ── */
 .modal-bg{position:fixed;inset:0;z-index:100;background:rgba(28,16,8,.5);backdrop-filter:blur(8px);display:none;align-items:center;justify-content:center;padding:20px}


### PR DESCRIPTION
## 📝 Description
This PR implements a friendly empty state for the organization grid. Previously, when a search or filter returned no matches, the grid would simply go blank, leading to a confusing user experience. 

Now, when no results are found:
- A centered empty state block is displayed with a 🔍 emoji.
- A helpful message and sub-message guide the user.
- A "Clear All Filters" button allows users to reset their search with a single click.

I have updated the inline logic in `index.html` (the primary site file) as well as the modular `app.js` and `styles.css` to ensure the codebase remains consistent and future-proof.

## 🔗 Related Issue
Closes #75

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔍 SEO improvement
- [x] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Open `index.html` in a browser.
2. Type a random string like "qwerty" into the search bar.
3. Verify that the empty state appears with the "Clear All Filters" button.
4. Click the button and verify all filters (search, categories, chips) are reset and the grid is restored.
5. Apply filters that result in zero matches to verify detection logic works for both search and dropdown/chip filters.

## 📸 Screenshots (if applicable)
<img width="1919" height="936" alt="image" src="https://github.com/user-attachments/assets/49dfa55c-acef-46ee-8356-d4cbc2e7e4d2" />

## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
