### PR TITLE
feat: auto-assign issues by title and description context

### DIFF
--- a/.github/issue-routing.json
+++ b/.github/issue-routing.json
@@ -1,0 +1,27 @@
+{
+  "default_assignees": [
+    "S3DFX-CYBER"
+  ],
+  "routes": [
+    {
+      "name": "Frontend/UI",
+      "keywords": ["ui", "ux", "frontend", "css", "html", "javascript", "accessibility", "responsive"],
+      "assignees": ["S3DFX-CYBER"]
+    },
+    {
+      "name": "Backend/API",
+      "keywords": ["backend", "api", "server", "endpoint", "database", "performance", "security"],
+      "assignees": ["S3DFX-CYBER"]
+    },
+    {
+      "name": "CI/CD & DevOps",
+      "keywords": ["workflow", "github action", "ci", "cd", "pipeline", "deploy", "build", "test"],
+      "assignees": ["S3DFX-CYBER"]
+    },
+    {
+      "name": "Documentation",
+      "keywords": ["docs", "documentation", "readme", "guide", "typo", "spell", "contributing"],
+      "assignees": ["S3DFX-CYBER"]
+    }
+  ]
+}

--- a/.github/workflows/issue-context-assignment.yml
+++ b/.github/workflows/issue-context-assignment.yml
@@ -1,0 +1,78 @@
+name: 🧭 Issue Context Assignment
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  assign-by-context:
+    if: github.event.issue.pull_request == null
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Auto-assign issue based on title and description context
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = '.github/issue-routing.json';
+
+            if (!fs.existsSync(path)) {
+              core.setFailed(`Missing routing config at ${path}`);
+              return;
+            }
+
+            const config = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const issue = context.payload.issue;
+            const text = `${issue.title || ''}\n${issue.body || ''}`.toLowerCase();
+
+            const selected = new Set();
+            const matchedRoutes = [];
+
+            for (const route of (config.routes || [])) {
+              const keywords = (route.keywords || []).map(k => String(k).toLowerCase());
+              const hit = keywords.some(k => text.includes(k));
+              if (hit) {
+                matchedRoutes.push(route.name || 'unnamed-route');
+                for (const a of (route.assignees || [])) {
+                  if (a) selected.add(a);
+                }
+              }
+            }
+
+            if (selected.size === 0) {
+              for (const a of (config.default_assignees || [])) {
+                if (a) selected.add(a);
+              }
+            }
+
+            const assignees = Array.from(selected);
+            if (assignees.length === 0) {
+              core.info('No assignees resolved. Skipping assignment.');
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = issue.number;
+
+            const currentlyAssigned = new Set((issue.assignees || []).map(a => a.login));
+            const toAdd = assignees.filter(a => !currentlyAssigned.has(a));
+
+            if (toAdd.length === 0) {
+              core.info('Issue already has all resolved assignees.');
+              return;
+            }
+
+            await github.rest.issues.addAssignees({ owner, repo, issue_number, assignees: toAdd });
+
+            core.info(`Matched routes: ${matchedRoutes.length ? matchedRoutes.join(', ') : 'none (used default)'} `);
+            core.info(`Assigned: ${toAdd.join(', ')}`);

--- a/.github/workflows/issue-context-assignment.yml
+++ b/.github/workflows/issue-context-assignment.yml
@@ -39,7 +39,7 @@ jobs:
 
             for (const route of (config.routes || [])) {
               const keywords = (route.keywords || []).map(k => String(k).toLowerCase());
-              const hit = keywords.some(k => text.includes(k));
+              const hit = keywords.some(k => new RegExp(`\\b${k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(text));
               if (hit) {
                 matchedRoutes.push(route.name || 'unnamed-route');
                 for (const a of (route.assignees || [])) {

--- a/.github/workflows/issue-context-assignment.yml
+++ b/.github/workflows/issue-context-assignment.yml
@@ -72,7 +72,13 @@ jobs:
               return;
             }
 
+            try {
             await github.rest.issues.addAssignees({ owner, repo, issue_number, assignees: toAdd });
-
-            core.info(`Matched routes: ${matchedRoutes.length ? matchedRoutes.join(', ') : 'none (used default)'} `);
+            core.info(`Matched routes: ${matchedRoutes.length ? matchedRoutes.join(', ') : 'none (used default)'}`);
             core.info(`Assigned: ${toAdd.join(', ')}`);
+            } catch (err) {
+            core.warning('Failed to assign ${toAdd.join(', ')}: ${err.message}`);
+            }
+            
+
+            


### PR DESCRIPTION
### Motivation
- Automate assignment of newly opened/edited/reopened issues by matching keywords in the issue title and description to reduce manual triage and address issue #179.

### Description
- Add `.github/issue-routing.json` containing `default_assignees` and keyword-based `routes` for Frontend/UI, Backend/API, CI/CD & DevOps, and Documentation.
- Add `.github/workflows/issue-context-assignment.yml` which runs on `issues` events, reads the routing config, matches keywords in the issue title and body, resolves assignees (with fallback to `default_assignees`), and avoids re-adding already-assigned users while skipping pull-request issues.

### Testing
- Verified the routing JSON can be parsed with `node` by running `node -e "JSON.parse(require('fs').readFileSync('.github/issue-routing.json','utf8'))"`, which succeeded.
- Attempted to validate the workflow YAML using `python` with `yaml.safe_load(...)`, which failed because `PyYAML` is not installed in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c6aac75c832bb0276f36b1ba59d2)