### PR TITLE
fix: star/favorite button not updating on org cards (#238)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2060,12 +2060,21 @@
     }
   });
 
+  function refreshOrgGridPreservingVisibleCount() {
+    const previousVisibleCount = visibleCount;
+    const grid = document.getElementById('orgGrid');
+    if (!grid) return;
+    grid.innerHTML = '';
+    visibleCount = previousVisibleCount; // preserve pagination state
+    renderOrgs(false); // re-render currently visible window
+  }
+
   function toggleBookmark(e, name) {
     if (e) e.stopPropagation();
     if (bookmarkedSet.has(name)) bookmarkedSet.delete(name);
     else bookmarkedSet.add(name);
     localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
-    renderOrgs(true); // Re-render grid so bookmark icon state updates correctly
+    refreshOrgGridPreservingVisibleCount();
     renderWatchlist();
   }
 

--- a/index.html
+++ b/index.html
@@ -2065,7 +2065,7 @@
     if (bookmarkedSet.has(name)) bookmarkedSet.delete(name);
     else bookmarkedSet.add(name);
     localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
-    renderOrgs(false); // Refresh current view
+    renderOrgs(true); // Re-render grid so bookmark icon state updates correctly
     renderWatchlist();
   }
 


### PR DESCRIPTION
## 📝 Description
Fixes the star/favorite button on organization cards not responding when clicked.

`toggleBookmark` was calling `renderOrgs(false)` (append-only/pagination mode), 
so the existing card with the unupdated star icon was never cleared from the DOM.

**Fix:** Added `refreshOrgGridPreservingVisibleCount()` as an outer-scope helper that 
clears the grid and re-renders the current visible window without resetting 
`visibleCount`, so users who loaded more cards don't lose their pagination position.

> Contributing as part of **NSoC 2026**

## 🔗 Related Issue
Closes #238

## 🔄 Type of Change
- [x] 🐛 Bug fix

## 🧪 How to Test
1. Open `index.html` in a browser
2. Click "Load More" to load cards beyond the first 12
3. Click the ⭐ star icon on any org card
4. Verify: star icon fills/unfills immediately ✅
5. Verify: cards loaded via "Load More" are still visible (pagination preserved) ✅
6. Refresh page — verify bookmark persists via localStorage ✅

## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format
