### PR TITLE
fix(GSoC): update libssh mentor contact info

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1245,12 +1245,12 @@
   },
   "libssh": {
     "org": "libssh",
-    "ideasUrl": "https://gitlab.com/libssh/libssh-mirror/-/wikis/Google-Summer-of-Code",
-    "channels": [],
-    "mentors": [],
+    "ideasUrl": "https://www.libssh.org/development/google-summer-of-code/",
+    "channels": ["MATRIX"],
+    "mentors": ["Jakub Jelen", "Sahana Prasad" ,"Eshan Kelkar"],
     "mailingLists": [],
     "tip": "",
-    "status": "fetch-failed",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Liquid Galaxy project": {


### PR DESCRIPTION
### Description
Updated the `mentors.json` file with the correct mentor contact information, Matrix channel, and fixed the broken ideas page URL for the libssh organization.

### Related Issue
Fixes #437

### Type of Change
- [x] Data update or bug fix

### Checklist
- [x] I have verified the information.
- [x] The ideas page URL is reachable.
- [x] The status is set to ok.