### PR TITLE
Add verified libssh mentor and communication info

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1245,12 +1245,12 @@
   },
   "libssh": {
     "org": "libssh",
-    "ideasUrl": "https://gitlab.com/libssh/libssh-mirror/-/wikis/Google-Summer-of-Code",
+    "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/libssh",
     "channels": [],
     "mentors": [],
     "mailingLists": [],
-    "tip": "",
-    "status": "fetch-failed",
+    "tip": "Verified official GSoC organization page manually after old URL returned 404.",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Liquid Galaxy project": {

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1246,9 +1246,19 @@
   "libssh": {
     "org": "libssh",
     "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/libssh",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
+     "channels": [
+    "Matrix: #libssh:matrix.org",
+    "Mailing List: libssh@libssh.org"
+  ],
+    "mentors": [
+    "Jakub Jelen",
+    "Sahana Prasad",
+    "Andreas Schneider",
+    "Eshan Kelkar"
+  ],
+    "mailingLists": [
+  "libssh@libssh.org"
+],
     "tip": "Verified official GSoC organization page manually after old URL returned 404.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"


### PR DESCRIPTION
## Description

Verified the libssh GSoC organization entry manually.

### Changes

* replaced broken ideas URL
* added verified Matrix and mailing list communication channels
* added verified mentor names
* updated mailing list field
* updated status to `ok`

Fixes #437
