### PR TITLE
Add mentor information for libssh

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1247,7 +1247,18 @@
     "org": "libssh",
     "ideasUrl": "https://gitlab.com/libssh/libssh-mirror/-/wikis/Google-Summer-of-Code",
     "channels": [],
-    "mentors": [],
+    "mentors": [
+  {
+    "name": "Jakub Jelen",
+    "github": "jakuje",
+    "githubUrl": "https://github.com/jakuje"
+  },
+  {
+    "name": "Eshan Kelkar",
+    "github": "eshankelkar",
+    "githubUrl": "https://github.com/eshankelkar"
+  }
+],
     "mailingLists": [],
     "tip": "",
     "status": "fetch-failed",


### PR DESCRIPTION
## Changes Made

* Verified mentor contact information for libssh
* Added and updated mentor GitHub details
* Fixed missing mentor entries where necessary

## Verification

Verified mentor information using official/public sources and existing maintainer profiles.
