### PR TITLE
fix: prevent speed insights loading in local development

### DIFF
--- a/agent/scripts/speed-insights.js
+++ b/agent/scripts/speed-insights.js
@@ -4,8 +4,13 @@
  */
 import { injectSpeedInsights } from './speed-insights-lib.mjs';
 
-// Initialize Speed Insights
-// Note: This only tracks in production, not in development mode
-injectSpeedInsights({
-  debug: false, // Set to true to enable debug logging
-});
+// Only initialize Speed Insights in production/Vercel environments
+const isProduction =
+  window.location.hostname !== 'localhost' &&
+  window.location.hostname !== '127.0.0.1';
+
+if (isProduction) {
+  injectSpeedInsights({
+    debug: false, // Set to true to enable debug logging
+  });
+}


### PR DESCRIPTION
## 📝 Description

This PR prevents the Vercel Speed Insights script from loading during local development environments such as Live Server or localhost.

Previously, the analytics script was initialized unconditionally, causing unnecessary console errors like:

`/_vercel/speed-insights/script.js 404`

The fix adds a production environment check before initializing Speed Insights, ensuring analytics only run in supported deployment environments while preserving existing production behavior.

## 🔗 Related Issue

Closes #200 

## 🔄 Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 🔍 SEO improvement
* [ ] 🎨 Style / UI improvement
* [ ] ♿ Accessibility improvement
* [ ] 📝 Documentation
* [x] ⚙️ CI / configuration
* [x] 🧹 Refactor / cleanup

## 🧪 How to Test

1. Clone the repository
2. Run the project locally using Live Server or any static server
3. Open the browser DevTools console
4. Verify that Vercel Speed Insights console errors no longer appear during local development
5. Confirm the application still functions normally

## 📸 Screenshots (if applicable)

N/A
