### PR TITLE
docs: fix Synfig mentor and contact information

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2362,14 +2362,20 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Synfig": {
-    "org": "Synfig",
-    "ideasUrl": "https://github.com/synfig/synfig/wiki/GSoC",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+  "org": "Synfig",
+  "ideasUrl": "https://github.com/synfig/synfig-docs-dev/blob/master/docs/gsoc/2025/ideas.rst",
+  "channels": [
+    "https://forums.synfig.org/",
+    "https://www.synfig.org/contact/"
+  ],
+  "mentors": [
+  "mohamedAdhamc",
+  "rodolforg"
+  ],
+  "mailingLists": [],
+  "tip": "",
+  "status": "ok",
+  "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "TARDIS RT Collaboration": {
     "org": "TARDIS RT Collaboration",


### PR DESCRIPTION
## 📝 Description

Updated Synfig organization information by:

* replacing the broken ideas page URL
* adding verified communication/contact channels
* adding mentor GitHub handles
* updating status from `no-contact-found` to `ok`

## 🔗 Related Issue

Closes #411

## 🔄 Type of Change

* [x] 📖 Documentation

## 🧪 How to Test

1. Open `data/mentors.json`
2. Verify the Synfig entry contains updated ideas URL, channels, mentor handles, and status

## ✅ Checklist

* [x] I am contributing under GSSoC
* [x] My code follows the project's existing style
* [x] I have linked the related issue above
