### PR TITLE
fix: replace placeholder footer Privacy and Contact links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1103,8 +1103,8 @@
     <nav class="flex flex-wrap gap-6">
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://summerofcode.withgoogle.com/programs/2026/organizations" target="_blank">GSoC 2026</a>
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank">GitHub</a>
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#">Privacy</a>
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#contact">Contact</a>
+<a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-#readme" target="_blank" rel="noopener noreferrer">Privacy</a>
+<a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/issues" target="_blank" rel="noopener noreferrer">Contact</a>
     </nav>
   </div>
 </footer>


### PR DESCRIPTION
## Related Issue
Closes #472

## Description
Fixed broken footer links where Privacy and Contact both used `href="#"` 
causing the page to scroll to top instead of navigating anywhere useful.

- Privacy → now links to the repo README on GitHub
- Contact → now links to the GitHub Issues page

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I am contributing under GSSoC '26
- [x] This issue was assigned to me before I started work
- [x] I have only changed what the issue asked for
- [x] No breaking changes introduced