### PR TITLE
fix: resolve mismatched quote causing SyntaxError in core.warning and workflow

### DIFF
--- a/.github/workflows/issue-context-assignment.yml
+++ b/.github/workflows/issue-context-assignment.yml
@@ -77,7 +77,7 @@ jobs:
             core.info(`Matched routes: ${matchedRoutes.length ? matchedRoutes.join(', ') : 'none (used default)'}`);
             core.info(`Assigned: ${toAdd.join(', ')}`);
             } catch (err) {
-            core.warning('Failed to assign ${toAdd.join(', ')}: ${err.message}`);
+            core.warning(`Failed to assign ${toAdd.join(', ')}: ${err.message}`);
             }
             
 


### PR DESCRIPTION
## 📝 Description
This PR fixes a blocking SyntaxError in the issue-context-assignment workflow.
## Fix: SyntaxError in core.warning

- Replaced incorrect single-quote with backtick
- Fixed invalid template literal syntax
- Resolved workflow failure issue

This ensures the GitHub Actions workflow runs without syntax errors.


## 🔗 Related Issue
Closes #185

## 🔄 Type of Change
<!-- Check all that apply -->
- [ x ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
<!-- Steps to verify your change works correctly -->
1. Trigger the GitHub Actions workflow (e.g., by opening/editing an issue)
2. Verify that the workflow runs without SyntaxError.

## 📸 Screenshots (if applicable)
<!-- Before and after screenshots for UI changes -->
N/A

## ✅ Checklist
- [ x ] My code follows the project's existing style
- [ ] I have tested my changes in a browser
- [ x ] I have linked the related issue above
- [ x ] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)