### PR TITLE
fix: resolve 7 bugs — XSS hardening, modal UX, filter logic, org coun…

### DIFF
--- a/api/github.js
+++ b/api/github.js
@@ -4,11 +4,18 @@ const CACHE = new Map();
 const CACHE_TTL = 60 * 60 * 1000; // 1 hour
 
 export default async function handler(req) {
+  // Security: restrict CORS to known origins instead of wildcard '*'
+  const allowedOrigins = (process.env.ALLOWED_ORIGINS || '*').split(',').map(s => s.trim());
+  const requestOrigin = req.headers.get('origin') || '';
+  const origin = allowedOrigins.includes('*') ? '*'
+    : allowedOrigins.includes(requestOrigin) ? requestOrigin : '';
+
   const headers = {
-    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Origin': origin || allowedOrigins[0] || '*',
     'Access-Control-Allow-Methods': 'GET, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
     'Content-Type': 'application/json',
+    'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
   };
 
   if (req.method === 'OPTIONS') {

--- a/index.html
+++ b/index.html
@@ -137,10 +137,13 @@
     .modal-bg.open .modal {
       transform: scale(1);
     }
+    /* Fix #475: sticky positioning keeps close button visible while scrolling modal */
     .close-btn {
-      position: absolute;
-      top: 1.5rem;
-      right: 1.5rem;
+      position: sticky;
+      top: 1rem;
+      z-index: 10;
+      float: right;
+      margin: 1rem 1rem 0 0;
       width: 2.5rem;
       height: 2.5rem;
       border-radius: 99px;
@@ -150,6 +153,7 @@
       justify-content: center;
       color: #555;
       font-size: 1.2rem;
+      cursor: pointer;
       transition: all 0.2s;
     }
     .close-btn:hover { background: #e8e8e8; color: #1a1c1c; }
@@ -937,7 +941,7 @@
       <div class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all">
         <div class="w-14 h-14 rounded-2xl bg-orange-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-primary group-hover:scale-110 transition-transform">1</div>
         <h3 class="text-xl font-bold text-white mb-3">Explore Organizations</h3>
-        <p class="text-zinc-400 text-sm leading-relaxed">Browse 185+ open source organizations. Filter by language, domain, and competition level to find your match.</p>
+        <p class="text-zinc-400 text-sm leading-relaxed">Browse all 184 open source organizations. Filter by language, domain, and competition level to find your match.</p>
       </div>
       <div class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all">
         <div class="w-14 h-14 rounded-2xl bg-blue-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-blue-400 group-hover:scale-110 transition-transform">2</div>
@@ -1027,7 +1031,7 @@
     <nav class="flex flex-wrap gap-6">
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://summerofcode.withgoogle.com/programs/2026/organizations" target="_blank">GSoC 2026</a>
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank">GitHub</a>
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#">Privacy</a>
+      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/wiki/Privacy-Policy" target="_blank" rel="noopener noreferrer">Privacy</a>
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#contact">Contact</a>
     </nav>
   </div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -536,8 +536,6 @@ function applyFilters(){
     if(yearsF){const yc=yCls(o.years);if(yearsF!==yc)return false;}
     if(compF&&o.competition!==compF)return false;
 
-    if(pills.size>0){let m=false;pills.forEach(p=>{if(txt.includes(p))m=true;});if(!m)return false;}
-
     // Use proper language matching with LANGUAGE_MAP
     if(pills.size>0&&!orgMatchesLanguages(o,pills))return false;
  
@@ -714,7 +712,7 @@ function renderGrid(orgs){
           </a>`:''}
         </div>
       </div>
-      <div class="org-desc">${o.desc}</div>
+      <div class="org-desc">${escapeHtml(o.desc)}</div>
       <div class="badges">
         <span class="b ${yBdg(o.years)}">${yLbl(o.years)} · ${o.years}y</span>
         <span class="b ${cBdg(o.competition)}">${cLbl(o.competition)}</span>
@@ -785,7 +783,10 @@ document.addEventListener('keydown',e=>{
     openModal(ORGS.indexOf(filteredOrgs[focusedIdx]));
   } else if((e.key==='c'||e.key==='C')&&focusedIdx>=0&&focusedIdx<n){
     e.preventDefault();
-    toggleCompare(ORGS.indexOf(filteredOrgs[focusedIdx]),null);
+    const org=filteredOrgs[focusedIdx];
+    const globalIdx=ORGS.indexOf(org);
+    toggleCompare(globalIdx,null);
+    showCompareToast(compareSet.has(globalIdx)?`Added "${org.name}" to compare`:`Removed "${org.name}" from compare`);
   } else if (e.key === '/' && !['INPUT', 'SELECT', 'TEXTAREA'].includes(document.activeElement?.tagName)) {
     e.preventDefault();
     document.getElementById('searchInput').focus();
@@ -879,13 +880,13 @@ function resetFilters(){
   document.getElementById('sortSelect').value='alpha';
   pills.clear();chips.clear();
 
-  document.querySelectorAll('.pill.active').forEach(p=>p.classList.remove('active'));
-  Object.keys(chipCls).forEach(k=>{const e=document.getElementById('chip-'+k);if(e)e.className='chip';});
-
-  document.querySelectorAll('.pill.active').forEach(p=>{p.classList.remove('active');p.setAttribute('aria-pressed','false');});
+  document.querySelectorAll('.pill.active').forEach(p=>{
+    p.classList.remove('active');
+    p.setAttribute('aria-pressed','false');
+  });
   Object.keys(chipCls).forEach(k=>{const e=document.getElementById('chip-'+k);if(e)e.className='chip';});
   renderSelectedLanguages();
- 
+
   applyFilters();
 }
 


### PR DESCRIPTION
…t, footer links, API CORS

Security:
- Escape o.desc in card rendering to prevent XSS via innerHTML injection
- Replace wildcard CORS '*' with configurable ALLOWED_ORIGINS env var in API proxy
- Add Cache-Control headers for CDN efficiency

UI/UX (#475, #473, #470, #469):
- Make modal close button sticky so it stays visible during scroll (#475)
- Fix Privacy footer link pointing to dead '#' anchor (#473)
- Correct '185+' to '184' in guide section to match actual org count (#470)
- Add toast feedback when keyboard 'C' shortcut toggles compare (#469)

Logic:
- Remove duplicate loose text-match filter for language pills (redundant with LANGUAGE_MAP)
- Consolidate duplicate pill/chip cleanup in resetFilters()