### PR TITLE
fix(mentors): verify and fix OSGeo contact info

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1891,13 +1891,7 @@
         "githubUrl": "https://github.com/krashish8"
       }
     ],
-    "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "https://discourse.osgeo.org/c/initiatives/soc",
-        "label": "OSGeo GSoC — migrated from mailman to Discourse"
-      }
-    ],
+    "mailingLists": [],
     "tip": "Send a short intro email with your background and the idea you're interested in.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1876,14 +1876,26 @@
   },
   "OSGeo (Open Source Geospatial Foundation)": {
     "org": "OSGeo (Open Source Geospatial Foundation)",
-    "ideasUrl": "https://wiki.osgeo.org/wiki/Google_Summer_of_Code",
-    "channels": [],
-    "mentors": [],
+    "ideasUrl": "https://wiki.osgeo.org/wiki/Google_Summer_of_Code_2026_Ideas",
+    "channels": [
+      {
+        "type": "Discourse",
+        "url": "https://discourse.osgeo.org/c/initiatives/soc",
+        "label": "OSGeo GSoC Discourse (Summer of Code)"
+      }
+    ],
+    "mentors": [
+       {
+        "name": "Ashish",
+        "github": "krashish8",
+        "githubUrl": "https://github.com/krashish8"
+      }
+    ],
     "mailingLists": [
       {
         "type": "Mailing list",
-        "url": "http://lists.osgeo.org/mailman/listinfo/soc",
-        "label": "OSGeo (Open Source Geospatial Foundation) Mailing list"
+        "url": "https://discourse.osgeo.org/c/initiatives/soc",
+        "label": "OSGeo GSoC — migrated from mailman to Discourse"
       }
     ],
     "tip": "Send a short intro email with your background and the idea you're interested in.",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -8,7 +8,7 @@
         "name": "",
         "github": "52north",
         "githubUrl": "https://github.com/52north" 
-      }
+      } 
     ],
     "mailingLists": [],
     "tip": "",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -7,7 +7,7 @@
       {
         "name": "",
         "github": "52north",
-        "githubUrl": "https://github.com/52north"
+        "githubUrl": "https://github.com/52north" 
       }
     ],
     "mailingLists": [],


### PR DESCRIPTION
<!-- GSSOC -->

Closes #383

### Description
Verified and fixed mentor contact info for OSGeo (Open Source Geospatial Foundation) for GSoC 2026.

### Related Issue
#383

### Type of Change
- [x] Bug fix / Data fix

### What I did
- Fixed ideasUrl from outdated redirect (pointed to 2020 page) to correct 2026 ideas page
- Added Discourse channel (discourse.osgeo.org/c/initiatives/soc) under channels
- Added GSoC admin Ashish (krashish8) under mentors
- Fixed broken mailingLists URL — old lists.osgeo.org/mailman/listinfo/soc returns "No such list", SOC list was migrated to Discourse
- status remains "ok"

No other entries touched.

### Checklist
- [x] My changes follow the project's contribution guidelines
- [x] I have linked the related issue
- [x] No unrelated files changed