### PR TITLE
fix: correct TENET PR Review workflow skip logic when TENET_AI_KEY is missing

### DIFF
--- a/.github/workflows/tenet-pr-review.yml
+++ b/.github/workflows/tenet-pr-review.yml
@@ -35,16 +35,20 @@ jobs:
         run: pip install -r agent/tenet_agent/requirements.txt
 
       - name: Check TENET_AI_KEY is configured
+        id: key_check
         run: |
           if [ -z "$TENET_AI_KEY" ]; then
             echo "⚠️  TENET_AI_KEY is not set — skipping review."
             echo "Add it under Settings → Secrets and variables → Actions."
-            exit 0
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_key=true" >> "$GITHUB_OUTPUT"
           fi
         env:
           TENET_AI_KEY: ${{ secrets.TENET_AI_KEY }}
 
       - name: Run TENET PR Review
+        if: steps.key_check.outputs.has_key == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TENET_AI_KEY: ${{ secrets.TENET_AI_KEY }}


### PR DESCRIPTION
Closes #184

## What I did
- Added `id: key_check` to the check step
- Replaced `exit 0` with a proper output flag written to `$GITHUB_OUTPUT`
- Added `if: steps.key_check.outputs.has_key == 'true'` to the run step so it gets skipped when the key is missing instead of failing with a misleading error

No other changes.