### PR TITLE
fix: added Wikimedia GSoC mentor contacts

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2799,7 +2799,7 @@
     "channels": [
       {
         "type": "Zulip",
-        "url": "https://wikimedia.zulipchat.com/#narrow/channel/561533-GSoC2026",
+        "url": "https://wikimedia.zulipchat.com/#narrow/stream/561533-GSoC2026",
         "label": "GSoC2026 Zulip stream"
       }
     ],
@@ -2815,12 +2815,12 @@
         "githubUrl": ""
       },
       {
-        "name": "Nazmul Haque Nokib",
+        "name": "Nokib_Sarkar",
         "github": "",
         "githubUrl": ""
       },
       {
-        "name": "Tiven Gonsalves",
+        "name": "Tiven2240",
         "github": "",
         "githubUrl": ""
       },
@@ -2875,12 +2875,12 @@
         "githubUrl": ""
       },
       {
-        "name": "Lodewijk",
+        "name": "Effeietsanders",
         "github": "",
         "githubUrl": ""
       },
       {
-        "name": "Sage Ross",
+        "name": "Ragesoss",
         "github": "",
         "githubUrl": ""
       },
@@ -2895,12 +2895,12 @@
         "githubUrl": ""
       },
       {
-        "name": "Henrik Thomasson",
+        "name": "Henrikt93",
         "github": "",
         "githubUrl": ""
       },
       {
-        "name": "Akindele Michael",
+        "name": "DeleMike",
         "github": "",
         "githubUrl": ""
       },

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2799,11 +2799,122 @@
     "channels": [
       {
         "type": "Zulip",
-        "url": "https://wikimedia.zulipchat.com/",
-        "label": "Wikimedia Foundation Zulip"
+        "url": "https://wikimedia.zulipchat.com/#narrow/channel/561533-GSoC2026",
+        "label": "GSoC2026 Zulip stream"
       }
     ],
-    "mentors": [],
+    "mentors": [
+      {
+        "name": "Parthiv Menon",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Satdeep Gill",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Nazmul Haque Nokib",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Tiven Gonsalves",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Peter F. Patel Schneider",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "David Martin",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Nicolas Raoul",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Ritika Pahwa",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Yaron Koren",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "cicalese",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Kaartic",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Neeldoshii",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "KC Velaga",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Jay Prakash",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Lodewijk",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Sage Ross",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Abishek Das",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Andrew Tavis",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Henrik Thomasson",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Akindele Michael",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Parashar Sarthak",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Jnanaranjan Sahu",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
     "mailingLists": [],
     "tip": "Post a new topic in the GSoC stream with your background and interest.",
     "status": "ok",


### PR DESCRIPTION
## Contribution Program
NSOC

## Description
Verified the Wikimedia Foundation GSoC 2026 ideas page and updated its mentor contact entry in `data/mentors.json`.

This PR updates the contact channel to the published Wikimedia `GSoC2026` Zulip stream and adds the mentor names listed on the Wikimedia ideas page. GitHub fields are left blank because the ideas page does not publish GitHub handles for those mentors.

## Related Issue
Closes #434

## Type of Change
- [x] Data fix
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor

## How to Test
Run:

```bash
node agent/scripts/validate-mentors.js
```
Expected result:
```text
Mentor data validation passed
```

Checklist
- [x] Issue is assigned to me
- [x] PR is linked to an issue
- [x] Changes are minimal and focused
- [x] No unnecessary dependencies added
- [x] Code follows the zero-build philosophy
- [x] I understand the change I submitted

Linked Issue #434 
