### PR TITLE
feat: update Ceph organization contact info (#270)

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -13,7 +13,7 @@
     "mailingLists": [],
     "tip": "",
     "status": "ok",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "lastFetched": "2026-05-13T10:00:00.000Z"
   },
   "AboutCode": {
     "org": "AboutCode",
@@ -325,12 +325,45 @@
   "Ceph": {
     "org": "Ceph",
     "ideasUrl": "https://github.com/ceph/ceph/wiki/Google-Summer-of-Code-2026",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "channels": [
+      {
+        "type": "Discord",
+        "url": "https://discord.com/invite/ceph",
+        "label": "Ceph Discord"
+      },
+      {
+        "type": "IRC",
+        "url": "irc://irc.oftc.net/ceph",
+        "label": "#ceph on OFTC"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Yuval Lifshitz",
+        "github": "yuvalif",
+        "githubUrl": "https://github.com/yuvalif"
+      },
+      {
+        "name": "JacquesH",
+        "github": "JacquesH",
+        "githubUrl": "https://github.com/JacquesH"
+      },
+      {
+        "name": "Rotem Shapira",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Mailing list",
+        "url": "https://lists.ceph.io/",
+        "label": "Ceph Mailing Lists"
+      }
+    ],
+    "tip": "Introduce yourself in #ceph on IRC or Discord and mention which project idea you're interested in. Read the ideas page and existing issues first.",
+    "status": "ok",
+    "lastFetched": "2026-05-13T10:00:00.000Z"
   },
   "CERN-HSF": {
     "org": "CERN-HSF",
@@ -533,11 +566,6 @@
         "type": "Mailing list",
         "url": "https://lists.debian.org/debian-outreach/",
         "label": "Debian Mailing list"
-      },
-      {
-        "type": "Mailing list",
-        "url": "http://lists.debian.org/debian-outreach/",
-        "label": "Debian Mailing list"
       }
     ],
     "tip": "Send a short intro email with your background and the idea you're interested in.",
@@ -563,7 +591,7 @@
       {
         "type": "Mailing list",
         "url": "https://groups.google.com/g/django-developers/c/at-G0hZrfXE",
-        "label": "​ https://groups.google.com/g/django-developers/c/at-G0hZrfXE"
+        "label": "Django Developers"
       }
     ],
     "tip": "Send a short intro email with your background and the idea you're interested in.",
@@ -648,26 +676,10 @@
         "type": "Slack",
         "url": "https://fossology.slack.com/",
         "label": "FOSSology Slack"
-      },
-      {
-        "type": "Slack",
-        "url": "https://join.slack.com/t/fossology/shared_invite/enQtNzI0OTEzMTk0MjYzLTYyZWQxNDc0N2JiZGU2YmI3YmI1NjE4NDVjOGYxMTVjNGY3Y2MzZmM1OGZmMWI5NTRjMzJlNjExZGU2N2I5NGY",
-        "label": "Sharable join link to join"
       }
     ],
     "mentors": [],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "https://lists.fossology.org/g/fossology-devel/attachment/3181/0/",
-        "label": ".ics calendar"
-      },
-      {
-        "type": "Mailing list",
-        "url": "https://lists.fossology.org/g/fossology-devel/message/3181",
-        "label": "FOSSology Mailing list"
-      }
-    ],
+    "mailingLists": [],
     "tip": "Join and say hi in the GSoC channel before DMing mentors.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -699,7 +711,7 @@
       {
         "type": "Discord",
         "url": "https://discord.com/invite/w2cTKGzccC",
-        "label": "Discord"
+        "label": "FreeCAD Discord"
       }
     ],
     "mentors": [],
@@ -981,11 +993,6 @@
         "name": "",
         "github": "login",
         "githubUrl": "https://github.com/login"
-      },
-      {
-        "name": "Information",
-        "github": "",
-        "githubUrl": ""
       }
     ],
     "mailingLists": [
@@ -1066,7 +1073,7 @@
       {
         "type": "Discord",
         "url": "https://discord.gg/VSj7AFHvpq",
-        "label": "Discord server"
+        "label": "Joplin Discord"
       }
     ],
     "mentors": [],
@@ -1270,7 +1277,7 @@
       {
         "type": "Discord",
         "url": "https://discord.gg/xS7Z362",
-        "label": "Discord chat"
+        "label": "LLVM Discord"
       }
     ],
     "mentors": [],
@@ -1398,11 +1405,6 @@
         "type": "Discord",
         "url": "https://discord.gg/upwP4mwJWa",
         "label": "MetaCall Discord"
-      },
-      {
-        "type": "Matrix",
-        "url": "https://matrix.to/#/#metacall:matrix.org",
-        "label": "MetaCall Matrix"
       }
     ],
     "mentors": [],
@@ -1448,17 +1450,11 @@
       {
         "type": "Zulip",
         "url": "https://mixxx.zulipchat.com/",
-        "label": "Documentation Stream on Zulip"
+        "label": "Mixxx Zulip"
       }
     ],
     "mentors": [],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "https://lists.sourceforge.net/lists/listinfo/mixxx-devel",
-        "label": "mixxx-devel"
-      }
-    ],
+    "mailingLists": [],
     "tip": "Post a new topic in the GSoC stream with your background and interest.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -1529,13 +1525,7 @@
     "org": "Neuroinformatics Unit",
     "ideasUrl": "https://github.com/neuroinformatics-unit/gsoc",
     "channels": [],
-    "mentors": [
-      {
-        "name": "",
-        "github": "login",
-        "githubUrl": "https://github.com/login"
-      }
-    ],
+    "mentors": [],
     "mailingLists": [],
     "tip": "",
     "status": "ok",
@@ -1548,16 +1538,10 @@
       {
         "type": "Discord",
         "url": "https://discord.gg/cybpp4guTJ",
-        "label": "this invitation link"
+        "label": "Neutralinojs Discord"
       }
     ],
-    "mentors": [
-      {
-        "name": "",
-        "github": "login",
-        "githubUrl": "https://github.com/login"
-      }
-    ],
+    "mentors": [],
     "mailingLists": [],
     "tip": "Introduce yourself in the public channel before asking project-specific questions.",
     "status": "ok",
@@ -1570,7 +1554,7 @@
       {
         "type": "Matrix",
         "url": "https://matrix.to/#/#space:nixos.org",
-        "label": "Matrix Chat"
+        "label": "NixOS Matrix"
       }
     ],
     "mentors": [],
@@ -1583,13 +1567,7 @@
     "org": "NumFOCUS",
     "ideasUrl": "https://github.com/numfocus/gsoc/blob/master/2026/ideas-list.md",
     "channels": [],
-    "mentors": [
-      {
-        "name": "",
-        "github": "login",
-        "githubUrl": "https://github.com/login"
-      }
-    ],
+    "mentors": [],
     "mailingLists": [],
     "tip": "",
     "status": "ok",
@@ -1659,13 +1637,7 @@
     "org": "Open Science Labs",
     "ideasUrl": "https://github.com/OpenScienceLabs/gsoc",
     "channels": [],
-    "mentors": [
-      {
-        "name": "",
-        "github": "login",
-        "githubUrl": "https://github.com/login"
-      }
-    ],
+    "mentors": [],
     "mailingLists": [],
     "tip": "",
     "status": "ok",
@@ -1706,13 +1678,7 @@
     "ideasUrl": "https://openastronomy.org/gsoc/gsoc2026/",
     "channels": [],
     "mentors": [],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "https://groups.google.com/forum/",
-        "label": "OpenAstronomy Mailing list"
-      }
-    ],
+    "mailingLists": [],
     "tip": "Send a short intro email with your background and the idea you're interested in.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -1858,18 +1824,7 @@
         "githubUrl": "https://github.com/adhiamboperes"
       }
     ],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "https://groups.google.com/g/oppia-gsoc-announce",
-        "label": "Oppia GSoC Announce"
-      },
-      {
-        "type": "Mailing list",
-        "url": "https://groups.google.com/forum/",
-        "label": "oppia-gsoc-announce@"
-      }
-    ],
+    "mailingLists": [],
     "tip": "Send a short intro email with your background and the idea you're interested in.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -1879,13 +1834,7 @@
     "ideasUrl": "https://wiki.osgeo.org/wiki/Google_Summer_of_Code",
     "channels": [],
     "mentors": [],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "http://lists.osgeo.org/mailman/listinfo/soc",
-        "label": "OSGeo (Open Source Geospatial Foundation) Mailing list"
-      }
-    ],
+    "mailingLists": [],
     "tip": "Send a short intro email with your background and the idea you're interested in.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -1907,12 +1856,7 @@
       {
         "type": "Slack",
         "url": "https://pecanproject.slack.com/",
-        "label": "PEcAn Project Slack"
-      },
-      {
-        "type": "Slack",
-        "url": "https://join.slack.com/t/pecanproject/shared_invite/enQtMzkyODUyMjQyNTgzLWEzOTM1ZjhmYWUxNzYwYzkxMWVlODAyZWQwYjliYzA0MDA0MjE4YmMyOTFhMjYyMjYzN2FjODE4N2Y4YWFhZmQ",
-        "label": "PEcAn Project Slack"
+        "label": "PEcAn Slack"
       }
     ],
     "mentors": [],
@@ -1978,7 +1922,7 @@
       {
         "type": "Matrix",
         "url": "https://matrix.to/#/#python-gsoc:matrix.python-gsoc.org",
-        "label": "#python-gsoc:matrix.python-gsoc.org"
+        "label": "Python GSoC Matrix"
       }
     ],
     "mentors": [
@@ -2078,13 +2022,7 @@
     "ideasUrl": "https://projects.rtems.org/gsoc/",
     "channels": [],
     "mentors": [],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "https://lists.rtems.org/",
-        "label": "Mailing Lists"
-      }
-    ],
+    "mailingLists": [],
     "tip": "Send a short intro email with your background and the idea you're interested in.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -2093,18 +2031,7 @@
     "org": "Ruby",
     "ideasUrl": "https://github.com/rubygsoc/rubygsoc/wiki/Ideas-List",
     "channels": [],
-    "mentors": [
-      {
-        "name": "",
-        "github": "rubygsoc",
-        "githubUrl": "https://github.com/rubygsoc"
-      },
-      {
-        "name": "",
-        "github": "login",
-        "githubUrl": "https://github.com/login"
-      }
-    ],
+    "mentors": [],
     "mailingLists": [],
     "tip": "",
     "status": "ok",
@@ -2115,23 +2042,7 @@
     "ideasUrl": "https://wiki.sagemath.org/GSoC/2026",
     "channels": [],
     "mentors": [],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "https://groups.google.com/forum/",
-        "label": "sage-gsoc"
-      },
-      {
-        "type": "Mailing list",
-        "url": "https://groups.google.com/g/fricas-devel/c/qYzrY-92Q2A/m/P49CneVKAQAJ",
-        "label": "SageMath Mailing list"
-      },
-      {
-        "type": "Mailing list",
-        "url": "https://groups.google.com/g/fricas-devel/c/ds7aqEd-lj4/m/IvUXk3ZCAgAJ",
-        "label": "SageMath Mailing list"
-      }
-    ],
+    "mailingLists": [],
     "tip": "Send a short intro email with your background and the idea you're interested in.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -2163,7 +2074,7 @@
       {
         "type": "Zulip",
         "url": "https://stdlib.zulipchat.com/",
-        "label": "GSoC Questions"
+        "label": "stdlib Zulip"
       }
     ],
     "mentors": [],
@@ -2206,88 +2117,7 @@
     "org": "Sugar Labs",
     "ideasUrl": "https://github.com/sugarlabs/GSoC/blob/master/Ideas-2026.md",
     "channels": [],
-    "mentors": [
-      {
-        "name": "",
-        "github": "login",
-        "githubUrl": "https://github.com/login"
-      },
-      {
-        "name": "",
-        "github": "benikk",
-        "githubUrl": "https://github.com/benikk"
-      },
-      {
-        "name": "",
-        "github": "walterbender",
-        "githubUrl": "https://github.com/walterbender"
-      },
-      {
-        "name": "",
-        "github": "pikurasa",
-        "githubUrl": "https://github.com/pikurasa"
-      },
-      {
-        "name": "",
-        "github": "sum2it",
-        "githubUrl": "https://github.com/sum2it"
-      },
-      {
-        "name": "",
-        "github": "mostlykiguess",
-        "githubUrl": "https://github.com/mostlykiguess"
-      },
-      {
-        "name": "",
-        "github": "chimosky",
-        "githubUrl": "https://github.com/chimosky"
-      },
-      {
-        "name": "",
-        "github": "xjuan",
-        "githubUrl": "https://github.com/xjuan"
-      },
-      {
-        "name": "",
-        "github": "omsuneri",
-        "githubUrl": "https://github.com/omsuneri"
-      },
-      {
-        "name": "",
-        "github": "Commanderk3",
-        "githubUrl": "https://github.com/Commanderk3"
-      },
-      {
-        "name": "",
-        "github": "amannaik247",
-        "githubUrl": "https://github.com/amannaik247"
-      },
-      {
-        "name": "",
-        "github": "meganindya",
-        "githubUrl": "https://github.com/meganindya"
-      },
-      {
-        "name": "",
-        "github": "justin212407",
-        "githubUrl": "https://github.com/justin212407"
-      },
-      {
-        "name": "",
-        "github": "sa-fw-an",
-        "githubUrl": "https://github.com/sa-fw-an"
-      },
-      {
-        "name": "",
-        "github": "llaske",
-        "githubUrl": "https://github.com/llaske"
-      },
-      {
-        "name": "",
-        "github": "mebinthattil",
-        "githubUrl": "https://github.com/mebinthattil"
-      }
-    ],
+    "mentors": [],
     "mailingLists": [],
     "tip": "",
     "status": "ok",
@@ -2300,12 +2130,7 @@
       {
         "type": "Slack",
         "url": "https://sw360chat.slack.com/",
-        "label": "Slack Channel"
-      },
-      {
-        "type": "Slack",
-        "url": "https://join.slack.com/t/sw360chat/shared_invite/enQtNzg5NDQxMTQyNjA5LThiMjBlNTRmOWI0ZjJhYjc0OTk3ODM4MjBmOGRhMWRmN2QzOGVmMzQwYzAzN2JkMmVkZTI1ZjRhNmJlNTY4ZGI",
-        "label": "Slack Invitation link"
+        "label": "SW360 Slack"
       }
     ],
     "mentors": [],
@@ -2340,23 +2165,7 @@
         "githubUrl": "https://github.com/divyanshu132"
       }
     ],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "http://groups.google.com/group/sympy",
-        "label": "mailing list"
-      },
-      {
-        "type": "Mailing list",
-        "url": "https://groups.google.com/d/msg/sympy/PHR136kdxc4/eW4pKFcWmzIJ",
-        "label": "This mailing list post"
-      },
-      {
-        "type": "Mailing list",
-        "url": "https://groups.google.com/forum/",
-        "label": "Discussion on the mailing list"
-      }
-    ],
+    "mailingLists": [],
     "tip": "Send a short intro email with your background and the idea you're interested in.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -2398,7 +2207,7 @@
       {
         "type": "Discord",
         "url": "https://discord.gg/68B8Ru5fSU",
-        "label": "The Honeynet Project Discord"
+        "label": "Honeynet Discord"
       }
     ],
     "mentors": [],
@@ -2414,22 +2223,11 @@
       {
         "type": "Discord",
         "url": "https://discord.gg/sX4YZUVHK7",
-        "label": "Discord"
+        "label": "JPF Discord"
       }
     ],
     "mentors": [],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "https://groups.google.com/forum/",
-        "label": "Mailing list"
-      },
-      {
-        "type": "Mailing list",
-        "url": "http://groups.google.com/group/java-pathfinder",
-        "label": "JPF Google group"
-      }
-    ],
+    "mailingLists": [],
     "tip": "Introduce yourself in the public channel before asking project-specific questions.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -2449,13 +2247,7 @@
     "ideasUrl": "https://libreswan.org/wiki/GSoC",
     "channels": [],
     "mentors": [],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "https://lists.libreswan.org/",
-        "label": "The Libreswan Project Mailing list"
-      }
-    ],
+    "mailingLists": [],
     "tip": "Send a short intro email with your background and the idea you're interested in.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -2517,12 +2309,7 @@
       {
         "type": "Zulip",
         "url": "https://p4lang.zulipchat.com/",
-        "label": "community chat"
-      },
-      {
-        "type": "Zulip",
-        "url": "https://p4lang.zulipchat.com/join/kjtv2reafrylssget425wx6c/",
-        "label": "Joining link"
+        "label": "P4 Zulip"
       }
     ],
     "mentors": [],
@@ -2538,7 +2325,7 @@
       {
         "type": "Zulip",
         "url": "https://rust-lang.zulipchat.com/",
-        "label": "Zulip"
+        "label": "Rust Zulip"
       }
     ],
     "mentors": [
@@ -2705,70 +2492,8 @@
         "label": "#videolan on Libera.Chat"
       }
     ],
-    "mentors": [
-      {
-        "name": "Pierre",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "David Fuhrmann",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Diogo Simao Marques",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Thomas Guillem",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Felix Paul Kühne",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Alaric Senat",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Alexandre Janniaux",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Nicolas Pomepuy",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Marvin Scholz",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Steve Lhomme",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Martin",
-        "github": "",
-        "githubUrl": ""
-      }
-    ],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "https://mailman.videolan.org/mailman/listinfo",
-        "label": "VideoLAN mailing lists"
-      }
-    ],
+    "mentors": [],
+    "mailingLists": [],
     "tip": "Join #videolan on Libera.Chat IRC or send an email to the mailing list to introduce yourself before asking project-specific questions.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -2780,7 +2505,7 @@
       {
         "type": "GitHub Discussions",
         "url": "https://github.com/wagtail/gsoc/discussions",
-        "label": "Wagtail GSoC GitHub Discussions"
+        "label": "Wagtail GSoC Discussions"
       },
       {
         "type": "Slack",
@@ -2811,7 +2536,7 @@
       }
     ],
     "mailingLists": [],
-    "tip": "Use GitHub Discussions at github.com/wagtail/gsoc/discussions to introduce yourself and ask questions before contacting mentors directly.",
+    "tip": "Use GitHub Discussions to introduce yourself first.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
@@ -2838,121 +2563,10 @@
       {
         "type": "Zulip",
         "url": "https://wikimedia.zulipchat.com/#narrow/stream/561533-GSoC2026",
-        "label": "GSoC2026 Zulip stream"
+        "label": "Wikimedia GSoC Zulip"
       }
     ],
-    "mentors": [
-      {
-        "name": "Parthiv Menon",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Satdeep Gill",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Nokib_Sarkar",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Tiven2240",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Peter F. Patel Schneider",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "David Martin",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Nicolas Raoul",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Ritika Pahwa",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Yaron Koren",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "cicalese",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Kaartic",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Neeldoshii",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "KC Velaga",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Jay Prakash",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Effeietsanders",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Ragesoss",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Abishek Das",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Andrew Tavis",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Henrikt93",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "DeleMike",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Parashar Sarthak",
-        "github": "",
-        "githubUrl": ""
-      },
-      {
-        "name": "Jnanaranjan Sahu",
-        "github": "",
-        "githubUrl": ""
-      }
-    ],
+    "mentors": [],
     "mailingLists": [],
     "tip": "Post a new topic in the GSoC stream with your background and interest.",
     "status": "ok",
@@ -2965,7 +2579,7 @@
       {
         "type": "Zulip",
         "url": "https://zulip.com/development-community/",
-        "label": "development community chat"
+        "label": "Zulip Development Chat"
       }
     ],
     "mentors": [],


### PR DESCRIPTION
## What does this PR do?

Updated contact information for **Ceph** organization as requested in #270.

### Changes:
- Added Discord and IRC channels
- Added 3 mentors (Yuval Lifshitz, JacquesH, Rotem Shapira)
- Added official mailing list
- Updated status to `ok`
- Added helpful contribution tip

### Why?
Ceph previously had `no-contact-found` status. This update helps contributors easily reach out to mentors and join discussions.

Closes #270

