### PR TITLE
Fix: Prevent list reset and restore correct pagination state during comparison toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1985,7 +1985,7 @@
       }
       compareList.push(name);
     }
-    renderOrgs(true);
+    refreshOrgGridPreservingVisibleCount();
     renderCompare();
   }
 
@@ -2109,8 +2109,11 @@
     const grid = document.getElementById('orgGrid');
     if (!grid) return;
     grid.innerHTML = '';
-    visibleCount = previousVisibleCount; // preserve pagination state
-    renderOrgs(false); // re-render currently visible window
+    visibleCount = 0; // Temporarily reset
+    while (visibleCount < previousVisibleCount) {
+      visibleCount += 12;
+      renderOrgs(false); // rebuild the grid page by page up to the previous state
+    }
   }
 
   function toggleBookmark(e, name) {


### PR DESCRIPTION
## Description

Fixed the Compare Organizations functionality issue where toggling comparison after loading multiple pages caused the organization grid to reset back to the initial state.

The issue occurred because `renderOrgs(true)` triggered a full grid reset whenever compare was toggled. This caused users to lose their pagination state and scroll position.

## Related Issue

Closes #478

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

## How Has This Been Tested?

* Loaded multiple organization pages using "Load More"
* Toggled compare on organizations from later pages
* Verified pagination state remains preserved
* Verified compare modal functionality works correctly
* Checked for console errors

## Checklist

* [x] My code follows the project style guidelines
* [x] I have tested the changes locally
* [x] I have checked for console errors
* [x] This PR is linked to an issue
* [x] I have added meaningful commit messages

## How to Test

1. Open the application
2. Load multiple organization pages using the "Load More" button
3. Click "Compare" on organizations from later pages
4. Verify that:

   * the organization grid does not reset
   * previously loaded organizations remain visible
   * pagination state is preserved
   * compare modal opens correctly
5. Repeat compare toggle multiple times to confirm stable behavior
6. Check browser console for errors


## Contribution Program

I am contributing under GSSoC'26.
