### PR TITLE
Potential fix for code scanning alert no. 7: Double escaping or unescaping

### DIFF
--- a/agent/scripts/extract-mentors.js
+++ b/agent/scripts/extract-mentors.js
@@ -78,12 +78,12 @@ function buildBaseEntry(org, fetchedAt) {
 
 function decodeHtmlEntities(value) {
   return String(value || '')
-    .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/gi, "'")
-    .replace(/&nbsp;/gi, ' ');
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&');
 }
 
 function stripHtml(value) {


### PR DESCRIPTION
Potential fix for [https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/security/code-scanning/7](https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/security/code-scanning/7)

To fix this safely, reorder replacements in `decodeHtmlEntities` so `&amp;` is decoded last.  
General rule: when **unescaping**, decode the escape-introducing sequence last to avoid cascading into a second decode pass.

Best minimal fix (no functional expansion, only correctness): in `agent/scripts/extract-mentors.js`, edit `decodeHtmlEntities` to decode `&lt;`, `&gt;`, `&quot;`, `&#39;`, and `&nbsp;` first, and move `.replace(/&amp;/gi, '&')` to the end of the chain. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
