### PR TITLE
fix: exclude bots and maintainers from NSoC leaderboard workflow

### DIFF
--- a/.github/scripts/generate-leaderboard-comment.js
+++ b/.github/scripts/generate-leaderboard-comment.js
@@ -1,32 +1,44 @@
 const token = process.env.GITHUB_TOKEN;
 
 const username = process.env.PR_AUTHOR;
+const userType = process.env.PR_AUTHOR_TYPE;
+const userAssociation = process.env.PR_AUTHOR_ASSOCIATION;
 const action = process.env.PR_ACTION;
 const merged = process.env.PR_MERGED === 'true';
 
 const owner = process.env.REPO_OWNER;
 const repo = process.env.REPO_NAME;
 
-const EXCLUDED_USERS = ['S3DFX-CYBER', 'github-actions[bot]'];
+const EXCLUDED_USERS = ['S3DFX-CYBER']; // Specific edge cases if any
 
 /**
  * Checks if a user should be excluded from the leaderboard.
  * @param {string} login User's login name
- * @param {string} type User's type (e.g., 'Bot')
- * @param {string} association User's association (e.g., 'OWNER')
+ * @param {string} type User's type (e.g., 'Bot', 'User')
+ * @param {string} association User's association (e.g., 'OWNER', 'MEMBER')
  */
 function isExcluded(login, type, association) {
   if (!login) return true;
+  const lowercaseLogin = login.toLowerCase();
+  
+  const isBot = 
+    type === 'Bot' || 
+    lowercaseLogin.endsWith('[bot]') || 
+    lowercaseLogin.endsWith('-bot');
+    
+  const isMaintainer = 
+    association === 'OWNER' || 
+    association === 'MEMBER';
+
   return (
-    EXCLUDED_USERS.includes(login) ||
-    login.endsWith('[bot]') ||
-    type === 'Bot' ||
-    association === 'OWNER'
+    EXCLUDED_USERS.some(u => u.toLowerCase() === lowercaseLogin) ||
+    isBot ||
+    isMaintainer
   );
 }
 
 // Early exit if the PR author is a bot or maintainer
-if (isExcluded(username)) {
+if (isExcluded(username, userType, userAssociation)) {
   process.exit(0);
 }
 

--- a/.github/scripts/generate-leaderboard-comment.js
+++ b/.github/scripts/generate-leaderboard-comment.js
@@ -7,6 +7,29 @@ const merged = process.env.PR_MERGED === 'true';
 const owner = process.env.REPO_OWNER;
 const repo = process.env.REPO_NAME;
 
+const EXCLUDED_USERS = ['S3DFX-CYBER', 'github-actions[bot]'];
+
+/**
+ * Checks if a user should be excluded from the leaderboard.
+ * @param {string} login User's login name
+ * @param {string} type User's type (e.g., 'Bot')
+ * @param {string} association User's association (e.g., 'OWNER')
+ */
+function isExcluded(login, type, association) {
+  if (!login) return true;
+  return (
+    EXCLUDED_USERS.includes(login) ||
+    login.endsWith('[bot]') ||
+    type === 'Bot' ||
+    association === 'OWNER'
+  );
+}
+
+// Early exit if the PR author is a bot or maintainer
+if (isExcluded(username)) {
+  process.exit(0);
+}
+
 async function github(path) {
   const res = await fetch(`https://api.github.com${path}`, {
     headers: {
@@ -48,7 +71,7 @@ async function getAllClosedPRs() {
   const contributorMap = new Map();
 
   for (const pr of prs) {
-    if (!pr.user) continue;
+    if (!pr.user || isExcluded(pr.user.login, pr.user.type, pr.author_association)) continue;
 
     const login = pr.user.login;
 
@@ -77,7 +100,7 @@ async function getAllClosedPRs() {
   );
 
   for (const pr of openPRs) {
-    if (!pr.user) continue;
+    if (!pr.user || isExcluded(pr.user.login, pr.user.type, pr.author_association)) continue;
 
     const login = pr.user.login;
 

--- a/.github/workflows/nsoc-leaderboard.yml
+++ b/.github/workflows/nsoc-leaderboard.yml
@@ -51,6 +51,11 @@ jobs:
 
             const body = fs.readFileSync('comment.md', 'utf8');
 
+            if (!body.trim()) {
+              core.info('Leaderboard comment is empty, skipping.');
+              return;
+            }
+
             const comments = await github.paginate(
               github.rest.issues.listComments,
               {

--- a/.github/workflows/nsoc-leaderboard.yml
+++ b/.github/workflows/nsoc-leaderboard.yml
@@ -35,6 +35,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           PR_ACTION: ${{ github.event.action }}
           PR_MERGED: ${{ github.event.pull_request.merged }}
           REPO_OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
## 📝 Description

Excludes bots and maintainers from the NSoC leaderboard rankings and PR comments to ensure fair rankings for external contributors.

## 🔗 Related Issue
Closes #236 

## 🔄 Type of Change
<!-- Check all that apply -->
- [x] 🐛 Bug fix
- [x] ⚙️ CI / configuration

## 🧪 How to Test

1. Verified isExcluded logic filters [bot] and OWNER users.
2. Verified workflow skips posting when script output is empty.

## 📸 Screenshots (if applicable)
<!-- Before and after screenshots for UI changes -->

## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)