### PR TITLE
Fix libssh mentor info schema and verification

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1245,12 +1245,12 @@
   },
   "libssh": {
     "org": "libssh",
-    "ideasUrl": "https://gitlab.com/libssh/libssh-mirror/-/wikis/Google-Summer-of-Code",
+    "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/libssh",
     "channels": [],
     "mentors": [],
     "mailingLists": [],
-    "tip": "",
-    "status": "fetch-failed",
+    "tip": "Verified official GSoC organization page manually after old URL returned 404.",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Liquid Galaxy project": {

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1246,9 +1246,19 @@
   "libssh": {
     "org": "libssh",
     "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/libssh",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
+     "channels": [
+    "Matrix: #libssh:matrix.org",
+    "Mailing List: libssh@libssh.org"
+  ],
+    "mentors": [
+    "Jakub Jelen",
+    "Sahana Prasad",
+    "Andreas Schneider",
+    "Eshan Kelkar"
+  ],
+    "mailingLists": [
+  "libssh@libssh.org"
+],
     "tip": "Verified official GSoC organization page manually after old URL returned 404.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1251,11 +1251,27 @@
     "Mailing List: libssh@libssh.org"
   ],
     "mentors": [
-    "Jakub Jelen",
-    "Sahana Prasad",
-    "Andreas Schneider",
-    "Eshan Kelkar"
-  ],
+  {
+    "name": "Jakub Jelen",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Sahana Prasad",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Andreas Schneider",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Eshan Kelkar",
+    "github": "",
+    "githubUrl": ""
+  }
+],
     "mailingLists": [
   "libssh@libssh.org"
 ],


### PR DESCRIPTION
## Summary

Updated the libssh organization entry in `data/mentors.json` to match the expected schema and resolve reviewer feedback.

## Changes made

* Converted mentor list from strings to structured objects
* Verified and updated GSoC 2026 organization URL
* Confirmed communication channels (Matrix + mailing list)
* Preserved required mailing list field
* Ensured JSON structure matches repository schema used by UI

## Issue

Fixes #437

## Notes

All changes are aligned with official libssh and GSoC organization information and pass lint checks locally.
