### PR TITLE
Fix Contact button: Add contact section and link

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@
     html { scroll-behavior: smooth; }
     
     /* Scroll offset for fixed header */
-    #timeline, #orgs, #guide, #watchlist, #issues, #mentors {
+    #timeline, #orgs, #guide, #watchlist, #issues, #mentors, #contact {
       scroll-margin-top: 80px;
     }
 
@@ -983,6 +983,37 @@
   </div>
 </section>
 
+<!-- ═══════════════════ CONTACT ═══════════════════ -->
+<section id="contact" class="py-20 px-6 max-w-7xl mx-auto">
+  <div class="text-center mb-12">
+    <h2 class="text-4xl font-extrabold font-headline tracking-tight mb-4">Get in Touch</h2>
+    <p class="text-zinc-600 max-w-2xl mx-auto">Have questions, feedback, or need help? We'd love to hear from you.</p>
+  </div>
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
+    <a href="https://github.com/S3DFX-CYBER" target="_blank" rel="noopener noreferrer" class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
+      <div class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
+        <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">person</span>
+      </div>
+      <h3 class="font-bold mb-2">GitHub Profile</h3>
+      <p class="text-sm text-zinc-600">Follow the maintainer and check out other projects.</p>
+    </a>
+    <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/issues" target="_blank" rel="noopener noreferrer" class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
+      <div class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
+        <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">bug_report</span>
+      </div>
+      <h3 class="font-bold mb-2">Report Issues</h3>
+      <p class="text-sm text-zinc-600">Found a bug or have a feature request? Open an issue.</p>
+    </a>
+    <a href="https://discord.gg/mgWV3xSV7" target="_blank" rel="noopener noreferrer" class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
+      <div class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
+        <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">forum</span>
+      </div>
+      <h3 class="font-bold mb-2">Join Discord</h3>
+      <p class="text-sm text-zinc-600">Connect with the community for discussions and support.</p>
+    </a>
+  </div>
+</section>
+
 <!-- ═══════════════════ FOOTER ═══════════════════ -->
 <footer class="w-full border-t border-zinc-200 bg-zinc-100">
   <div class="flex flex-col md:flex-row justify-between items-center px-8 py-12 gap-6 max-w-7xl mx-auto">
@@ -997,7 +1028,7 @@
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://summerofcode.withgoogle.com/programs/2026/organizations" target="_blank">GSoC 2026</a>
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank">GitHub</a>
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#">Privacy</a>
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#">Contact</a>
+      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#contact">Contact</a>
     </nav>
   </div>
 </footer>


### PR DESCRIPTION
Closes #445 

## Description
The Contact button in the footer wasn't working - clicking it did nothing. I've added a proper contact section that provides users with clear ways to reach out to the project maintainers and community.

## Changes Made
- Added a new "Get in Touch" section before the footer with three contact options (GitHub profile, issue reporting, Discord community)
- Updated the Contact button to smoothly scroll to the new contact section instead of being a dead link
- Added proper scroll offset handling for the fixed header

## Testing
- Tested locally with a development server
- Verified smooth scrolling to the contact section
- Confirmed all contact links work and open in new tabs
- Checked responsive design on different screen sizes

This fix improves user experience by providing actual contact functionality instead of broken links.

<img width="1470" height="956" alt="issue#445-gsoc_org" src="https://github.com/user-attachments/assets/11c20402-bee0-439a-9dd7-b5a8779dcf2c" />

