### PR TITLE
fix: XSS/HTML injection risk from unsafe innerHTML rendering of data

### DIFF
--- a/index.html
+++ b/index.html
@@ -1124,9 +1124,9 @@
   function escapeHtml(value) {
     return String(value)
       .replaceAll('&', '&amp;')
-      .replaceAll('<', '<')
-      .replaceAll('>', '>')
-      .replaceAll('"', '"')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
       .replaceAll("'", '&#39;');
   }
 
@@ -1387,13 +1387,13 @@
       card.innerHTML = `
         <div class="flex justify-between items-start mb-4">
           <div class="w-14 h-14 rounded-xl bg-surface-container-low flex items-center justify-center p-2 overflow-hidden">
-            <img src="${logoUrl}" onerror="handleImgError(this, '${org.name}')" alt="${org.name} logo" class="w-full h-full object-contain rounded-lg" />
+            <img src="${logoUrl}" data-org-name="${escapeHtml(org.name)}" alt="${org.name} logo" class="w-full h-full object-contain rounded-lg" />
             <div class="logo-placeholder hidden w-full h-full items-center justify-center text-primary font-bold text-xl bg-primary/5"></div>
           </div>
           <div class="flex items-center gap-2">
             <span class="bg-primary/10 text-primary text-[10px] font-label uppercase tracking-widest px-2 py-1 rounded-full font-bold">${org.years}y Veteran</span>
             <span class="complexity-badge ${org.codebase}">${org.codebase}</span>
-            <button class="bookmark-btn ${isBookmarked ? 'active' : 'text-zinc-300'}" onclick="toggleBookmark(event, '${org.name}')">
+            <button class="bookmark-btn ${isBookmarked ? 'active' : 'text-zinc-300'}" data-bookmark-org="${escapeHtml(org.name)}" title="${isBookmarked ? 'Remove bookmark' : 'Add bookmark'}">
               <span class="material-symbols-outlined text-lg ${isBookmarked ? 'icon-fill' : ''}">star</span>
             </button>
           </div>
@@ -1408,18 +1408,57 @@
 
         <div class="flex items-center justify-between pt-4 border-t border-zinc-100">
           <div class="flex items-center gap-3">
-             <button onclick="toggleCompare(event, '${org.name}')" class="text-[10px] font-bold uppercase tracking-widest ${isComparing ? 'text-primary' : 'text-zinc-400'} hover:text-primary flex items-center gap-1">
+             <button data-compare-org="${escapeHtml(org.name)}" class="text-[10px] font-bold uppercase tracking-widest ${isComparing ? 'text-primary' : 'text-zinc-400'} hover:text-primary flex items-center gap-1">
                 <span class="material-symbols-outlined text-sm">${isComparing ? 'check_circle' : 'compare_arrows'}</span> ${isComparing ? 'Comparing' : 'Compare'}
              </button>
           </div>
-          <button onclick="openModal('${org.name}')" class="text-primary font-bold text-xs uppercase tracking-widest flex items-center gap-1 group-hover:gap-2 transition-all">View <span class="material-symbols-outlined text-sm">arrow_forward</span></button>
+           <button data-open-org="${escapeHtml(org.name)}" class="text-primary font-bold text-xs uppercase tracking-widest flex items-center gap-1 group-hover:gap-2 transition-all">View <span class="material-symbols-outlined text-sm">arrow_forward</span></button>
         </div>
       `;
       grid.appendChild(card);
+        // Attach per-card listeners for non-bubbling events and data-driven actions
+        attachOrgCardListeners(card);
     });
 
     document.getElementById('orgCount').textContent = filteredOrgs.length;
     document.getElementById('loadMoreContainer').style.display = (visibleCount < filteredOrgs.length) ? 'flex' : 'none';
+  }
+
+  // Attach listeners to elements created from org templates.
+  // Uses data-* attributes to avoid injecting user data into inline JS handlers.
+  function attachOrgCardListeners(root = document) {
+    // image error fallback (error doesn't bubble reliably)
+    (root.querySelectorAll ? root.querySelectorAll('img[data-org-name]') : []).forEach(img => {
+      if (img.__orgListenerAttached) return;
+      img.addEventListener('error', (e) => {
+        handleImgError(e.target, e.target.dataset.orgName);
+      });
+      img.__orgListenerAttached = true;
+    });
+
+    // bookmark buttons
+    (root.querySelectorAll ? root.querySelectorAll('.bookmark-btn[data-bookmark-org]') : []).forEach(btn => {
+      if (btn.__orgListenerAttached) return;
+      btn.addEventListener('click', (e) => toggleBookmark(e, btn.dataset.bookmarkOrg));
+      btn.__orgListenerAttached = true;
+    });
+
+    // compare buttons
+    (root.querySelectorAll ? root.querySelectorAll('[data-compare-org]') : []).forEach(btn => {
+      if (btn.__orgListenerAttached) return;
+      btn.addEventListener('click', (e) => toggleCompare(e, btn.dataset.compareOrg));
+      btn.__orgListenerAttached = true;
+    });
+
+    // open modal buttons
+    (root.querySelectorAll ? root.querySelectorAll('[data-open-org]') : []).forEach(btn => {
+      if (btn.__orgListenerAttached) return;
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        openModal(btn.dataset.openOrg);
+      });
+      btn.__orgListenerAttached = true;
+    });
   }
 
   function toggleCompare(e, name) {
@@ -1452,13 +1491,14 @@
       item.className = 'bg-white rounded-xl p-4 border border-zinc-100';
       item.innerHTML = `
         <div class="w-10 h-10 rounded-lg bg-orange-100 flex items-center justify-center mx-auto mb-3 overflow-hidden">
-          <img src="${logoUrl}" onerror="handleImgError(this, '${org.name}')" class="w-full h-full object-contain" />
+          <img src="${logoUrl}" data-org-name="${escapeHtml(org.name)}" class="w-full h-full object-contain" />
         </div>
-        <p class="font-bold text-sm truncate">${org.name}</p>
+        <p class="font-bold text-sm truncate">${escapeHtml(org.name)}</p>
         <p class="text-[10px] text-zinc-500 font-label uppercase mt-1">${org.years}y · ${org.competition}</p>
-        <button onclick="toggleCompare(null, '${org.name}')" class="text-[9px] text-red-500 font-bold uppercase mt-2 hover:underline">Remove</button>
+        <button data-compare-org="${escapeHtml(org.name)}" class="text-[9px] text-red-500 font-bold uppercase mt-2 hover:underline">Remove</button>
       `;
       container.appendChild(item);
+      attachOrgCardListeners(item);
     });
 
     // Add empty slots
@@ -1587,18 +1627,19 @@
         </div>
         <div class="flex-1 w-full">
           <div class="flex items-center justify-between gap-2 mb-1">
-            <h4 class="font-bold">${org.name}</h4>
+            <h4 class="font-bold">${escapeHtml(org.name)}</h4>
             <span class="text-[10px] font-label uppercase tracking-wider text-white bg-primary px-2 py-0.5 rounded">Watchlisted</span>
           </div>
-          <p class="text-sm text-zinc-600 mb-3 line-clamp-1">${org.desc}</p>
+          <p class="text-sm text-zinc-600 mb-3 line-clamp-1">${escapeHtml(org.desc)}</p>
           <div class="flex items-center gap-4 text-xs text-zinc-500">
-            <span class="flex items-center gap-1"><span class="material-symbols-outlined text-xs">code</span> ${org.github}</span>
-            <span class="flex items-center gap-1"><span class="material-symbols-outlined text-xs">bar_chart</span> ${org.competition}</span>
-            <button onclick="toggleBookmark(event, '${org.name}')" class="ml-auto text-red-500 font-bold hover:underline">Remove</button>
+            <span class="flex items-center gap-1"><span class="material-symbols-outlined text-xs">code</span> ${escapeHtml(org.github)}</span>
+            <span class="flex items-center gap-1"><span class="material-symbols-outlined text-xs">bar_chart</span> ${escapeHtml(org.competition)}</span>
+            <button data-bookmark-org="${escapeHtml(org.name)}" class="ml-auto text-red-500 font-bold hover:underline">Remove</button>
           </div>
         </div>
       `;
       container.appendChild(item);
+      attachOrgCardListeners(item);
     });
 
     // Data-driven AI Insight
@@ -1619,9 +1660,9 @@
     if (!org) return;
 
     document.getElementById('mHeader').innerHTML = `
-      <span class="category-tag">${org.cat.toUpperCase()}</span>
-      <h2>${org.name}</h2>
-      <p class="text-zinc-500">GSoC Partner for ${org.years} Years</p>
+      <span class="category-tag">${escapeHtml(org.cat.toUpperCase())}</span>
+      <h2>${escapeHtml(org.name)}</h2>
+      <p class="text-zinc-500">GSoC Partner for ${escapeHtml(org.years.toString())} Years</p>
     `;
 
     document.getElementById('mMetrics').innerHTML = `
@@ -1807,9 +1848,9 @@ if(org.ideas){
           <h4 class="font-bold text-sm group-hover:text-primary transition-colors line-clamp-1">Browse open Good First Issues</h4>
           <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
         </div>
-        <p class="text-xs text-zinc-500 mb-3 font-mono">${org.github}</p>
+        <p class="text-xs text-zinc-500 mb-3 font-mono">${escapeHtml(org.github)}</p>
         <div class="flex flex-wrap gap-1.5">
-          <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">${org.name}</span>
+          <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">${escapeHtml(org.name)}</span>
           <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
         </div>
       `;

--- a/index.html
+++ b/index.html
@@ -1119,9 +1119,25 @@
   document.addEventListener('DOMContentLoaded', updateActiveSection);
 
   // ══════════════════════════════════════════════
+  // Shared escaping helper (for all dynamic text used in HTML strings)
+  // Prevents HTML injection via <, >, &, quotes.
+  function escapeHtml(value) {
+    return String(value)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '<')
+      .replaceAll('>', '>')
+      .replaceAll('"', '"')
+      .replaceAll("'", '&#39;');
+  }
+
+  // NOTE: For JS-string contexts inside inline event handlers,
+  // we must also escape quotes. Prefer removing inline handlers.
+
+  // ══════════════════════════════════════════════
   // MAIN APP LOGIC
   // ══════════════════════════════════════════════
   let visibleCount = 12;
+
   let filteredOrgs = [...ORGS];
   let compareList = [];
   const bookmarkedSet = new Set(JSON.parse(localStorage.getItem('bookmarks') || '[]'));
@@ -1339,6 +1355,7 @@
 
   function renderOrgs(reset = true) {
     const grid = document.getElementById('orgGrid');
+
     const emptyState = document.getElementById('emptyState');
     if (reset) {
       grid.innerHTML = '';
@@ -1381,13 +1398,14 @@
             </button>
           </div>
         </div>
-        <h3 class="font-headline text-lg font-bold text-on-surface mb-1 group-hover:text-primary transition-colors">${org.name}</h3>
-        <span class="category-tag">${org.cat.toUpperCase()}</span>
-        <p class="text-on-surface-variant text-sm leading-relaxed mb-4 line-clamp-2">${org.desc}</p>
+        <h3 class="font-headline text-lg font-bold text-on-surface mb-1 group-hover:text-primary transition-colors">${escapeHtml(org.name)}</h3>
+        <span class="category-tag">${escapeHtml(org.cat.toUpperCase())}</span>
+        <p class="text-on-surface-variant text-sm leading-relaxed mb-4 line-clamp-2">${escapeHtml(org.desc)}</p>
         <div class="flex flex-wrap gap-1.5 mb-4">
-          ${org.tags.slice(0, 3).map(t => `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded">${t}</span>`).join('')}
+          ${org.tags.slice(0, 3).map(t => `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded">${escapeHtml(t)}</span>`).join('')}
           ${org.tags.length > 3 ? `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded">+${org.tags.length - 3}</span>` : ''}
         </div>
+
         <div class="flex items-center justify-between pt-4 border-t border-zinc-100">
           <div class="flex items-center gap-3">
              <button onclick="toggleCompare(event, '${org.name}')" class="text-[10px] font-bold uppercase tracking-widest ${isComparing ? 'text-primary' : 'text-zinc-400'} hover:text-primary flex items-center gap-1">


### PR DESCRIPTION
Implemented HTML escaping for dynamic organization fields in index.html (inside renderOrgs()): org.name, org.cat, org.desc, and each org.tags entry now pass through the existing escapeHtml() helper before being interpolated into card.innerHTML, reducing HTML injection risk during dynamic rendering.

closes #211