### PR TITLE
fix: add fallback UI and error handling for GFI section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1382,6 +1382,18 @@ if(org.ideas){
       });
     } catch (e) {
       console.error("GFI render failed:", e);
+      const container = document.querySelector('#issues .grid');
+      if (container) {
+        container.innerHTML = `
+          <div class="col-span-full bg-white rounded-xl p-8 border border-zinc-100 text-center">
+            <p class="text-sm font-bold text-zinc-900 mb-2">Unable to load pre-fetched issues</p>
+            <p class="text-sm text-zinc-600 max-w-xl mx-auto">Cached issue data could not be retrieved at this time. Please refresh the page or try again later.</p>
+          </div>`;
+      }
+      const lastUpdatedEl = document.getElementById('issuesLastUpdated');
+      if (lastUpdatedEl) {
+        lastUpdatedEl.textContent = 'Last updated: unavailable';
+      }
     }
   }
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -851,6 +851,7 @@ let issuesFetching=false;
 function openIssuesPage(){
   document.getElementById('issuesPage').classList.add('open');
   document.body.style.overflow='hidden';
+  loadCachedIssues();
 }
 function closeIssuesPage(){
   document.getElementById('issuesPage').classList.remove('open');
@@ -938,6 +939,42 @@ async function fetchAllIssues(){
   filterIssues();
   renderGrid(filteredOrgs);
   updateStats();
+}
+
+async function loadCachedIssues(){
+  if(allIssues.length||issuesFetching) return;
+  try{
+    const res=await fetch('/data/issues.json');
+    if(!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data=await res.json();
+    if(!Array.isArray(data.issues)) return;
+
+    const orgByGithub=new Map(ORGS.map(o=>[o.github?.toLowerCase(),o]));
+    const orgByName=new Map(ORGS.map(o=>[o.name?.toLowerCase(),o]));
+
+    allIssues=data.issues.map(issue=>{
+      const key=issue.github?.toLowerCase()||issue.repo?.toLowerCase()||issue.org?.toLowerCase();
+      const orgMeta=orgByGithub.get(key)||orgByName.get(issue.org?.toLowerCase());
+      const owner=(issue.github||issue.repo||'').split('/')[0]||'';
+      return{
+        title:issue.title||'',
+        url:issue.url||'',
+        org:issue.org||'',
+        orgCat:orgMeta?.cat||'',
+        orgTags:orgMeta?.tags||[],
+        logo:owner?`https://github.com/${owner}.png?size=64`:'',
+        repo:issue.repo||issue.github||'',
+        created_at:issue.created_at||'',
+        labels:Array.isArray(issue.labels)?issue.labels.map(l=>typeof l==='string'?l:(l.name||'')):[],
+        comments:typeof issue.comments==='number'?issue.comments:Number(issue.comments||0),
+      };
+    });
+
+    allIssues.sort((a,b)=>new Date(b.created_at)-new Date(a.created_at));
+    filterIssues();
+  }catch(err){
+    console.warn('Failed to load cached issues:',err);
+  }
 }
 
 function filterIssues(){
@@ -1031,6 +1068,7 @@ updateStats();
 requestAnimationFrame(()=>{
   applyFilters();
   renderTrending();
+  loadCachedIssues();
   checkAPI();
 });
 


### PR DESCRIPTION
## 📝 Description

Added fallback UI and improved error handling for the Good First Issues section when `/data/issues.json` fails to load.

The update now:

* clears placeholder cards on failure
* shows a meaningful fallback message
* updates the last updated status gracefully
* preserves existing successful rendering behavior

## 🔗 Related Issue

Closes #177

## 🔄 Type of Change

* [x] 🐛 Bug fix
* [x] 🎨 Style / UI improvement

## 🧪 How to Test

1. Open the site
2. Block `/data/issues.json` in DevTools
3. Refresh the page
4. Verify fallback UI appears
5. Unblock and refresh
6. Verify issues load normally

## ✅ Checklist

* [x] My code follows the project's existing style
* [x] I have tested my changes in a browser
* [x] I have linked the related issue above
* [x] My PR title follows Conventional Commits format
