### PR TITLE
fix: prevent Material Symbols FOUI on initial page load [GSSOC]

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,20 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <title>Live GSoC 2026 Org Finder & Good First Issue Tracker | FindMyGSoC</title>
-  <meta name="description" content="Live GSoC 2026 Org Finder & Good First Issue Tracker. Discover organizations, compare project fit, and track beginner-friendly GitHub issues in real time." />
+  <meta name="description"
+    content="Live GSoC 2026 Org Finder & Good First Issue Tracker. Discover organizations, compare project fit, and track beginner-friendly GitHub issues in real time." />
   <link rel="canonical" href="https://findmygsoc.vercel.app/" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="FindMyGSoC" />
   <meta property="og:title" content="Live GSoC 2026 Org Finder & Good First Issue Tracker" />
-  <meta property="og:description" content="Discover Google Summer of Code 2026 organizations and track live good first issues across GitHub." />
+  <meta property="og:description"
+    content="Discover Google Summer of Code 2026 organizations and track live good first issues across GitHub." />
   <meta property="og:url" content="https://findmygsoc.vercel.app/" />
   <meta property="og:image" content="https://findmygsoc.vercel.app/src/assets/og-image.jpeg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Live GSoC 2026 Org Finder & Good First Issue Tracker" />
-  <meta name="twitter:description" content="Find your best-fit GSoC 2026 org and track beginner-friendly GitHub issues." />
+  <meta name="twitter:description"
+    content="Find your best-fit GSoC 2026 org and track beginner-friendly GitHub issues." />
   <meta name="twitter:image" content="https://findmygsoc.vercel.app/src/assets/og-image.jpeg" />
   <script type="application/ld+json">
     {
@@ -37,16 +41,32 @@
     }
   </script>
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap"
+    rel="stylesheet" />
+  <!--Fix: Preload material symbol before render-->
+  <link rel="preload"
+    href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap"
+    as="style" onload="this.rel='stylesheet'" />
+  <noscript>
+    <link rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap" />
+  </noscript>
+  <link rel="preload"
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=block"
+    as="style" onload="this.rel='stylesheet'" />
+  <noscript>
+    <link rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=block" />
+  </noscript>
   <script>
     // Theme restoration - runs early to prevent FOUC
-    (function(){
+    (function () {
       try {
         if (localStorage.getItem('theme') === 'dark') {
           document.documentElement.classList.add('dark');
         }
-      } catch(e) {
+      } catch (e) {
         // localStorage might be unavailable in some browsers/modes
         console.warn('Theme restoration failed:', e);
       }
@@ -66,43 +86,109 @@
             '2xl': '1536px',
           },
           colors: {
-            "surface-container-highest":"#e2e2e2","background":"#f9f9f9",
-            "surface-container":"#eeeeee","primary-container":"#f97316",
-            "surface":"#f9f9f9","surface-variant":"#e2e2e2",
-            "on-background":"#1a1c1c","on-primary":"#ffffff",
-            "on-surface":"#1a1c1c","error":"#ba1a1a",
-            "primary":"#9d4300","on-surface-variant":"#584237",
-            "outline":"#8c7164","surface-container-lowest":"#ffffff",
-            "secondary":"#006c47","secondary-container":"#8af5be",
-            "on-secondary-container":"#00714b","on-secondary":"#ffffff",
-            "surface-container-low":"#f3f3f3","surface-container-high":"#e8e8e8",
-            "surface-dim":"#dadada","primary-fixed":"#ffdbca",
-            "primary-fixed-dim":"#ffb690","error-container":"#ffdad6",
-            "on-error-container":"#93000a","on-secondary-fixed":"#002113",
-            "secondary-fixed-dim":"#71dba6","tertiary":"#5f5e5e",
-            "on-primary-container":"#582200","surface-tint":"#9d4300",
+            "surface-container-highest": "#e2e2e2", "background": "#f9f9f9",
+            "surface-container": "#eeeeee", "primary-container": "#f97316",
+            "surface": "#f9f9f9", "surface-variant": "#e2e2e2",
+            "on-background": "#1a1c1c", "on-primary": "#ffffff",
+            "on-surface": "#1a1c1c", "error": "#ba1a1a",
+            "primary": "#9d4300", "on-surface-variant": "#584237",
+            "outline": "#8c7164", "surface-container-lowest": "#ffffff",
+            "secondary": "#006c47", "secondary-container": "#8af5be",
+            "on-secondary-container": "#00714b", "on-secondary": "#ffffff",
+            "surface-container-low": "#f3f3f3", "surface-container-high": "#e8e8e8",
+            "surface-dim": "#dadada", "primary-fixed": "#ffdbca",
+            "primary-fixed-dim": "#ffb690", "error-container": "#ffdad6",
+            "on-error-container": "#93000a", "on-secondary-fixed": "#002113",
+            "secondary-fixed-dim": "#71dba6", "tertiary": "#5f5e5e",
+            "on-primary-container": "#582200", "surface-tint": "#9d4300",
           },
           fontFamily: {
-            "headline":["Plus Jakarta Sans"],"body":["Plus Jakarta Sans"],
-            "label":["Space Grotesk"],"mono":["Fira Code"]
+            "headline": ["Plus Jakarta Sans"], "body": ["Plus Jakarta Sans"],
+            "label": ["Space Grotesk"], "mono": ["Fira Code"]
           },
-          borderRadius:{"DEFAULT":"0.25rem","lg":"0.5rem","xl":"0.75rem","full":"9999px"},
+          borderRadius: { "DEFAULT": "0.25rem", "lg": "0.5rem", "xl": "0.75rem", "full": "9999px" },
         },
       },
     }
   </script>
   <style>
-    .material-symbols-outlined{font-variation-settings:'FILL' 0,'wght' 400,'GRAD' 0,'opsz' 24;vertical-align:middle}
-    .icon-fill{font-variation-settings:'FILL' 1,'wght' 400,'GRAD' 0,'opsz' 24}
-    .glass{backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px)}
-    .no-scrollbar::-webkit-scrollbar{display:none}.no-scrollbar{-ms-overflow-style:none;scrollbar-width:none}
-    @keyframes fadeUp{from{opacity:0;transform:translateY(20px)}to{opacity:1;transform:translateY(0)}}
-    .fade-up{animation:fadeUp .6s ease-out both}
-    @keyframes pulse-dot{0%,100%{opacity:.4}50%{opacity:1}}
-    .pulse-dot{animation:pulse-dot 2s infinite}
-    @keyframes gradient-shift{0%{background-position:0% 50%}50%{background-position:100% 50%}100%{background-position:0% 50%}}
-    .gradient-animate{background-size:200% 200%;animation:gradient-shift 8s ease infinite}
-    .hero-gradient{background:linear-gradient(135deg,#9d4300 0%,#f97316 50%,#f59e0b 100%)}
+    .material-symbols-outlined {
+      font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+      vertical-align: middle
+    }
+
+    .icon-fill {
+      font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24
+    }
+
+    .glass {
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px)
+    }
+
+    .no-scrollbar::-webkit-scrollbar {
+      display: none
+    }
+
+    .no-scrollbar {
+      -ms-overflow-style: none;
+      scrollbar-width: none
+    }
+
+    @keyframes fadeUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px)
+      }
+
+      to {
+        opacity: 1;
+        transform: translateY(0)
+      }
+    }
+
+    .fade-up {
+      animation: fadeUp .6s ease-out both
+    }
+
+    @keyframes pulse-dot {
+
+      0%,
+      100% {
+        opacity: .4
+      }
+
+      50% {
+        opacity: 1
+      }
+    }
+
+    .pulse-dot {
+      animation: pulse-dot 2s infinite
+    }
+
+    @keyframes gradient-shift {
+      0% {
+        background-position: 0% 50%
+      }
+
+      50% {
+        background-position: 100% 50%
+      }
+
+      100% {
+        background-position: 0% 50%
+      }
+    }
+
+    .gradient-animate {
+      background-size: 200% 200%;
+      animation: gradient-shift 8s ease infinite
+    }
+
+    .hero-gradient {
+      background: linear-gradient(135deg, #9d4300 0%, #f97316 50%, #f59e0b 100%)
+    }
 
     /* Modal Styles */
     .modal-bg {
@@ -118,10 +204,12 @@
       pointer-events: none;
       transition: all 0.3s ease;
     }
+
     .modal-bg.open {
       opacity: 1;
       pointer-events: auto;
     }
+
     .modal {
       background: white;
       width: 90%;
@@ -134,9 +222,11 @@
       transform: scale(0.9);
       transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
     }
+
     .modal-bg.open .modal {
       transform: scale(1);
     }
+
     .close-btn {
       position: absolute;
       top: 1.5rem;
@@ -152,9 +242,16 @@
       font-size: 1.2rem;
       transition: all 0.2s;
     }
-    .close-btn:hover { background: #e8e8e8; color: #1a1c1c; }
-    
-    .modal-header { padding: 3rem 3rem 1.5rem; }
+
+    .close-btn:hover {
+      background: #e8e8e8;
+      color: #1a1c1c;
+    }
+
+    .modal-header {
+      padding: 3rem 3rem 1.5rem;
+    }
+
     .category-tag {
       background: rgba(157, 67, 0, 0.1);
       color: #9d4300;
@@ -166,81 +263,372 @@
       display: inline-block;
       margin-bottom: 1rem;
     }
-    .modal-header h2 { font-size: 2.5rem; font-weight: 800; line-height: 1.1; margin-bottom: 0.5rem; }
-    .modal-header p { color: #584237; font-size: 1rem; line-height: 1.5; }
 
-    .modal-body { padding: 0 3rem 3rem; }
-    .section-title { font-size: 0.75rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.15em; color: #aaa; margin-bottom: 1rem; margin-top: 2rem; border-bottom: 1px solid #f3f3f3; padding-bottom: 0.5rem; }
-    
-    .metrics-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 1rem; }
-    .metric-card { background: #f9f9f9; padding: 1.2rem; border-radius: 1.2rem; border: 1px solid #eee; text-align: center; }
-    .metric-value { font-size: 1.25rem; font-weight: 800; color: #1a1c1c; margin-bottom: 0.2rem; }
-    .metric-label { font-size: 0.65rem; font-weight: 700; text-transform: uppercase; color: #888; }
+    .modal-header h2 {
+      font-size: 2.5rem;
+      font-weight: 800;
+      line-height: 1.1;
+      margin-bottom: 0.5rem;
+    }
 
-    .github-stats-container { background: #1a1a1a; border-radius: 1.5rem; padding: 1.5rem; color: #fff; display: flex; flex-wrap: wrap; gap: 1.5rem; align-items: center; position: relative; overflow: hidden; }
-    .gh-fetch { position: absolute; top: 1rem; right: 1rem; background: #333; color: #aaa; border: none; padding: 0.3rem 0.8rem; border-radius: 99px; font-size: 0.65rem; font-weight: 700; cursor: pointer; transition: all 0.2s; }
-    .gh-fetch:hover { background: #444; color: #fff; }
-    .gh-stat-item { font-family: 'Fira Code', monospace; font-size: 0.75rem; color: #4ade80; display: flex; align-items: center; gap: 0.5rem; }
+    .modal-header p {
+      color: #584237;
+      font-size: 1rem;
+      line-height: 1.5;
+    }
 
-    .tech-tags, .fit-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-    .tech-tag { background: #f3f4f6; color: #4b5563; font-size: 0.7rem; font-weight: 600; padding: 0.4rem 0.8rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; }
-    .fit-tag { background: #eff6ff; color: #2563eb; font-size: 0.7rem; font-weight: 600; padding: 0.4rem 0.8rem; border-radius: 0.5rem; border: 1px solid #dbeafe; }
-    .mentor-link-chip { display:inline-flex; align-items:center; gap:.45rem; background:#fff7ed; color:#9d4300; border:1px solid #fed7aa; border-radius:999px; padding:.45rem .75rem; font-size:.75rem; font-weight:700; }
-    .mentor-handle-chip { display:inline-flex; align-items:center; gap:.35rem; background:#f3f4f6; color:#374151; border:1px solid #e5e7eb; border-radius:999px; padding:.4rem .7rem; font-size:.75rem; font-weight:600; }
-    .mentor-card { background:#ffffff; border:1px solid #e5e7eb; border-radius:1rem; padding:1.25rem; box-shadow:0 1px 2px rgba(15,23,42,.04); }
-    .mentor-empty { background:#ffffff; border:1px solid #e5e7eb; border-radius:1rem; padding:2rem; text-align:center; }
+    .modal-body {
+      padding: 0 3rem 3rem;
+    }
 
-    .timeline-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-    .timeline-grid span { font-size: 0.75rem; font-weight: 500; color: #666; background: #fff; border: 1px solid #eee; padding: 0.3rem 0.7rem; border-radius: 0.5rem; }
-    .timeline-grid span.current-year { background: #fffbeb; color: #d97706; border-color: #fef3c7; font-weight: 700; }
+    .section-title {
+      font-size: 0.75rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.15em;
+      color: #aaa;
+      margin-bottom: 1rem;
+      margin-top: 2rem;
+      border-bottom: 1px solid #f3f3f3;
+      padding-bottom: 0.5rem;
+    }
 
-    .modal-footer { padding: 2rem 3rem 3rem; background: #f9f9f9; display: flex; gap: 1rem; border-top: 1px solid #eee; }
-    .modal-cta { flex: 1; padding: 1rem; border-radius: 1rem; font-size: 0.8rem; font-weight: 800; text-align: center; text-transform: uppercase; letter-spacing: 0.05em; transition: all 0.2s; }
-    .modal-ideas-link { background: #9d4300; color: white; }
-    .modal-ideas-link:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(157, 67, 0, 0.3); }
-    .modal-repo-link { background: white; color: #1a1c1c; border: 1px solid #ddd; }
-    .modal-repo-link:hover { background: #f0f0f0; }
+    .metrics-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 1rem;
+    }
+
+    .metric-card {
+      background: #f9f9f9;
+      padding: 1.2rem;
+      border-radius: 1.2rem;
+      border: 1px solid #eee;
+      text-align: center;
+    }
+
+    .metric-value {
+      font-size: 1.25rem;
+      font-weight: 800;
+      color: #1a1c1c;
+      margin-bottom: 0.2rem;
+    }
+
+    .metric-label {
+      font-size: 0.65rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      color: #888;
+    }
+
+    .github-stats-container {
+      background: #1a1a1a;
+      border-radius: 1.5rem;
+      padding: 1.5rem;
+      color: #fff;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .gh-fetch {
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      background: #333;
+      color: #aaa;
+      border: none;
+      padding: 0.3rem 0.8rem;
+      border-radius: 99px;
+      font-size: 0.65rem;
+      font-weight: 700;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .gh-fetch:hover {
+      background: #444;
+      color: #fff;
+    }
+
+    .gh-stat-item {
+      font-family: 'Fira Code', monospace;
+      font-size: 0.75rem;
+      color: #4ade80;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .tech-tags,
+    .fit-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .tech-tag {
+      background: #f3f4f6;
+      color: #4b5563;
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 0.4rem 0.8rem;
+      border-radius: 0.5rem;
+      border: 1px solid #e5e7eb;
+    }
+
+    .fit-tag {
+      background: #eff6ff;
+      color: #2563eb;
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 0.4rem 0.8rem;
+      border-radius: 0.5rem;
+      border: 1px solid #dbeafe;
+    }
+
+    .mentor-link-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: .45rem;
+      background: #fff7ed;
+      color: #9d4300;
+      border: 1px solid #fed7aa;
+      border-radius: 999px;
+      padding: .45rem .75rem;
+      font-size: .75rem;
+      font-weight: 700;
+    }
+
+    .mentor-handle-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: .35rem;
+      background: #f3f4f6;
+      color: #374151;
+      border: 1px solid #e5e7eb;
+      border-radius: 999px;
+      padding: .4rem .7rem;
+      font-size: .75rem;
+      font-weight: 600;
+    }
+
+    .mentor-card {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 1rem;
+      padding: 1.25rem;
+      box-shadow: 0 1px 2px rgba(15, 23, 42, .04);
+    }
+
+    .mentor-empty {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 1rem;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    .timeline-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .timeline-grid span {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: #666;
+      background: #fff;
+      border: 1px solid #eee;
+      padding: 0.3rem 0.7rem;
+      border-radius: 0.5rem;
+    }
+
+    .timeline-grid span.current-year {
+      background: #fffbeb;
+      color: #d97706;
+      border-color: #fef3c7;
+      font-weight: 700;
+    }
+
+    .modal-footer {
+      padding: 2rem 3rem 3rem;
+      background: #f9f9f9;
+      display: flex;
+      gap: 1rem;
+      border-top: 1px solid #eee;
+    }
+
+    .modal-cta {
+      flex: 1;
+      padding: 1rem;
+      border-radius: 1rem;
+      font-size: 0.8rem;
+      font-weight: 800;
+      text-align: center;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      transition: all 0.2s;
+    }
+
+    .modal-ideas-link {
+      background: #9d4300;
+      color: white;
+    }
+
+    .modal-ideas-link:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(157, 67, 0, 0.3);
+    }
+
+    .modal-repo-link {
+      background: white;
+      color: #1a1c1c;
+      border: 1px solid #ddd;
+    }
+
+    .modal-repo-link:hover {
+      background: #f0f0f0;
+    }
 
     /* Custom Scrollbar for Modal */
-    .modal::-webkit-scrollbar { width: 6px; }
-    .modal::-webkit-scrollbar-track { background: transparent; }
-    .modal::-webkit-scrollbar-thumb { background: #ddd; border-radius: 3px; }
-    .modal::-webkit-scrollbar-thumb:hover { background: #ccc; }
+    .modal::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    .modal::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .modal::-webkit-scrollbar-thumb {
+      background: #ddd;
+      border-radius: 3px;
+    }
+
+    .modal::-webkit-scrollbar-thumb:hover {
+      background: #ccc;
+    }
 
     /* Complexity Badges */
-    .complexity-badge { font-size: 0.65rem; font-weight: 800; padding: 0.2rem 0.6rem; border-radius: 99px; text-transform: uppercase; }
-    .complexity-badge.beginner { background: #dcfce7; color: #166534; }
-    .complexity-badge.intermediate { background: #fef9c3; color: #854d0e; }
-    .complexity-badge.advanced { background: #fee2e2; color: #991b1b; }
+    .complexity-badge {
+      font-size: 0.65rem;
+      font-weight: 800;
+      padding: 0.2rem 0.6rem;
+      border-radius: 99px;
+      text-transform: uppercase;
+    }
+
+    .complexity-badge.beginner {
+      background: #dcfce7;
+      color: #166534;
+    }
+
+    .complexity-badge.intermediate {
+      background: #fef9c3;
+      color: #854d0e;
+    }
+
+    .complexity-badge.advanced {
+      background: #fee2e2;
+      color: #991b1b;
+    }
 
     /* Bookmark Button */
-    .bookmark-btn { transition: all 0.2s; font-size: 1.25rem; }
-    .bookmark-btn.active { color: #f59e0b; }
-    .bookmark-btn:hover { transform: scale(1.2); }
+    .bookmark-btn {
+      transition: all 0.2s;
+      font-size: 1.25rem;
+    }
+
+    .bookmark-btn.active {
+      color: #f59e0b;
+    }
+
+    .bookmark-btn:hover {
+      transform: scale(1.2);
+    }
 
     /* Base mobile-first styles */
-    html, body { width: 100%; overflow-x: hidden; }
-    html { scroll-behavior: smooth; }
-    
+    html,
+    body {
+      width: 100%;
+      overflow-x: hidden;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
     /* Scroll offset for fixed header */
-    #timeline, #orgs, #guide, #watchlist, #issues, #mentors, #contact {
+    #timeline,
+    #orgs,
+    #guide,
+    #watchlist,
+    #issues,
+    #mentors,
+    #contact {
       scroll-margin-top: 80px;
     }
 
     /* Minimal dark-mode support */
-    .dark body { background: #0f0f10; color: #e5e7eb; }
-    .dark .glass { background: rgba(24, 24, 27, 0.85); }
-    .dark .bg-white { background: #18181b !important; }
-    .dark .bg-surface-container-low { background: #27272a !important; color: #d4d4d8 !important; }
-    .dark .text-zinc-900 { color: #f4f4f5 !important; }
-    .dark .text-zinc-600, .dark .text-zinc-500, .dark .text-zinc-400 { color: #a1a1aa !important; }
-    .dark .text-zinc-300 { color: #a1a1aa !important; }
-    .dark .text-on-surface { color: #f4f4f5 !important; }
-    .dark .text-on-surface-variant { color: #a1a1aa !important; }
-    .dark .border-zinc-100 { border-color: #3f3f46 !important; }
-    .dark .border-zinc-200 { border-color: #3f3f46 !important; }
-    .dark #timeline-milestones .bg-zinc-200 { background-color: #3f3f46 !important; }
-    .dark .hover\:bg-zinc-100\/50:hover { background: rgba(63, 63, 70, 0.45) !important; }
+    .dark body {
+      background: #0f0f10;
+      color: #e5e7eb;
+    }
+
+    .dark .glass {
+      background: rgba(24, 24, 27, 0.85);
+    }
+
+    .dark .bg-white {
+      background: #18181b !important;
+    }
+
+    .dark .bg-surface-container-low {
+      background: #27272a !important;
+      color: #d4d4d8 !important;
+    }
+
+    .dark .text-zinc-900 {
+      color: #f4f4f5 !important;
+    }
+
+    .dark .text-zinc-600,
+    .dark .text-zinc-500,
+    .dark .text-zinc-400 {
+      color: #a1a1aa !important;
+    }
+
+    .dark .text-zinc-300 {
+      color: #a1a1aa !important;
+    }
+
+    .dark .text-on-surface {
+      color: #f4f4f5 !important;
+    }
+
+    .dark .text-on-surface-variant {
+      color: #a1a1aa !important;
+    }
+
+    .dark .border-zinc-100 {
+      border-color: #3f3f46 !important;
+    }
+
+    .dark .border-zinc-200 {
+      border-color: #3f3f46 !important;
+    }
+
+    .dark #timeline-milestones .bg-zinc-200 {
+      background-color: #3f3f46 !important;
+    }
+
+    .dark .hover\:bg-zinc-100\/50:hover {
+      background: rgba(63, 63, 70, 0.45) !important;
+    }
 
     /* Light mode - Language pills active state */
     .pill.active {
@@ -251,97 +639,289 @@
     }
 
     /* Dark mode - Filter chips & language pills */
-    .dark .bg-surface-container-highest { background: #27272a !important; color: #d4d4d8 !important; }
-    .dark .filter-chip:not(.bg-orange-600) { background: #27272a !important; color: #d4d4d8 !important; border: 1px solid #3f3f46 !important; }
-    .dark .filter-chip:not(.bg-orange-600):hover { background: #fb923c !important; color: #ffffff !important; border-color: #fb923c !important; }
+    .dark .bg-surface-container-highest {
+      background: #27272a !important;
+      color: #d4d4d8 !important;
+    }
+
+    .dark .filter-chip:not(.bg-orange-600) {
+      background: #27272a !important;
+      color: #d4d4d8 !important;
+      border: 1px solid #3f3f46 !important;
+    }
+
+    .dark .filter-chip:not(.bg-orange-600):hover {
+      background: #fb923c !important;
+      color: #ffffff !important;
+      border-color: #fb923c !important;
+    }
 
     /* Dark mode - Language tag pills */
-    .dark section .flex.flex-wrap.gap-2 > button:not(.filter-chip) { 
-      background: #27272a !important; 
-      color: #d4d4d8 !important; 
-      border-color: #3f3f46 !important; 
+    .dark section .flex.flex-wrap.gap-2>button:not(.filter-chip) {
+      background: #27272a !important;
+      color: #d4d4d8 !important;
+      border-color: #3f3f46 !important;
     }
-    .dark section .flex.flex-wrap.gap-2 > button:not(.filter-chip):hover { 
-      border-color: #f97316 !important; 
-      color: #f97316 !important; 
+
+    .dark section .flex.flex-wrap.gap-2>button:not(.filter-chip):hover {
+      border-color: #f97316 !important;
+      color: #f97316 !important;
     }
+
     /* Higher-specificity rule beats .dark section .flex.flex-wrap.gap-2 > button:not(.filter-chip) (0,5,2) */
     .dark .pill.active,
-    .dark section .flex.flex-wrap.gap-2 > button.pill.active {
+    .dark section .flex.flex-wrap.gap-2>button.pill.active {
       background: rgba(251, 146, 60, 0.2) !important;
       border-color: #fb923c !important;
       color: #fb923c !important;
     }
-    
+
     /* Dark mode - Issue card badges */
-    .dark .bg-green-100 { background: #14532d !important; }
-    .dark .bg-zinc-100 { background: #27272a !important; }
-    .dark .text-green-700 { color: #4ade80 !important; }
-    .dark .text-green-800 { color: #86efac !important; }
-    .dark .text-green-600 { color: #4ade80 !important; }
-    .dark .text-zinc-600 { color: #a1a1aa !important; }
-    
+    .dark .bg-green-100 {
+      background: #14532d !important;
+    }
+
+    .dark .bg-zinc-100 {
+      background: #27272a !important;
+    }
+
+    .dark .text-green-700 {
+      color: #4ade80 !important;
+    }
+
+    .dark .text-green-800 {
+      color: #86efac !important;
+    }
+
+    .dark .text-green-600 {
+      color: #4ade80 !important;
+    }
+
+    .dark .text-zinc-600 {
+      color: #a1a1aa !important;
+    }
+
     /* Dark mode - Card hover effects */
-    .dark .group:hover { background: #1f1f23 !important; border-color: rgba(249, 115, 22, 0.3) !important; box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.4) !important; }
-    .dark .group:hover .text-on-surface { color: #f97316 !important; }
-    .dark .group-hover\:text-primary:hover, .dark .group:hover .group-hover\:text-primary { color: #f97316 !important; }
-    
+    .dark .group:hover {
+      background: #1f1f23 !important;
+      border-color: rgba(249, 115, 22, 0.3) !important;
+      box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.4) !important;
+    }
+
+    .dark .group:hover .text-on-surface {
+      color: #f97316 !important;
+    }
+
+    .dark .group-hover\:text-primary:hover,
+    .dark .group:hover .group-hover\:text-primary {
+      color: #f97316 !important;
+    }
+
     /* Dark mode - Tech tags */
-    .dark .tech-tag { background: #27272a; color: #d4d4d8; border-color: #3f3f46; }
-    .dark .fit-tag { background: #1e293b; color: #93c5fd; border-color: #334155; }
-    .dark .mentor-link-chip { background: rgba(124,45,18,0.72); color: #fff7ed; border-color: rgba(251,146,60,0.45); }
-    .dark .mentor-handle-chip { background: #27272a; color: #d4d4d8; border-color: #3f3f46; }
-    .dark .mentor-card, .dark .mentor-empty { background:#18181b; border-color:#3f3f46; }
+    .dark .tech-tag {
+      background: #27272a;
+      color: #d4d4d8;
+      border-color: #3f3f46;
+    }
+
+    .dark .fit-tag {
+      background: #1e293b;
+      color: #93c5fd;
+      border-color: #334155;
+    }
+
+    .dark .mentor-link-chip {
+      background: rgba(124, 45, 18, 0.72);
+      color: #fff7ed;
+      border-color: rgba(251, 146, 60, 0.45);
+    }
+
+    .dark .mentor-handle-chip {
+      background: #27272a;
+      color: #d4d4d8;
+      border-color: #3f3f46;
+    }
+
+    .dark .mentor-card,
+    .dark .mentor-empty {
+      background: #18181b;
+      border-color: #3f3f46;
+    }
 
     @media (max-width: 640px) {
-      .modal-header { padding: 2rem 1.5rem 1rem; }
-      .modal-body { padding: 0 1.5rem 2rem; }
-      .modal-footer { padding: 1.5rem; flex-direction: column; }
-      .modal-cta { width: 100%; }
+      .modal-header {
+        padding: 2rem 1.5rem 1rem;
+      }
+
+      .modal-body {
+        padding: 0 1.5rem 2rem;
+      }
+
+      .modal-footer {
+        padding: 1.5rem;
+        flex-direction: column;
+      }
+
+      .modal-cta {
+        width: 100%;
+      }
     }
-    
+
     /* Dark mode - Modal */
-    .dark .modal { background: #18181b; }
-    .dark .modal-header h2 { color: #f4f4f5; }
-    .dark .modal-header p { color: #a1a1aa; }
-    .dark .section-title { color: #a1a1aa; border-color: #27272a; }
-    .dark .metric-card { background: #27272a; border-color: #3f3f46; }
-    .dark .metric-value { color: #f4f4f5; }
-    .dark .metric-label { color: #a1a1aa; }
-    .dark .close-btn { background: #27272a; color: #a1a1aa; }
-    .dark .close-btn:hover { background: #3f3f46; color: #f4f4f5; }
-    .dark .modal-footer { background: #0f0f10; border-color: #27272a; }
-    .dark .modal-repo-link { background: #27272a; color: #e5e7eb; border-color: #3f3f46; }
-    .dark .modal-repo-link:hover { background: #3f3f46; }
-    .dark #compareModalBody { color: #e5e7eb; }
-    .dark #compareModalBody .text-zinc-700 { color: #e5e7eb !important; }
-    .dark #compareModalBody .text-zinc-500 { color: #a1a1aa !important; }
-    .dark #compareModalBody .text-zinc-400 { color: #d4d4d8 !important; }
+    .dark .modal {
+      background: #18181b;
+    }
+
+    .dark .modal-header h2 {
+      color: #f4f4f5;
+    }
+
+    .dark .modal-header p {
+      color: #a1a1aa;
+    }
+
+    .dark .section-title {
+      color: #a1a1aa;
+      border-color: #27272a;
+    }
+
+    .dark .metric-card {
+      background: #27272a;
+      border-color: #3f3f46;
+    }
+
+    .dark .metric-value {
+      color: #f4f4f5;
+    }
+
+    .dark .metric-label {
+      color: #a1a1aa;
+    }
+
+    .dark .close-btn {
+      background: #27272a;
+      color: #a1a1aa;
+    }
+
+    .dark .close-btn:hover {
+      background: #3f3f46;
+      color: #f4f4f5;
+    }
+
+    .dark .modal-footer {
+      background: #0f0f10;
+      border-color: #27272a;
+    }
+
+    .dark .modal-repo-link {
+      background: #27272a;
+      color: #e5e7eb;
+      border-color: #3f3f46;
+    }
+
+    .dark .modal-repo-link:hover {
+      background: #3f3f46;
+    }
+
+    .dark #compareModalBody {
+      color: #e5e7eb;
+    }
+
+    .dark #compareModalBody .text-zinc-700 {
+      color: #e5e7eb !important;
+    }
+
+    .dark #compareModalBody .text-zinc-500 {
+      color: #a1a1aa !important;
+    }
+
+    .dark #compareModalBody .text-zinc-400 {
+      color: #d4d4d8 !important;
+    }
 
     /* Dark mode - Guide section cards */
-    .dark #guide article { background: #18181b !important; border-color: #3f3f46 !important; }
-    .dark #guide article h3 { color: #f4f4f5 !important; }
-    .dark #guide article p, .dark #guide article li { color: #a1a1aa !important; }
-    .dark #guide details { border-color: #3f3f46 !important; }
-    .dark #guide details summary { color: #f4f4f5 !important; }
-    .dark #guide a.block { border-color: #3f3f46 !important; }
-    .dark #guide a.block:hover { background: rgba(249, 115, 22, 0.1) !important; }
-    .dark #guide .font-mono { background: #27272a !important; color: #d4d4d8 !important; }
+    .dark #guide article {
+      background: #18181b !important;
+      border-color: #3f3f46 !important;
+    }
+
+    .dark #guide article h3 {
+      color: #f4f4f5 !important;
+    }
+
+    .dark #guide article p,
+    .dark #guide article li {
+      color: #a1a1aa !important;
+    }
+
+    .dark #guide details {
+      border-color: #3f3f46 !important;
+    }
+
+    .dark #guide details summary {
+      color: #f4f4f5 !important;
+    }
+
+    .dark #guide a.block {
+      border-color: #3f3f46 !important;
+    }
+
+    .dark #guide a.block:hover {
+      background: rgba(249, 115, 22, 0.1) !important;
+    }
+
+    .dark #guide .font-mono {
+      background: #27272a !important;
+      color: #d4d4d8 !important;
+    }
 
     /* Dark mode - Mobile menu */
-    .dark #mobileMenu #menuPanel { background: #18181b !important; border-right: 1px solid #3f3f46; }
-    .dark #mobileMenu .border-zinc-100 { border-color: #3f3f46 !important; }
-    .dark #mobileMenu .text-zinc-900 { color: #f4f4f5 !important; }
-    .dark #mobileMenu .text-zinc-700 { color: #e5e7eb !important; }
-    .dark #mobileMenu .hover\:bg-zinc-100:hover { background: #27272a !important; }
-    .dark #mobileMenu .bg-orange-50 { background: rgba(249, 115, 22, 0.15) !important; }
+    .dark #mobileMenu #menuPanel {
+      background: #18181b !important;
+      border-right: 1px solid #3f3f46;
+    }
+
+    .dark #mobileMenu .border-zinc-100 {
+      border-color: #3f3f46 !important;
+    }
+
+    .dark #mobileMenu .text-zinc-900 {
+      color: #f4f4f5 !important;
+    }
+
+    .dark #mobileMenu .text-zinc-700 {
+      color: #e5e7eb !important;
+    }
+
+    .dark #mobileMenu .hover\:bg-zinc-100:hover {
+      background: #27272a !important;
+    }
+
+    .dark #mobileMenu .bg-orange-50 {
+      background: rgba(249, 115, 22, 0.15) !important;
+    }
 
     /* Header dark mode */
-    .dark header { background: rgba(24, 24, 27, 0.85) !important; border-bottom: 1px solid #3f3f46; }
-    .dark header .text-zinc-900 { color: #f4f4f5 !important; }
-    .dark header .text-zinc-600 { color: #a1a1aa !important; }
-    .dark header .hover\:text-zinc-900:hover { color: #f4f4f5 !important; }
-    .dark header .hover\:bg-zinc-100\/50:hover { background: rgba(39, 39, 42, 0.5) !important; }
+    .dark header {
+      background: rgba(24, 24, 27, 0.85) !important;
+      border-bottom: 1px solid #3f3f46;
+    }
+
+    .dark header .text-zinc-900 {
+      color: #f4f4f5 !important;
+    }
+
+    .dark header .text-zinc-600 {
+      color: #a1a1aa !important;
+    }
+
+    .dark header .hover\:text-zinc-900:hover {
+      color: #f4f4f5 !important;
+    }
+
+    .dark header .hover\:bg-zinc-100\/50:hover {
+      background: rgba(39, 39, 42, 0.5) !important;
+    }
 
     /* Selected Languages Strip */
     #selectedLangsStrip {
@@ -351,11 +931,13 @@
       gap: 8px;
       min-height: 32px;
     }
+
     #selectedLangsStrip .empty-state {
       color: #888;
       font-style: italic;
       font-size: 12px;
     }
+
     .selected-lang-badge {
       display: inline-flex;
       align-items: center;
@@ -368,6 +950,7 @@
       font-weight: 600;
       color: #d45800;
     }
+
     .unselect-lang-btn {
       display: inline-flex;
       align-items: center;
@@ -384,10 +967,12 @@
       padding: 0;
       margin-left: 2px;
     }
+
     .unselect-lang-btn:hover {
       background: #f46b0e;
       color: white;
     }
+
     .clear-all-langs-btn {
       display: inline-flex;
       align-items: center;
@@ -400,30 +985,39 @@
       color: #888;
       cursor: pointer;
     }
+
     .clear-all-langs-btn:hover {
       border-color: #f46b0e;
       color: #f46b0e;
       background: #fff4ec;
     }
+
     /* Dark mode */
-    .dark #selectedLangsStrip .empty-state { color: #8a6a45; }
+    .dark #selectedLangsStrip .empty-state {
+      color: #8a6a45;
+    }
+
     .dark .selected-lang-badge {
       background: #1c0f05;
       border-color: #2a1508;
       color: #f97316;
     }
+
     .dark .unselect-lang-btn {
       background: #2a1508;
       color: #f97316;
     }
+
     .dark .unselect-lang-btn:hover {
       background: #fb923c;
       color: white;
     }
+
     .dark .clear-all-langs-btn {
       border-color: #2e1e0a;
       color: #8a6a45;
     }
+
     .dark .clear-all-langs-btn:hover {
       border-color: #f97316;
       color: #fb923c;
@@ -437,1336 +1031,1529 @@
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-title" content="FindMyGSoC" />
 </head>
+
 <body class="bg-background text-on-surface font-body antialiased">
 
-<!-- ═══════════════════ NAVBAR ═══════════════════ -->
-<header class="fixed top-0 w-full z-50 bg-white/80 glass shadow-sm">
-  <div class="flex items-center justify-between px-4 sm:px-6 py-3 max-w-7xl mx-auto w-full">
-    <div class="flex items-center gap-3 sm:gap-4 md:gap-8">
-      <!-- Hamburger menu button (mobile only) -->
-      <button id="menuBtn" onclick="toggleMenu()" class="inline-flex md:hidden shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
-        <span class="material-symbols-outlined text-zinc-600">menu</span>
-      </button>
-      
-      <a href="#" class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center flex-shrink-0">
-          <span class="text-white font-bold text-sm">G</span>
-        </div>
-        <span class="text-base sm:text-lg font-extrabold tracking-tighter text-zinc-900 font-headline"><span class="hidden xs:inline">GSoC 2026 </span><span class="text-primary italic">Org Finder</span></span>
-      </a>
-      <nav class="hidden md:flex items-center gap-6 text-sm font-medium">
-        <a class="desktop-nav-link text-orange-600 font-bold border-b-2 border-orange-600 transition-colors" href="#orgs" data-section="orgs">Organizations</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#guide" data-section="guide">Guide</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#watchlist" data-section="watchlist">Watchlist</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#issues" data-section="issues">Issues</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#mentors" data-section="mentors">Mentors</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#timeline" data-section="timeline">Timeline</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#ai-recommender" data-section="ai-recommender">AI Recommender</a>
-      </nav>
-    </div>
-    
-    <!-- Right side: Toggle visible on all screens, GitHub button hidden on mobile -->
-    <div class="flex items-center gap-2 sm:gap-3">
-    
-      <button id="themeToggleBtn" onclick="toggleTheme()"
-        class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-full transition-colors"
-        aria-label="Switch to dark theme" aria-pressed="false" title="Switch to dark theme">
-    
-        <span class="material-symbols-outlined text-zinc-600">
-          dark_mode
-        </span>
-      </button>
-    
-      <!-- HELP BUTTON -->
-      <button id="helpBtn"
-        class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-full transition-colors"
-        title="Keyboard shortcuts (?)">
-    
-        <span class="material-symbols-outlined text-zinc-600">
-          help
-        </span>
-      </button>
-    
-      <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank"
-        class="hidden sm:flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-900 text-white text-xs font-bold hover:bg-zinc-700 transition-colors">
-    
-        <span class="material-symbols-outlined text-sm">
-          star
-        </span>
-    
-        Star & Contribute
-      </a>
-    
-    </div>
-  </div>
-</header>
+  <!-- ═══════════════════ NAVBAR ═══════════════════ -->
+  <header class="fixed top-0 w-full z-50 bg-white/80 glass shadow-sm">
+    <div class="flex items-center justify-between px-4 sm:px-6 py-3 max-w-7xl mx-auto w-full">
+      <div class="flex items-center gap-3 sm:gap-4 md:gap-8">
+        <!-- Hamburger menu button (mobile only) -->
+        <button id="menuBtn" onclick="toggleMenu()"
+          class="inline-flex md:hidden shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors"
+          aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
+          <span class="material-symbols-outlined text-zinc-600">menu</span>
+        </button>
 
-<!-- Mobile Menu Overlay -->
-<div id="mobileMenu" class="fixed inset-0 z-40 hidden" role="dialog" aria-modal="true" aria-label="Navigation menu">
-  <!-- Backdrop -->
-  <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" onclick="toggleMenu()" onkeydown="if(event.key==='Enter'||event.key===' ')toggleMenu()" tabindex="0" role="button" aria-label="Close menu"></div>
-  
-  <!-- Menu Panel -->
-  <nav class="absolute top-0 left-0 bottom-0 w-72 bg-white shadow-2xl transform transition-transform duration-300 ease-out -translate-x-full" id="menuPanel" aria-label="Main navigation">
-    <div class="flex items-center justify-between p-6 border-b border-zinc-100">
-      <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center">
-          <span class="text-white font-bold text-sm">G</span>
-        </div>
-        <span class="font-extrabold tracking-tight text-zinc-900">Menu</span>
+        <a href="#" class="flex items-center gap-2">
+          <div
+            class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center flex-shrink-0">
+            <span class="text-white font-bold text-sm">G</span>
+          </div>
+          <span class="text-base sm:text-lg font-extrabold tracking-tighter text-zinc-900 font-headline"><span
+              class="hidden xs:inline">GSoC 2026 </span><span class="text-primary italic">Org Finder</span></span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6 text-sm font-medium">
+          <a class="desktop-nav-link text-orange-600 font-bold border-b-2 border-orange-600 transition-colors"
+            href="#orgs" data-section="orgs">Organizations</a>
+          <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#guide"
+            data-section="guide">Guide</a>
+          <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#watchlist"
+            data-section="watchlist">Watchlist</a>
+          <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#issues"
+            data-section="issues">Issues</a>
+          <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#mentors"
+            data-section="mentors">Mentors</a>
+          <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#timeline"
+            data-section="timeline">Timeline</a>
+          <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#ai-recommender"
+            data-section="ai-recommender">AI Recommender</a>
+        </nav>
       </div>
-      <button onclick="toggleMenu()" class="p-2 hover:bg-zinc-100 rounded-lg transition-colors">
-        <span class="material-symbols-outlined text-zinc-600">close</span>
-      </button>
-    </div>
-    
-    <div class="p-4 space-y-1">
-      <a href="#orgs" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="orgs">
-        <span class="material-symbols-outlined text-lg">business</span>
-        Organizations
-      </a>
-      <a href="#guide" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="guide">
-        <span class="material-symbols-outlined text-lg">menu_book</span>
-        Guide
-      </a>
-      <a href="#watchlist" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="watchlist">
-        <span class="material-symbols-outlined text-lg">bookmark</span>
-        Watchlist
-      </a>
-      <a href="#issues" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="issues">
-        <span class="material-symbols-outlined text-lg">bug_report</span>
-        Issues
-      </a>
-      <a href="#mentors" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="mentors">
-        <span class="material-symbols-outlined text-lg">group</span>
-        Mentors
-      </a>
-      <a href="#timeline" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="timeline">
-        <span class="material-symbols-outlined text-lg">schedule</span>
-        Timeline
-      </a>
-      <a href="#ai-recommender" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="ai-recommender">
-        <span class="material-symbols-outlined text-lg">auto_awesome</span>
-        AI Recommender
-      </a>
-    </div>
-    
-    <div class="absolute bottom-0 left-0 right-0 p-4 border-t border-zinc-100">
-      <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" class="flex items-center justify-center gap-2 w-full px-4 py-3 rounded-lg bg-zinc-900 text-white text-sm font-bold hover:bg-zinc-700 transition-colors">
-        <span class="material-symbols-outlined text-base">star</span> Star & Contribute
-      </a>
-    </div>
-  </nav>
-</div>
 
-<!-- ═══════════════════ HERO ═══════════════════ -->
-<section class="pt-20 sm:pt-28 pb-12 sm:pb-20 px-4 sm:px-6 max-w-7xl mx-auto fade-up">
-  <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-center">
-    <div class="lg:col-span-7">
-      <div class="inline-flex items-center gap-2 px-3 sm:px-4 py-1.5 rounded-full bg-orange-50 border border-orange-100 text-primary mb-6 sm:mb-8">
-        <span class="material-symbols-outlined text-sm icon-fill" style="color:#f97316">verified</span>
-        <span class="font-label text-[10px] sm:text-xs uppercase font-bold tracking-widest">Google Summer of Code 2026</span>
+      <!-- Right side: Toggle visible on all screens, GitHub button hidden on mobile -->
+      <div class="flex items-center gap-2 sm:gap-3">
+
+        <button id="themeToggleBtn" onclick="toggleTheme()"
+          class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-full transition-colors"
+          aria-label="Switch to dark theme" aria-pressed="false" title="Switch to dark theme">
+
+          <span class="material-symbols-outlined text-zinc-600">
+            dark_mode
+          </span>
+        </button>
+
+        <!-- HELP BUTTON -->
+        <button id="helpBtn"
+          class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-full transition-colors"
+          title="Keyboard shortcuts (?)">
+
+          <span class="material-symbols-outlined text-zinc-600">
+            help
+          </span>
+        </button>
+
+        <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank"
+          class="hidden sm:flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-900 text-white text-xs font-bold hover:bg-zinc-700 transition-colors">
+
+          <span class="material-symbols-outlined text-sm">
+            star
+          </span>
+
+          Star & Contribute
+        </a>
+
       </div>
-      <h1 class="text-4xl sm:text-5xl md:text-7xl font-extrabold font-headline tracking-tighter text-zinc-900 mb-4 sm:mb-6 leading-[0.95]">
-        Find Your<br/><span class="text-primary italic">Perfect GSoC Org</span>
-      </h1>
-      <p class="text-base sm:text-lg text-zinc-600 max-w-xl mb-8 sm:mb-10 leading-relaxed">
-        Browse all <strong>184</strong> organizations. Filter by language, domain, competition, and live GitHub activity. Land your summer internship.
-      </p>
-      <!-- Search Bar -->
-      <div class="relative max-w-xl mb-6 sm:mb-8">
-        <span class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400">search</span>
-        <input id="hero-search" type="text" placeholder="Search organization names..." class="w-full bg-white border-2 border-zinc-100 rounded-2xl py-3 sm:py-4 pl-12 pr-4 text-sm font-medium focus:ring-2 focus:ring-primary/30 focus:border-primary/40 transition-all shadow-lg shadow-zinc-200/50" />
-      </div>
-      <!-- Surprise Button -->
-      <div class="mb-8 sm:mb-10">
-        <button id="surpriseBtn" class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-primary to-primary-container text-white rounded-full text-sm font-bold hover:shadow-lg hover:scale-105 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:ring-offset-2" aria-label="🎲 Surprise Me! - Open a random organization">
-          <span class="material-symbols-outlined text-sm">casino</span>
-          🎲 Surprise Me!
+    </div>
+  </header>
+
+  <!-- Mobile Menu Overlay -->
+  <div id="mobileMenu" class="fixed inset-0 z-40 hidden" role="dialog" aria-modal="true" aria-label="Navigation menu">
+    <!-- Backdrop -->
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" onclick="toggleMenu()"
+      onkeydown="if(event.key==='Enter'||event.key===' ')toggleMenu()" tabindex="0" role="button"
+      aria-label="Close menu"></div>
+
+    <!-- Menu Panel -->
+    <nav
+      class="absolute top-0 left-0 bottom-0 w-72 bg-white shadow-2xl transform transition-transform duration-300 ease-out -translate-x-full"
+      id="menuPanel" aria-label="Main navigation">
+      <div class="flex items-center justify-between p-6 border-b border-zinc-100">
+        <div class="flex items-center gap-2">
+          <div
+            class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center">
+            <span class="text-white font-bold text-sm">G</span>
+          </div>
+          <span class="font-extrabold tracking-tight text-zinc-900">Menu</span>
+        </div>
+        <button onclick="toggleMenu()" class="p-2 hover:bg-zinc-100 rounded-lg transition-colors">
+          <span class="material-symbols-outlined text-zinc-600">close</span>
         </button>
       </div>
-      <!-- Stat Badges -->
-      <div class="flex flex-wrap gap-3 sm:gap-4">
-        <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
-          <span class="material-symbols-outlined text-primary text-lg">groups</span>
-          <div><p class="text-[10px] sm:text-xs text-zinc-500">Total Orgs</p><p class="font-bold text-sm">184</p></div>
+
+      <div class="p-4 space-y-1">
+        <a href="#orgs" onclick="setActiveMenu(this)"
+          class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+          data-section="orgs">
+          <span class="material-symbols-outlined text-lg">business</span>
+          Organizations
+        </a>
+        <a href="#guide" onclick="setActiveMenu(this)"
+          class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+          data-section="guide">
+          <span class="material-symbols-outlined text-lg">menu_book</span>
+          Guide
+        </a>
+        <a href="#watchlist" onclick="setActiveMenu(this)"
+          class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+          data-section="watchlist">
+          <span class="material-symbols-outlined text-lg">bookmark</span>
+          Watchlist
+        </a>
+        <a href="#issues" onclick="setActiveMenu(this)"
+          class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+          data-section="issues">
+          <span class="material-symbols-outlined text-lg">bug_report</span>
+          Issues
+        </a>
+        <a href="#mentors" onclick="setActiveMenu(this)"
+          class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+          data-section="mentors">
+          <span class="material-symbols-outlined text-lg">group</span>
+          Mentors
+        </a>
+        <a href="#timeline" onclick="setActiveMenu(this)"
+          class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+          data-section="timeline">
+          <span class="material-symbols-outlined text-lg">schedule</span>
+          Timeline
+        </a>
+        <a href="#ai-recommender" onclick="setActiveMenu(this)"
+          class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+          data-section="ai-recommender">
+          <span class="material-symbols-outlined text-lg">auto_awesome</span>
+          AI Recommender
+        </a>
+      </div>
+
+      <div class="absolute bottom-0 left-0 right-0 p-4 border-t border-zinc-100">
+        <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank"
+          class="flex items-center justify-center gap-2 w-full px-4 py-3 rounded-lg bg-zinc-900 text-white text-sm font-bold hover:bg-zinc-700 transition-colors">
+          <span class="material-symbols-outlined text-base">star</span> Star & Contribute
+        </a>
+      </div>
+    </nav>
+  </div>
+
+  <!-- ═══════════════════ HERO ═══════════════════ -->
+  <section class="pt-20 sm:pt-28 pb-12 sm:pb-20 px-4 sm:px-6 max-w-7xl mx-auto fade-up">
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-center">
+      <div class="lg:col-span-7">
+        <div
+          class="inline-flex items-center gap-2 px-3 sm:px-4 py-1.5 rounded-full bg-orange-50 border border-orange-100 text-primary mb-6 sm:mb-8">
+          <span class="material-symbols-outlined text-sm icon-fill" style="color:#f97316">verified</span>
+          <span class="font-label text-[10px] sm:text-xs uppercase font-bold tracking-widest">Google Summer of Code
+            2026</span>
         </div>
-        <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
-          <span class="material-symbols-outlined text-secondary text-lg">code</span>
-          <div><p class="text-[10px] sm:text-xs text-zinc-500">Languages</p><p class="font-bold text-sm">30+</p></div>
+        <h1
+          class="text-4xl sm:text-5xl md:text-7xl font-extrabold font-headline tracking-tighter text-zinc-900 mb-4 sm:mb-6 leading-[0.95]">
+          Find Your<br /><span class="text-primary italic">Perfect GSoC Org</span>
+        </h1>
+        <p class="text-base sm:text-lg text-zinc-600 max-w-xl mb-8 sm:mb-10 leading-relaxed">
+          Browse all <strong>184</strong> organizations. Filter by language, domain, competition, and live GitHub
+          activity. Land your summer internship.
+        </p>
+        <!-- Search Bar -->
+        <div class="relative max-w-xl mb-6 sm:mb-8">
+          <span class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400">search</span>
+          <input id="hero-search" type="text" placeholder="Search organization names..."
+            class="w-full bg-white border-2 border-zinc-100 rounded-2xl py-3 sm:py-4 pl-12 pr-4 text-sm font-medium focus:ring-2 focus:ring-primary/30 focus:border-primary/40 transition-all shadow-lg shadow-zinc-200/50" />
         </div>
-        <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
-          <span class="material-symbols-outlined text-primary-container text-lg">category</span>
-          <div><p class="text-[10px] sm:text-xs text-zinc-500">Domains</p><p class="font-bold text-sm">15+</p></div>
+        <!-- Surprise Button -->
+        <div class="mb-8 sm:mb-10">
+          <button id="surpriseBtn"
+            class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-primary to-primary-container text-white rounded-full text-sm font-bold hover:shadow-lg hover:scale-105 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:ring-offset-2"
+            aria-label="🎲 Surprise Me! - Open a random organization">
+            <span class="material-symbols-outlined text-sm">casino</span>
+            🎲 Surprise Me!
+          </button>
+        </div>
+        <!-- Stat Badges -->
+        <div class="flex flex-wrap gap-3 sm:gap-4">
+          <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
+            <span class="material-symbols-outlined text-primary text-lg">groups</span>
+            <div>
+              <p class="text-[10px] sm:text-xs text-zinc-500">Total Orgs</p>
+              <p class="font-bold text-sm">184</p>
+            </div>
+          </div>
+          <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
+            <span class="material-symbols-outlined text-secondary text-lg">code</span>
+            <div>
+              <p class="text-[10px] sm:text-xs text-zinc-500">Languages</p>
+              <p class="font-bold text-sm">30+</p>
+            </div>
+          </div>
+          <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
+            <span class="material-symbols-outlined text-primary-container text-lg">category</span>
+            <div>
+              <p class="text-[10px] sm:text-xs text-zinc-500">Domains</p>
+              <p class="font-bold text-sm">15+</p>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-    <!-- Timeline Card -->
-    <div id="timeline" class="lg:col-span-5 fade-up" style="animation-delay:.2s">
-      <div class="bg-white rounded-2xl sm:rounded-3xl p-6 sm:p-8 shadow-2xl shadow-zinc-200/50 border border-zinc-100">
-        <div class="flex items-center justify-between mb-6 sm:mb-8">
-          <h3 class="font-headline font-extrabold text-lg sm:text-xl">2026 Timeline</h3>
-          <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-[10px] font-bold uppercase tracking-wider">Live</span>
-        </div>
-        <div id="timeline-milestones" class="space-y-4 sm:space-y-5"></div>
-        <div class="mt-5 sm:mt-6 pt-5 sm:pt-6 border-t border-zinc-100">
-          <div class="flex items-center justify-between">
-            <span class="text-xs text-zinc-500" id="countdown-label">Next milestone</span>
-            <span id="countdown" class="font-mono text-sm font-bold text-primary">--d --h --m</span>
+      <!-- Timeline Card -->
+      <div id="timeline" class="lg:col-span-5 fade-up" style="animation-delay:.2s">
+        <div
+          class="bg-white rounded-2xl sm:rounded-3xl p-6 sm:p-8 shadow-2xl shadow-zinc-200/50 border border-zinc-100">
+          <div class="flex items-center justify-between mb-6 sm:mb-8">
+            <h3 class="font-headline font-extrabold text-lg sm:text-xl">2026 Timeline</h3>
+            <span
+              class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-[10px] font-bold uppercase tracking-wider">Live</span>
+          </div>
+          <div id="timeline-milestones" class="space-y-4 sm:space-y-5"></div>
+          <div class="mt-5 sm:mt-6 pt-5 sm:pt-6 border-t border-zinc-100">
+            <div class="flex items-center justify-between">
+              <span class="text-xs text-zinc-500" id="countdown-label">Next milestone</span>
+              <span id="countdown" class="font-mono text-sm font-bold text-primary">--d --h --m</span>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<!-- ═══════════════════ FILTER CHIPS ═══════════════════ -->
-<section class="px-6 max-w-7xl mx-auto mb-6 fade-up" style="animation-delay:.3s">
-  <div class="flex flex-wrap gap-2 mb-4">
-    <button id="chip-veteran" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm">military_tech</span> Veterans Only</button>
-    <button id="chip-newcomer" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm">fiber_new</span> Newcomers</button>
-    <button id="chip-hot" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm">local_fire_department</span> High Competition</button>
-    <button id="chip-chill" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm">sentiment_satisfied</span> Low Competition</button>
-    <button id="chip-active" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm">bolt</span> Actively Maintained</button>
-    <button id="chip-bookmarked" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm icon-fill" style="color:#f59e0b">star</span> Bookmarked</button>
-  </div>
-  <div class="flex flex-wrap gap-2">
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Python" aria-pressed="false" onclick="togglePill(this)">Python</button>
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="JavaScript" aria-pressed="false" onclick="togglePill(this)">JavaScript</button>
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="TypeScript" aria-pressed="false" onclick="togglePill(this)">TypeScript</button>
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="C/C++" aria-pressed="false" onclick="togglePill(this)">C/C++</button>
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Java" aria-pressed="false" onclick="togglePill(this)">Java</button>
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Rust" aria-pressed="false" onclick="togglePill(this)">Rust</button>
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Go" aria-pressed="false" onclick="togglePill(this)">Go</button>
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Ruby" aria-pressed="false" onclick="togglePill(this)">Ruby</button>
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Haskell" aria-pressed="false" onclick="togglePill(this)">Haskell</button>
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Scala" aria-pressed="false" onclick="togglePill(this)">Scala</button>
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="ML/AI" aria-pressed="false" onclick="togglePill(this)">ML/AI</button>
-    <button class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Robotics" aria-pressed="false" onclick="togglePill(this)">Robotics</button>
-  </div>
-  <div id="selectedLangsStrip" class="mt-3 flex flex-wrap items-center gap-2 min-h-[32px]">
-    <span class="empty-state">No languages selected</span>
-  </div>
-  <div class="mt-2 flex items-center gap-2">
-    <label class="inline-flex items-center gap-2 cursor-pointer select-none">
-      <input id="matchAllLanguagesToggle" type="checkbox" class="rounded border-zinc-300 text-primary focus:ring-primary" />
-      <span class="text-xs text-zinc-600 font-medium">Match all selected languages </span>
-    </label>
-  </div>
-</section>
-
-<!-- ═══════════════════ ORG DIRECTORY ═══════════════════ -->
-<section id="orgs" class="px-6 max-w-7xl mx-auto pb-20">
-  <div class="flex items-center justify-between mb-8">
-    <p class="font-label text-xs uppercase tracking-widest text-zinc-500">Showing <strong id="orgCount">184</strong> of 184 organizations</p>
-    <div class="flex items-center gap-4">
-      <select id="categoryFilter" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
-        <option value="all">Categories: All</option>
-        <option value="web">Web</option>
-        <option value="programming">Programming</option>
-        <option value="science">Science</option>
-        <option value="os">OS</option>
-        <option value="infra">Infra</option>
-        <option value="security">Security</option>
-        <option value="data">Data</option>
-        <option value="media">Media</option>
-        <option value="other">Other</option>
-      </select>
-      <select id="complexityFilter" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
-        <option value="all">Complexity: All</option>
-        <option value="beginner">Beginner</option>
-        <option value="intermediate">Intermediate</option>
-        <option value="advanced">Advanced</option>
-      </select>
-      <select id="sortSelect" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
-        <option value="alpha">Sort: A-Z</option>
-        <option value="years-desc">Years (High-Low)</option>
-        <option value="years-asc">Years (Low-High)</option>
-        <option value="comp-low">Competition (Chill First)</option>
-        <option value="stars">GitHub Stars</option>
-        <option value="gfi">Good First Issues</option>
-      </select>
+  <!-- ═══════════════════ FILTER CHIPS ═══════════════════ -->
+  <section class="px-6 max-w-7xl mx-auto mb-6 fade-up" style="animation-delay:.3s">
+    <div class="flex flex-wrap gap-2 mb-4">
+      <button id="chip-veteran"
+        class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span
+          class="material-symbols-outlined text-sm">military_tech</span> Veterans Only</button>
+      <button id="chip-newcomer"
+        class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span
+          class="material-symbols-outlined text-sm">fiber_new</span> Newcomers</button>
+      <button id="chip-hot"
+        class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span
+          class="material-symbols-outlined text-sm">local_fire_department</span> High Competition</button>
+      <button id="chip-chill"
+        class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span
+          class="material-symbols-outlined text-sm">sentiment_satisfied</span> Low Competition</button>
+      <button id="chip-active"
+        class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span
+          class="material-symbols-outlined text-sm">bolt</span> Actively Maintained</button>
+      <button id="chip-bookmarked"
+        class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span
+          class="material-symbols-outlined text-sm icon-fill" style="color:#f59e0b">star</span> Bookmarked</button>
     </div>
-  </div>
-  
-  <!-- Hidden search input for JavaScript compatibility -->
-  <input type="hidden" id="searchInput" />
-  
-  <div class="org-grid grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6" id="orgGrid">
-    <!-- Organizations will be rendered here dynamically -->
-    <div class="col-span-full py-20 text-center animate-pulse">
-      <p class="text-zinc-400 font-headline italic">Loading organization directory...</p>
+    <div class="flex flex-wrap gap-2">
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="Python" aria-pressed="false" onclick="togglePill(this)">Python</button>
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="JavaScript" aria-pressed="false" onclick="togglePill(this)">JavaScript</button>
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="TypeScript" aria-pressed="false" onclick="togglePill(this)">TypeScript</button>
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="C/C++" aria-pressed="false" onclick="togglePill(this)">C/C++</button>
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="Java" aria-pressed="false" onclick="togglePill(this)">Java</button>
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="Rust" aria-pressed="false" onclick="togglePill(this)">Rust</button>
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="Go" aria-pressed="false" onclick="togglePill(this)">Go</button>
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="Ruby" aria-pressed="false" onclick="togglePill(this)">Ruby</button>
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="Haskell" aria-pressed="false" onclick="togglePill(this)">Haskell</button>
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="Scala" aria-pressed="false" onclick="togglePill(this)">Scala</button>
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="ML/AI" aria-pressed="false" onclick="togglePill(this)">ML/AI</button>
+      <button
+        class="pill px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+        data-lang="Robotics" aria-pressed="false" onclick="togglePill(this)">Robotics</button>
     </div>
-  </div>
-
-  <!-- Empty State -->
-  <div id="emptyState" class="hidden py-20 text-center animate-fade-up">
-    <div class="text-6xl mb-4">🔍</div>
-    <h3 class="text-2xl font-bold text-zinc-900 dark:text-white mb-2">No organizations match your current filters.</h3>
-    <p class="text-zinc-500 dark:text-zinc-400 mb-8">Try adjusting your search or clearing some filters.</p>
-    <button onclick="clearAllFilters()" class="px-8 py-3 bg-primary text-white rounded-xl font-bold hover:bg-orange-600 transition-colors shadow-lg shadow-primary/20">
-      Clear All Filters
-    </button>
-  </div>
-
-  <div class="mt-12 flex justify-center" id="loadMoreContainer" style="display:none">
-    <button id="loadMoreBtn" class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2">
-      View More Organizations <span class="material-symbols-outlined text-lg">expand_more</span>
-    </button>
-  </div>
-</section>
-
-<!-- ═══════════════════ AI RECOMMENDER ═══════════════════ -->
-<section id="ai-recommender" class="px-6 max-w-7xl mx-auto py-20 border-t border-zinc-100 dark:border-zinc-800">
-  <div class="mb-12">
-    <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">AI-Powered</span>
-    <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Personalized Org Suggestions</h2>
-    <p class="text-zinc-600 dark:text-zinc-400 mt-4 max-w-2xl">Enter your GitHub username or paste your resume to get deterministic AI-style organization recommendations tailored to your skills and experience.</p>
-  </div>
-
-  <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
-    <!-- Input Form -->
-    <div class="lg:col-span-4 bg-white dark:bg-[#18181b] p-6 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm h-fit">
-      <div class="space-y-5">
-        <div>
-          <label for="aiGhUsername" class="block text-sm font-bold text-zinc-900 dark:text-zinc-100 mb-1">GitHub Username</label>
-          <div class="relative">
-            <span class="material-symbols-outlined absolute left-3 top-2.5 text-zinc-400 text-sm">person</span>
-            <input type="text" id="aiGhUsername" placeholder="e.g. torvalds" class="w-full pl-9 pr-4 py-2 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm focus:ring-2 focus:ring-primary dark:text-white transition-all">
-          </div>
-          <p class="text-[10px] text-zinc-500 mt-1 ml-1">Used to analyze your repo languages and activity.</p>
-        </div>
-
-        <div>
-          <label for="aiResumeText" class="block text-sm font-bold text-zinc-900 dark:text-zinc-100 mb-1">Resume / Skills</label>
-          <textarea id="aiResumeText" rows="4" placeholder="Paste your resume or list your skills here (e.g. Python, React, Machine Learning)..." class="w-full p-3 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm focus:ring-2 focus:ring-primary dark:text-white transition-all resize-none"></textarea>
-          <div class="mt-2 flex items-center justify-between">
-            <label class="text-xs text-primary font-bold cursor-pointer hover:underline flex items-center gap-1">
-              <span class="material-symbols-outlined text-[14px]">upload_file</span> Upload .txt
-              <input type="file" id="aiResumeFile" accept=".txt" class="hidden">
-            </label>
-          </div>
-        </div>
-
-        <button id="btnGetRecommendations" class="w-full py-3 bg-gradient-to-r from-primary to-primary-container text-white rounded-xl font-bold text-sm shadow-md hover:shadow-lg hover:scale-[1.02] transition-all flex items-center justify-center gap-2">
-          <span class="material-symbols-outlined text-sm">auto_awesome</span> Get Recommendations
-        </button>
-      </div>
+    <div id="selectedLangsStrip" class="mt-3 flex flex-wrap items-center gap-2 min-h-[32px]">
+      <span class="empty-state">No languages selected</span>
     </div>
+    <div class="mt-2 flex items-center gap-2">
+      <label class="inline-flex items-center gap-2 cursor-pointer select-none">
+        <input id="matchAllLanguagesToggle" type="checkbox"
+          class="rounded border-zinc-300 text-primary focus:ring-primary" />
+        <span class="text-xs text-zinc-600 font-medium">Match all selected languages </span>
+      </label>
+    </div>
+  </section>
 
-    <!-- Results Area -->
-    <div class="lg:col-span-8">
-      <!-- Initial State -->
-      <div id="aiLoadingState" aria-live="polite" class="hidden flex flex-col items-center justify-center py-16 bg-zinc-50 dark:bg-zinc-900/50 rounded-2xl border border-dashed border-zinc-300 dark:border-zinc-700">
-        <div class="w-10 h-10 border-4 border-primary border-t-transparent rounded-full animate-spin mb-4"></div>
-        <p class="text-zinc-600 dark:text-zinc-400 font-bold animate-pulse">Analyzing profile & calculating matches...</p>
-      </div>
-      
-      <!-- Error State -->
-      <div id="aiErrorState" aria-live="assertive" class="hidden bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-2xl p-6 text-center block">
-        <span class="material-symbols-outlined text-red-500 text-4xl mb-2">error</span>
-        <h3 class="text-red-800 dark:text-red-400 font-bold mb-1">Analysis Failed</h3>
-        <p id="aiErrorMsg" class="text-red-600 dark:text-red-300 text-sm"></p>
-      </div>
-
-      <!-- Results Container -->
-      <div id="aiResultsContainer" class="org-grid w-full">
-        <div class="flex flex-col items-center justify-center py-20 text-center text-zinc-400 dark:text-zinc-500">
-          <span class="material-symbols-outlined text-6xl mb-4 opacity-50">magic_button</span>
-          <p class="font-bold">Provide your details to see personalized matches.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════ WATCHLIST ═══════════════════ -->
-<section id="watchlist" class="bg-surface-container-low py-20 px-6">
-  <div class="max-w-7xl mx-auto">
-    <div class="mb-12">
-      <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Scholarly Sandbox</span>
-      <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Watchlist.</h2>
-      <p class="text-zinc-600 mt-4 max-w-2xl">Curate your open-source journey. Track organizations, monitor deadlines, and prepare your proposals for GSoC 2026.</p>
-    </div>
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-      <div class="lg:col-span-2 space-y-4" id="watchlistContainer">
-        <!-- Watchlist items will be rendered here -->
-      </div>
-      <!-- Sidebar -->
-      <div class="space-y-6">
-        <div class="bg-white rounded-2xl p-6 border border-zinc-100">
-          <h4 class="font-bold mb-4 flex items-center gap-2"><span class="material-symbols-outlined text-primary text-lg">event</span> Upcoming Deadlines</h4>
-          <div class="space-y-4">
-            <div><p class="text-[10px] font-label uppercase tracking-wider text-zinc-400">MAR 31, 2026</p><p class="text-sm font-bold">Proposal Submission Deadline</p><p class="text-xs text-zinc-500">Ensure your final proposals are submitted by 18:00 UTC.</p></div>
-            <div><p class="text-[10px] font-label uppercase tracking-wider text-zinc-400">APR 21, 2026</p><p class="text-sm font-bold">Review Period Starts</p><p class="text-xs text-zinc-500">Mentors begin ranking of proposals.</p></div>
-          </div>
-        </div>
-        <div class="bg-gradient-to-br from-primary to-primary-container text-white rounded-2xl p-6 relative overflow-hidden">
-          <div class="absolute top-0 right-0 p-4 opacity-20"><span class="material-symbols-outlined text-5xl">auto_awesome</span></div>
-          <h4 class="font-bold mb-3">AI Application Insight</h4>
-          <p id="aiInsightText" class="text-sm text-orange-100 leading-relaxed mb-4">Select organizations to get personalized contribution advice.</p>
-          <span class="text-[10px] font-label uppercase tracking-widest text-orange-200">Automated System Advice</span>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════ GOOD FIRST ISSUES ═══════════════════ -->
-<section id="issues" class="py-20 px-6 max-w-7xl mx-auto">
-  <div class="mb-12">
-    <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">First Contributions</span>
-    <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Good First Issues</h2>
-    <p class="text-zinc-600 mt-4 max-w-2xl">Pre-fetched from all GSoC 2026 orgs every 6 hours — no rate limits, no token required, instant results.</p>
-  </div>
-  <!-- Status Banner -->
-  <div class="bg-green-50 border border-green-200 rounded-2xl p-6 mb-8 flex flex-col sm:flex-row items-start sm:items-center gap-4">
-    <div class="flex items-center gap-3">
-      <div class="w-3 h-3 rounded-full bg-green-500 pulse-dot"></div>
-      <div>
-        <p class="font-bold text-green-800 text-sm">Pre-fetched Issues Ready</p>
-        <p class="text-xs text-green-600">Updated every 6 hours via GitHub Actions — no API rate limits for visitors.</p>
-      </div>
-    </div>
-    <span id="issuesLastUpdated" class="text-xs font-mono text-green-600 ml-auto">Last updated: pending refresh</span>
-  </div>
-  <!-- Issue Cards -->
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/rust-lang/rust/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
-      <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
-        <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
-      </div>
-      <p class="text-xs text-zinc-500 mb-3 font-mono">rust-lang/rust</p>
-      <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
-      </div>
-    </div>
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/django/django/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
-      <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
-        <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
-      </div>
-      <p class="text-xs text-zinc-500 mb-3 font-mono">django/django</p>
-      <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
-      </div>
-    </div>
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/tensorflow/tensorflow/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
-      <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
-        <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
-      </div>
-      <p class="text-xs text-zinc-500 mb-3 font-mono">tensorflow/tensorflow</p>
-      <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
-      </div>
-    </div>
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
-      <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
-        <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
-      </div>
-      <p class="text-xs text-zinc-500 mb-3 font-mono">kubernetes/kubernetes</p>
-      <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════ MENTOR FINDER ═══════════════════ -->
-<section id="mentors" class="py-20 px-6 bg-surface-container-low">
-  <div class="max-w-7xl mx-auto">
-    <div class="mb-12">
-      <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Mentor Outreach</span>
-      <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Mentor Finder</h2>
-      <p class="text-zinc-600 mt-4 max-w-3xl">Pre-fetched contact channels and conservative mentor handles from org ideas pages, so you can find where to introduce yourself before proposal season gets busy.</p>
-    </div>
-
-    <div class="bg-white border border-zinc-100 rounded-2xl p-6 mb-8 flex flex-col sm:flex-row items-start sm:items-center gap-4">
-      <div class="flex items-center gap-3">
-        <div class="w-3 h-3 rounded-full bg-orange-500 pulse-dot"></div>
-        <div>
-          <p class="font-bold text-zinc-900 text-sm">Cached mentor contact data</p>
-          <p class="text-xs text-zinc-600">Generated offline by the project workflow to keep scraping out of the browser.</p>
-        </div>
-      </div>
-      <span id="mentorLastUpdated" class="text-xs font-mono text-zinc-500 ml-auto">Last updated: pending refresh</span>
-    </div>
-
-    <div class="bg-white rounded-2xl border border-zinc-100 p-6 mb-8">
-      <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_220px] gap-4">
-        <label class="relative block">
-          <span class="material-symbols-outlined absolute left-3 top-3 text-zinc-400 text-sm">search</span>
-          <input id="mentorSearchInput" type="text" placeholder="Search org name or mentor GitHub handle..." class="w-full pl-10 pr-4 py-3 bg-surface-container-low border-none rounded-xl text-sm focus:ring-2 focus:ring-primary" />
-        </label>
-        <select id="mentorChannelFilter" class="bg-surface-container-low border-none rounded-xl text-sm font-medium focus:ring-2 focus:ring-primary text-zinc-700 px-4">
-          <option value="all">All channels</option>
-          <option value="Slack">Slack</option>
-          <option value="Zulip">Zulip</option>
-          <option value="Discord">Discord</option>
-          <option value="Matrix">Matrix</option>
-          <option value="IRC">IRC</option>
-          <option value="Mailing list">Mailing list</option>
+  <!-- ═══════════════════ ORG DIRECTORY ═══════════════════ -->
+  <section id="orgs" class="px-6 max-w-7xl mx-auto pb-20">
+    <div class="flex items-center justify-between mb-8">
+      <p class="font-label text-xs uppercase tracking-widest text-zinc-500">Showing <strong id="orgCount">184</strong>
+        of 184 organizations</p>
+      <div class="flex items-center gap-4">
+        <select id="categoryFilter"
+          class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
+          <option value="all">Categories: All</option>
+          <option value="web">Web</option>
+          <option value="programming">Programming</option>
+          <option value="science">Science</option>
+          <option value="os">OS</option>
+          <option value="infra">Infra</option>
+          <option value="security">Security</option>
+          <option value="data">Data</option>
+          <option value="media">Media</option>
+          <option value="other">Other</option>
+        </select>
+        <select id="complexityFilter"
+          class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
+          <option value="all">Complexity: All</option>
+          <option value="beginner">Beginner</option>
+          <option value="intermediate">Intermediate</option>
+          <option value="advanced">Advanced</option>
+        </select>
+        <select id="sortSelect"
+          class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
+          <option value="alpha">Sort: A-Z</option>
+          <option value="years-desc">Years (High-Low)</option>
+          <option value="years-asc">Years (Low-High)</option>
+          <option value="comp-low">Competition (Chill First)</option>
+          <option value="stars">GitHub Stars</option>
+          <option value="gfi">Good First Issues</option>
         </select>
       </div>
     </div>
 
-    <div id="mentorGrid" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
-      <div class="col-span-full bg-white rounded-2xl border border-zinc-100 p-8 text-center">
-        <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
+    <!-- Hidden search input for JavaScript compatibility -->
+    <input type="hidden" id="searchInput" />
+
+    <div class="org-grid grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6" id="orgGrid">
+      <!-- Organizations will be rendered here dynamically -->
+      <div class="col-span-full py-20 text-center animate-pulse">
+        <p class="text-zinc-400 font-headline italic">Loading organization directory...</p>
       </div>
     </div>
-  </div>
-</section>
- 
-<!-- ═══════════════════ CONTRIBUTOR GUIDE ═══════════════════ -->
-<section id="guide" class="py-20 px-6 max-w-7xl mx-auto">
-  <div class="mb-12">
-    <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Contributor Guide</span>
-    <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Start Contributing with Confidence</h2>
-    <p class="text-zinc-600 mt-4 max-w-3xl">New to open source or this project? Follow this quick path: learn the basics, set up locally, find a good first issue, and open your first PR.</p>
-  </div>
 
-  <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-    <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm">
-      <h3 class="text-xl font-bold mb-3">1) Open Source Basics</h3>
-      <p class="text-sm text-zinc-600 mb-4 leading-relaxed">Open source projects publish source code publicly so anyone can inspect, improve, and share it. Contribution usually starts with reading contribution guidelines and making small, focused changes.</p>
-      <ul class="space-y-2 text-sm text-zinc-700 list-disc pl-5">
-        <li>Understand how licensing and collaboration work.</li>
-        <li>Start with documentation or beginner-friendly issues.</li>
-        <li>Communicate early through issues and PR comments.</li>
-      </ul>
-    </article>
-
-    <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm">
-      <h3 class="text-xl font-bold mb-3">2) Contribute to a GSoC Organization</h3>
-      <ol class="space-y-2 text-sm text-zinc-700 list-decimal pl-5">
-        <li>Pick 2–3 organizations that match your skills and interests.</li>
-        <li>Read their ideas page, contribution guide, and communication channels.</li>
-        <li>Set up the project locally and start with a small issue or documentation task.</li>
-        <li>Open a focused pull request and respond to mentor feedback quickly.</li>
-        <li>Document your contributions and turn them into a stronger GSoC proposal.</li>
-      </ol>
-      <p class="text-xs text-zinc-500 mt-4">Tip: quality communication and small, consistent contributions usually matter more than a single large PR.</p>
-    </article>
-
-    <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm lg:col-span-2">
-      <h3 class="text-xl font-bold mb-5">3) Useful Resources</h3>
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm">
-        <a href="https://opensource.guide/how-to-contribute/" target="_blank" rel="noopener noreferrer" class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
-          <p class="font-bold mb-1">Open Source Guide</p>
-          <p class="text-zinc-600">Practical guide for first-time and returning contributors.</p>
-        </a>
-        <a href="https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project" target="_blank" rel="noopener noreferrer" class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
-          <p class="font-bold mb-1">GitHub Contribution Flow</p>
-          <p class="text-zinc-600">Official docs for forking, cloning, and opening pull requests.</p>
-        </a>
-        <a href="https://developers.google.com/open-source/gsoc/resources/guide" target="_blank" rel="noopener noreferrer" class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
-          <p class="font-bold mb-1">GSoC Contributor/Student Guide</p>
-          <p class="text-zinc-600">Official program timeline and best practices for applicants.</p>
-        </a>
-        <a href="https://developers.google.com/open-source/gsoc/help/student-advice" target="_blank" rel="noopener noreferrer" class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
-          <p class="font-bold mb-1">Student Advice</p>
-          <p class="text-zinc-600">Official guidance for choosing orgs, communicating well, and writing proposals.</p>
-        </a>
-        <a href="https://firstcontributions.github.io/" target="_blank" rel="noopener noreferrer" class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
-          <p class="font-bold mb-1">First Contributions</p>
-          <p class="text-zinc-600">Hands-on tutorial to practice your first fork, commit, and pull request.</p>
-        </a>
-      </div>
-    </article>
-
-    <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm lg:col-span-2">
-      <h3 class="text-xl font-bold mb-4">4) FAQ</h3>
-      <div class="space-y-3 text-sm">
-        <details class="group border border-zinc-200 rounded-xl p-4">
-          <summary class="font-semibold cursor-pointer">Do I need prior GSoC experience to contribute?</summary>
-          <p class="text-zinc-600 mt-2">No. Start with small docs or UI fixes, then move to larger tasks as you learn the codebase.</p>
-        </details>
-        <details class="group border border-zinc-200 rounded-xl p-4">
-          <summary class="font-semibold cursor-pointer">What should my first pull request look like?</summary>
-          <p class="text-zinc-600 mt-2">Keep it focused on one change, reference the issue number, and include a short explanation of what you tested.</p>
-        </details>
-        <details class="group border border-zinc-200 rounded-xl p-4">
-          <summary class="font-semibold cursor-pointer">How do I find tasks I can start quickly?</summary>
-          <p class="text-zinc-600 mt-2">Look for issues labeled <span class="font-mono text-xs bg-zinc-100 px-1 py-0.5 rounded">good first issue</span> and comment before starting work.</p>
-        </details>
-      </div>
-    </article>
-  </div>
-</section>
-
-<!-- ═══════════════════ HOW IT WORKS ═══════════════════ -->
-<section class="bg-zinc-900 py-20 px-6">
-  <div class="max-w-7xl mx-auto">
-    <div class="text-center mb-16">
-      <h2 class="text-4xl font-extrabold font-headline tracking-tight text-white mb-4">New to GSoC? Start here.</h2>
-      <p class="text-zinc-400 max-w-2xl mx-auto">Google Summer of Code is a global, online program focused on bringing new contributors into open source software development.</p>
-    </div>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-      <div class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all">
-        <div class="w-14 h-14 rounded-2xl bg-orange-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-primary group-hover:scale-110 transition-transform">1</div>
-        <h3 class="text-xl font-bold text-white mb-3">Explore Organizations</h3>
-        <p class="text-zinc-400 text-sm leading-relaxed">Browse 185+ open source organizations. Filter by language, domain, and competition level to find your match.</p>
-      </div>
-      <div class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all">
-        <div class="w-14 h-14 rounded-2xl bg-blue-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-blue-400 group-hover:scale-110 transition-transform">2</div>
-        <h3 class="text-xl font-bold text-white mb-3">Submit a Proposal</h3>
-        <p class="text-zinc-400 text-sm leading-relaxed">Reach out to mentors and write a detailed proposal outlining how you'll contribute to your chosen project.</p>
-      </div>
-      <div class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all">
-        <div class="w-14 h-14 rounded-2xl bg-green-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-green-400 group-hover:scale-110 transition-transform">3</div>
-        <h3 class="text-xl font-bold text-white mb-3">Start Coding</h3>
-        <p class="text-zinc-400 text-sm leading-relaxed">If accepted, spend your summer coding under the guidance of experienced mentors and earn a stipend of $1,500–$6,600.</p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════ COMPARE ═══════════════════ -->
-<section class="py-20 px-6 max-w-7xl mx-auto">
-  <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-    <div>
-      <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Decision Tool</span>
-      <h2 class="text-4xl font-extrabold font-headline tracking-tighter mt-2 mb-6">Compare Organizations</h2>
-      <p class="text-zinc-600 leading-relaxed mb-8">Select up to 3 orgs to compare side-by-side. See history, mentor count, tech stack, competition level, and active GFIs at a glance.</p>
-      <button onclick="openCompareModal()" class="inline-flex items-center gap-2 px-8 py-4 bg-primary text-white font-bold rounded-xl hover:scale-95 transition-all shadow-lg">
-        <span class="material-symbols-outlined">compare</span> Open Comparison Tool
+    <!-- Empty State -->
+    <div id="emptyState" class="hidden py-20 text-center animate-fade-up">
+      <div class="text-6xl mb-4">🔍</div>
+      <h3 class="text-2xl font-bold text-zinc-900 dark:text-white mb-2">No organizations match your current filters.
+      </h3>
+      <p class="text-zinc-500 dark:text-zinc-400 mb-8">Try adjusting your search or clearing some filters.</p>
+      <button onclick="clearAllFilters()"
+        class="px-8 py-3 bg-primary text-white rounded-xl font-bold hover:bg-orange-600 transition-colors shadow-lg shadow-primary/20">
+        Clear All Filters
       </button>
     </div>
-    <div id="compare" class="bg-surface-container-low rounded-3xl p-8 border border-zinc-100">
-      <div class="grid grid-cols-3 gap-4 text-center">
-        <div class="bg-white rounded-xl p-4 border border-zinc-100">
-          <div class="w-10 h-10 rounded-lg bg-orange-100 flex items-center justify-center mx-auto mb-3"><span class="material-symbols-outlined text-orange-600">psychology</span></div>
-          <p class="font-bold text-sm">TensorFlow</p><p class="text-[10px] text-zinc-500 font-label uppercase mt-1">15y · 42 mentors</p>
+
+    <div class="mt-12 flex justify-center" id="loadMoreContainer" style="display:none">
+      <button id="loadMoreBtn"
+        class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2">
+        View More Organizations <span class="material-symbols-outlined text-lg">expand_more</span>
+      </button>
+    </div>
+  </section>
+
+  <!-- ═══════════════════ AI RECOMMENDER ═══════════════════ -->
+  <section id="ai-recommender" class="px-6 max-w-7xl mx-auto py-20 border-t border-zinc-100 dark:border-zinc-800">
+    <div class="mb-12">
+      <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">AI-Powered</span>
+      <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Personalized Org Suggestions
+      </h2>
+      <p class="text-zinc-600 dark:text-zinc-400 mt-4 max-w-2xl">Enter your GitHub username or paste your resume to get
+        deterministic AI-style organization recommendations tailored to your skills and experience.</p>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
+      <!-- Input Form -->
+      <div
+        class="lg:col-span-4 bg-white dark:bg-[#18181b] p-6 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm h-fit">
+        <div class="space-y-5">
+          <div>
+            <label for="aiGhUsername" class="block text-sm font-bold text-zinc-900 dark:text-zinc-100 mb-1">GitHub
+              Username</label>
+            <div class="relative">
+              <span class="material-symbols-outlined absolute left-3 top-2.5 text-zinc-400 text-sm">person</span>
+              <input type="text" id="aiGhUsername" placeholder="e.g. torvalds"
+                class="w-full pl-9 pr-4 py-2 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm focus:ring-2 focus:ring-primary dark:text-white transition-all">
+            </div>
+            <p class="text-[10px] text-zinc-500 mt-1 ml-1">Used to analyze your repo languages and activity.</p>
+          </div>
+
+          <div>
+            <label for="aiResumeText" class="block text-sm font-bold text-zinc-900 dark:text-zinc-100 mb-1">Resume /
+              Skills</label>
+            <textarea id="aiResumeText" rows="4"
+              placeholder="Paste your resume or list your skills here (e.g. Python, React, Machine Learning)..."
+              class="w-full p-3 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm focus:ring-2 focus:ring-primary dark:text-white transition-all resize-none"></textarea>
+            <div class="mt-2 flex items-center justify-between">
+              <label class="text-xs text-primary font-bold cursor-pointer hover:underline flex items-center gap-1">
+                <span class="material-symbols-outlined text-[14px]">upload_file</span> Upload .txt
+                <input type="file" id="aiResumeFile" accept=".txt" class="hidden">
+              </label>
+            </div>
+          </div>
+
+          <button id="btnGetRecommendations"
+            class="w-full py-3 bg-gradient-to-r from-primary to-primary-container text-white rounded-xl font-bold text-sm shadow-md hover:shadow-lg hover:scale-[1.02] transition-all flex items-center justify-center gap-2">
+            <span class="material-symbols-outlined text-sm">auto_awesome</span> Get Recommendations
+          </button>
         </div>
-        <div class="bg-white rounded-xl p-4 border border-zinc-100">
-          <div class="w-10 h-10 rounded-lg bg-amber-100 flex items-center justify-center mx-auto mb-3"><span class="material-symbols-outlined text-amber-600">developer_board</span></div>
-          <p class="font-bold text-sm">Apache</p><p class="text-[10px] text-zinc-500 font-label uppercase mt-1">19y · 64 mentors</p>
+      </div>
+
+      <!-- Results Area -->
+      <div class="lg:col-span-8">
+        <!-- Initial State -->
+        <div id="aiLoadingState" aria-live="polite"
+          class="hidden flex flex-col items-center justify-center py-16 bg-zinc-50 dark:bg-zinc-900/50 rounded-2xl border border-dashed border-zinc-300 dark:border-zinc-700">
+          <div class="w-10 h-10 border-4 border-primary border-t-transparent rounded-full animate-spin mb-4"></div>
+          <p class="text-zinc-600 dark:text-zinc-400 font-bold animate-pulse">Analyzing profile & calculating matches...
+          </p>
         </div>
-        <div class="bg-white rounded-xl p-4 border border-zinc-100 border-dashed border-zinc-300">
-          <div class="w-10 h-10 rounded-lg bg-zinc-100 flex items-center justify-center mx-auto mb-3"><span class="material-symbols-outlined text-zinc-400">add</span></div>
-          <p class="font-bold text-sm text-zinc-400">Add org</p><p class="text-[10px] text-zinc-400 font-label uppercase mt-1">slot 3</p>
+
+        <!-- Error State -->
+        <div id="aiErrorState" aria-live="assertive"
+          class="hidden bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-2xl p-6 text-center block">
+          <span class="material-symbols-outlined text-red-500 text-4xl mb-2">error</span>
+          <h3 class="text-red-800 dark:text-red-400 font-bold mb-1">Analysis Failed</h3>
+          <p id="aiErrorMsg" class="text-red-600 dark:text-red-300 text-sm"></p>
+        </div>
+
+        <!-- Results Container -->
+        <div id="aiResultsContainer" class="org-grid w-full">
+          <div class="flex flex-col items-center justify-center py-20 text-center text-zinc-400 dark:text-zinc-500">
+            <span class="material-symbols-outlined text-6xl mb-4 opacity-50">magic_button</span>
+            <p class="font-bold">Provide your details to see personalized matches.</p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<!-- ═══════════════════ CONTACT ═══════════════════ -->
-<section id="contact" class="py-20 px-6 max-w-7xl mx-auto">
-  <div class="text-center mb-12">
-    <h2 class="text-4xl font-extrabold font-headline tracking-tight mb-4">Get in Touch</h2>
-    <p class="text-zinc-600 max-w-2xl mx-auto">Have questions, feedback, or need help? We'd love to hear from you.</p>
-  </div>
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
-    <a href="https://github.com/S3DFX-CYBER" target="_blank" rel="noopener noreferrer" class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
-      <div class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
-        <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">person</span>
+  <!-- ═══════════════════ WATCHLIST ═══════════════════ -->
+  <section id="watchlist" class="bg-surface-container-low py-20 px-6">
+    <div class="max-w-7xl mx-auto">
+      <div class="mb-12">
+        <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Scholarly Sandbox</span>
+        <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Watchlist.</h2>
+        <p class="text-zinc-600 mt-4 max-w-2xl">Curate your open-source journey. Track organizations, monitor deadlines,
+          and prepare your proposals for GSoC 2026.</p>
       </div>
-      <h3 class="font-bold mb-2">GitHub Profile</h3>
-      <p class="text-sm text-zinc-600">Follow the maintainer and check out other projects.</p>
-    </a>
-    <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/issues" target="_blank" rel="noopener noreferrer" class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
-      <div class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
-        <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">bug_report</span>
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <div class="lg:col-span-2 space-y-4" id="watchlistContainer">
+          <!-- Watchlist items will be rendered here -->
+        </div>
+        <!-- Sidebar -->
+        <div class="space-y-6">
+          <div class="bg-white rounded-2xl p-6 border border-zinc-100">
+            <h4 class="font-bold mb-4 flex items-center gap-2"><span
+                class="material-symbols-outlined text-primary text-lg">event</span> Upcoming Deadlines</h4>
+            <div class="space-y-4">
+              <div>
+                <p class="text-[10px] font-label uppercase tracking-wider text-zinc-400">MAR 31, 2026</p>
+                <p class="text-sm font-bold">Proposal Submission Deadline</p>
+                <p class="text-xs text-zinc-500">Ensure your final proposals are submitted by 18:00 UTC.</p>
+              </div>
+              <div>
+                <p class="text-[10px] font-label uppercase tracking-wider text-zinc-400">APR 21, 2026</p>
+                <p class="text-sm font-bold">Review Period Starts</p>
+                <p class="text-xs text-zinc-500">Mentors begin ranking of proposals.</p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="bg-gradient-to-br from-primary to-primary-container text-white rounded-2xl p-6 relative overflow-hidden">
+            <div class="absolute top-0 right-0 p-4 opacity-20"><span
+                class="material-symbols-outlined text-5xl">auto_awesome</span></div>
+            <h4 class="font-bold mb-3">AI Application Insight</h4>
+            <p id="aiInsightText" class="text-sm text-orange-100 leading-relaxed mb-4">Select organizations to get
+              personalized contribution advice.</p>
+            <span class="text-[10px] font-label uppercase tracking-widest text-orange-200">Automated System
+              Advice</span>
+          </div>
+        </div>
       </div>
-      <h3 class="font-bold mb-2">Report Issues</h3>
-      <p class="text-sm text-zinc-600">Found a bug or have a feature request? Open an issue.</p>
-    </a>
-    <a href="https://discord.gg/mgWV3xSV7" target="_blank" rel="noopener noreferrer" class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
-      <div class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
-        <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">forum</span>
-      </div>
-      <h3 class="font-bold mb-2">Join Discord</h3>
-      <p class="text-sm text-zinc-600">Connect with the community for discussions and support.</p>
-    </a>
-  </div>
-</section>
-
-<!-- ═══════════════════ FOOTER ═══════════════════ -->
-<footer class="w-full border-t border-zinc-200 bg-zinc-100">
-  <div class="flex flex-col md:flex-row justify-between items-center px-8 py-12 gap-6 max-w-7xl mx-auto">
-    <div class="flex flex-col gap-2">
-      <div class="flex items-center gap-2">
-        <div class="w-6 h-6 rounded bg-gradient-to-br from-primary to-primary-container flex items-center justify-center"><span class="text-white font-bold text-[10px]">G</span></div>
-        <span class="text-lg font-bold text-zinc-900">FindMyGSoC</span>
-      </div>
-      <p class="text-[10px] font-bold uppercase tracking-widest text-zinc-400">© 2026 S3DFX-CYBER · Built for the Open Source Community</p>
     </div>
-    <nav class="flex flex-wrap gap-6">
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://summerofcode.withgoogle.com/programs/2026/organizations" target="_blank">GSoC 2026</a>
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank">GitHub</a>
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#">Privacy</a>
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#contact">Contact</a>
-    </nav>
-  </div>
-</footer>
+  </section>
 
-<!-- ═══════════════════ MODAL ═══════════════════ -->
-<div class="modal-bg" id="orgModal">
-  <div class="modal">
-    <button class="close-btn" onclick="closeModal()"><span class="material-symbols-outlined">close</span></button>
-    <div class="modal-header" id="mHeader">
-      <!-- Injected: Category, Name, Tagline -->
+  <!-- ═══════════════════ GOOD FIRST ISSUES ═══════════════════ -->
+  <section id="issues" class="py-20 px-6 max-w-7xl mx-auto">
+    <div class="mb-12">
+      <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">First Contributions</span>
+      <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Good First Issues</h2>
+      <p class="text-zinc-600 mt-4 max-w-2xl">Pre-fetched from all GSoC 2026 orgs every 6 hours — no rate limits, no
+        token required, instant results.</p>
     </div>
-    <div class="modal-body">
-      <div class="metrics-grid mb-8" id="mMetrics">
-        <!-- Injected: Years, Competition, First Year, etc. -->
-      </div>
-      
-      <div class="github-stats-container mb-8">
-        <button class="gh-fetch" id="mFetchBtn">Fetch Live Stats</button>
-        <div class="gh-stat-item"><span class="material-symbols-outlined text-sm">star</span> <span id="mStars">---</span></div>
-        <div class="gh-stat-item"><span class="material-symbols-outlined text-sm">fork_right</span> <span id="mForks">---</span></div>
-        <div class="gh-stat-item"><span class="material-symbols-outlined text-sm">bug_report</span> <span id="mIssues">---</span></div>
-        <div class="gh-stat-item text-blue-400"><span class="material-symbols-outlined text-sm">history</span> <span id="mActivity">Moderate</span></div>
-      </div>
-
-      <div class="section-title">Description</div>
-      <p id="mDesc" class="text-sm text-zinc-600 leading-relaxed mb-6"></p>
-
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+    <!-- Status Banner -->
+    <div
+      class="bg-green-50 border border-green-200 rounded-2xl p-6 mb-8 flex flex-col sm:flex-row items-start sm:items-center gap-4">
+      <div class="flex items-center gap-3">
+        <div class="w-3 h-3 rounded-full bg-green-500 pulse-dot"></div>
         <div>
-          <div class="section-title">Technologies</div>
-          <div class="tech-tags" id="mTech"></div>
+          <p class="font-bold text-green-800 text-sm">Pre-fetched Issues Ready</p>
+          <p class="text-xs text-green-600">Updated every 6 hours via GitHub Actions — no API rate limits for visitors.
+          </p>
         </div>
-        <div>
-          <div class="section-title">Ideal Fit</div>
-          <div class="fit-tags" id="mFit"></div>
+      </div>
+      <span id="issuesLastUpdated" class="text-xs font-mono text-green-600 ml-auto">Last updated: pending refresh</span>
+    </div>
+    <!-- Issue Cards -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div
+        class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card"
+        data-url="https://github.com/rust-lang/rust/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
+        <div class="flex items-start justify-between mb-3">
+          <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
+          <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
+        </div>
+        <p class="text-xs text-zinc-500 mb-3 font-mono">rust-lang/rust</p>
+        <div class="flex flex-wrap gap-1.5">
+          <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
+          <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
+        </div>
+      </div>
+      <div
+        class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card"
+        data-url="https://github.com/django/django/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
+        <div class="flex items-start justify-between mb-3">
+          <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
+          <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
+        </div>
+        <p class="text-xs text-zinc-500 mb-3 font-mono">django/django</p>
+        <div class="flex flex-wrap gap-1.5">
+          <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
+          <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
+        </div>
+      </div>
+      <div
+        class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card"
+        data-url="https://github.com/tensorflow/tensorflow/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
+        <div class="flex items-start justify-between mb-3">
+          <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
+          <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
+        </div>
+        <p class="text-xs text-zinc-500 mb-3 font-mono">tensorflow/tensorflow</p>
+        <div class="flex flex-wrap gap-1.5">
+          <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
+          <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
+        </div>
+      </div>
+      <div
+        class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card"
+        data-url="https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
+        <div class="flex items-start justify-between mb-3">
+          <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
+          <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
+        </div>
+        <p class="text-xs text-zinc-500 mb-3 font-mono">kubernetes/kubernetes</p>
+        <div class="flex flex-wrap gap-1.5">
+          <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
+          <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════ MENTOR FINDER ═══════════════════ -->
+  <section id="mentors" class="py-20 px-6 bg-surface-container-low">
+    <div class="max-w-7xl mx-auto">
+      <div class="mb-12">
+        <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Mentor Outreach</span>
+        <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Mentor Finder</h2>
+        <p class="text-zinc-600 mt-4 max-w-3xl">Pre-fetched contact channels and conservative mentor handles from org
+          ideas pages, so you can find where to introduce yourself before proposal season gets busy.</p>
+      </div>
+
+      <div
+        class="bg-white border border-zinc-100 rounded-2xl p-6 mb-8 flex flex-col sm:flex-row items-start sm:items-center gap-4">
+        <div class="flex items-center gap-3">
+          <div class="w-3 h-3 rounded-full bg-orange-500 pulse-dot"></div>
+          <div>
+            <p class="font-bold text-zinc-900 text-sm">Cached mentor contact data</p>
+            <p class="text-xs text-zinc-600">Generated offline by the project workflow to keep scraping out of the
+              browser.</p>
+          </div>
+        </div>
+        <span id="mentorLastUpdated" class="text-xs font-mono text-zinc-500 ml-auto">Last updated: pending
+          refresh</span>
+      </div>
+
+      <div class="bg-white rounded-2xl border border-zinc-100 p-6 mb-8">
+        <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_220px] gap-4">
+          <label class="relative block">
+            <span class="material-symbols-outlined absolute left-3 top-3 text-zinc-400 text-sm">search</span>
+            <input id="mentorSearchInput" type="text" placeholder="Search org name or mentor GitHub handle..."
+              class="w-full pl-10 pr-4 py-3 bg-surface-container-low border-none rounded-xl text-sm focus:ring-2 focus:ring-primary" />
+          </label>
+          <select id="mentorChannelFilter"
+            class="bg-surface-container-low border-none rounded-xl text-sm font-medium focus:ring-2 focus:ring-primary text-zinc-700 px-4">
+            <option value="all">All channels</option>
+            <option value="Slack">Slack</option>
+            <option value="Zulip">Zulip</option>
+            <option value="Discord">Discord</option>
+            <option value="Matrix">Matrix</option>
+            <option value="IRC">IRC</option>
+            <option value="Mailing list">Mailing list</option>
+          </select>
         </div>
       </div>
 
-      <div class="section-title">Participation Timeline</div>
-      <div class="timeline-grid" id="mTimeline"></div>
-
-      <div class="section-title">Mentors &amp; Contact</div>
-      <div id="mMentorSection" class="space-y-4">
-        <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
+      <div id="mentorGrid" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+        <div class="col-span-full bg-white rounded-2xl border border-zinc-100 p-8 text-center">
+          <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
+        </div>
       </div>
     </div>
-    <div class="modal-footer">
-      <a href="#" target="_blank" id="mIdeasBtn" class="modal-cta modal-ideas-link flex items-center justify-center gap-2">
-        <span class="material-symbols-outlined text-lg">lightbulb</span> Project Ideas
+  </section>
+
+  <!-- ═══════════════════ CONTRIBUTOR GUIDE ═══════════════════ -->
+  <section id="guide" class="py-20 px-6 max-w-7xl mx-auto">
+    <div class="mb-12">
+      <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Contributor Guide</span>
+      <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Start Contributing with
+        Confidence</h2>
+      <p class="text-zinc-600 mt-4 max-w-3xl">New to open source or this project? Follow this quick path: learn the
+        basics, set up locally, find a good first issue, and open your first PR.</p>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm">
+        <h3 class="text-xl font-bold mb-3">1) Open Source Basics</h3>
+        <p class="text-sm text-zinc-600 mb-4 leading-relaxed">Open source projects publish source code publicly so
+          anyone can inspect, improve, and share it. Contribution usually starts with reading contribution guidelines
+          and making small, focused changes.</p>
+        <ul class="space-y-2 text-sm text-zinc-700 list-disc pl-5">
+          <li>Understand how licensing and collaboration work.</li>
+          <li>Start with documentation or beginner-friendly issues.</li>
+          <li>Communicate early through issues and PR comments.</li>
+        </ul>
+      </article>
+
+      <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm">
+        <h3 class="text-xl font-bold mb-3">2) Contribute to a GSoC Organization</h3>
+        <ol class="space-y-2 text-sm text-zinc-700 list-decimal pl-5">
+          <li>Pick 2–3 organizations that match your skills and interests.</li>
+          <li>Read their ideas page, contribution guide, and communication channels.</li>
+          <li>Set up the project locally and start with a small issue or documentation task.</li>
+          <li>Open a focused pull request and respond to mentor feedback quickly.</li>
+          <li>Document your contributions and turn them into a stronger GSoC proposal.</li>
+        </ol>
+        <p class="text-xs text-zinc-500 mt-4">Tip: quality communication and small, consistent contributions usually
+          matter more than a single large PR.</p>
+      </article>
+
+      <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm lg:col-span-2">
+        <h3 class="text-xl font-bold mb-5">3) Useful Resources</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm">
+          <a href="https://opensource.guide/how-to-contribute/" target="_blank" rel="noopener noreferrer"
+            class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
+            <p class="font-bold mb-1">Open Source Guide</p>
+            <p class="text-zinc-600">Practical guide for first-time and returning contributors.</p>
+          </a>
+          <a href="https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project"
+            target="_blank" rel="noopener noreferrer"
+            class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
+            <p class="font-bold mb-1">GitHub Contribution Flow</p>
+            <p class="text-zinc-600">Official docs for forking, cloning, and opening pull requests.</p>
+          </a>
+          <a href="https://developers.google.com/open-source/gsoc/resources/guide" target="_blank"
+            rel="noopener noreferrer"
+            class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
+            <p class="font-bold mb-1">GSoC Contributor/Student Guide</p>
+            <p class="text-zinc-600">Official program timeline and best practices for applicants.</p>
+          </a>
+          <a href="https://developers.google.com/open-source/gsoc/help/student-advice" target="_blank"
+            rel="noopener noreferrer"
+            class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
+            <p class="font-bold mb-1">Student Advice</p>
+            <p class="text-zinc-600">Official guidance for choosing orgs, communicating well, and writing proposals.</p>
+          </a>
+          <a href="https://firstcontributions.github.io/" target="_blank" rel="noopener noreferrer"
+            class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
+            <p class="font-bold mb-1">First Contributions</p>
+            <p class="text-zinc-600">Hands-on tutorial to practice your first fork, commit, and pull request.</p>
+          </a>
+        </div>
+      </article>
+
+      <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm lg:col-span-2">
+        <h3 class="text-xl font-bold mb-4">4) FAQ</h3>
+        <div class="space-y-3 text-sm">
+          <details class="group border border-zinc-200 rounded-xl p-4">
+            <summary class="font-semibold cursor-pointer">Do I need prior GSoC experience to contribute?</summary>
+            <p class="text-zinc-600 mt-2">No. Start with small docs or UI fixes, then move to larger tasks as you learn
+              the codebase.</p>
+          </details>
+          <details class="group border border-zinc-200 rounded-xl p-4">
+            <summary class="font-semibold cursor-pointer">What should my first pull request look like?</summary>
+            <p class="text-zinc-600 mt-2">Keep it focused on one change, reference the issue number, and include a short
+              explanation of what you tested.</p>
+          </details>
+          <details class="group border border-zinc-200 rounded-xl p-4">
+            <summary class="font-semibold cursor-pointer">How do I find tasks I can start quickly?</summary>
+            <p class="text-zinc-600 mt-2">Look for issues labeled <span
+                class="font-mono text-xs bg-zinc-100 px-1 py-0.5 rounded">good first issue</span> and comment before
+              starting work.</p>
+          </details>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <!-- ═══════════════════ HOW IT WORKS ═══════════════════ -->
+  <section class="bg-zinc-900 py-20 px-6">
+    <div class="max-w-7xl mx-auto">
+      <div class="text-center mb-16">
+        <h2 class="text-4xl font-extrabold font-headline tracking-tight text-white mb-4">New to GSoC? Start here.</h2>
+        <p class="text-zinc-400 max-w-2xl mx-auto">Google Summer of Code is a global, online program focused on bringing
+          new contributors into open source software development.</p>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all">
+          <div
+            class="w-14 h-14 rounded-2xl bg-orange-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-primary group-hover:scale-110 transition-transform">
+            1</div>
+          <h3 class="text-xl font-bold text-white mb-3">Explore Organizations</h3>
+          <p class="text-zinc-400 text-sm leading-relaxed">Browse 185+ open source organizations. Filter by language,
+            domain, and competition level to find your match.</p>
+        </div>
+        <div class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all">
+          <div
+            class="w-14 h-14 rounded-2xl bg-blue-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-blue-400 group-hover:scale-110 transition-transform">
+            2</div>
+          <h3 class="text-xl font-bold text-white mb-3">Submit a Proposal</h3>
+          <p class="text-zinc-400 text-sm leading-relaxed">Reach out to mentors and write a detailed proposal outlining
+            how you'll contribute to your chosen project.</p>
+        </div>
+        <div class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all">
+          <div
+            class="w-14 h-14 rounded-2xl bg-green-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-green-400 group-hover:scale-110 transition-transform">
+            3</div>
+          <h3 class="text-xl font-bold text-white mb-3">Start Coding</h3>
+          <p class="text-zinc-400 text-sm leading-relaxed">If accepted, spend your summer coding under the guidance of
+            experienced mentors and earn a stipend of $1,500–$6,600.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════ COMPARE ═══════════════════ -->
+  <section class="py-20 px-6 max-w-7xl mx-auto">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+      <div>
+        <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Decision Tool</span>
+        <h2 class="text-4xl font-extrabold font-headline tracking-tighter mt-2 mb-6">Compare Organizations</h2>
+        <p class="text-zinc-600 leading-relaxed mb-8">Select up to 3 orgs to compare side-by-side. See history, mentor
+          count, tech stack, competition level, and active GFIs at a glance.</p>
+        <button onclick="openCompareModal()"
+          class="inline-flex items-center gap-2 px-8 py-4 bg-primary text-white font-bold rounded-xl hover:scale-95 transition-all shadow-lg">
+          <span class="material-symbols-outlined">compare</span> Open Comparison Tool
+        </button>
+      </div>
+      <div id="compare" class="bg-surface-container-low rounded-3xl p-8 border border-zinc-100">
+        <div class="grid grid-cols-3 gap-4 text-center">
+          <div class="bg-white rounded-xl p-4 border border-zinc-100">
+            <div class="w-10 h-10 rounded-lg bg-orange-100 flex items-center justify-center mx-auto mb-3"><span
+                class="material-symbols-outlined text-orange-600">psychology</span></div>
+            <p class="font-bold text-sm">TensorFlow</p>
+            <p class="text-[10px] text-zinc-500 font-label uppercase mt-1">15y · 42 mentors</p>
+          </div>
+          <div class="bg-white rounded-xl p-4 border border-zinc-100">
+            <div class="w-10 h-10 rounded-lg bg-amber-100 flex items-center justify-center mx-auto mb-3"><span
+                class="material-symbols-outlined text-amber-600">developer_board</span></div>
+            <p class="font-bold text-sm">Apache</p>
+            <p class="text-[10px] text-zinc-500 font-label uppercase mt-1">19y · 64 mentors</p>
+          </div>
+          <div class="bg-white rounded-xl p-4 border border-zinc-100 border-dashed border-zinc-300">
+            <div class="w-10 h-10 rounded-lg bg-zinc-100 flex items-center justify-center mx-auto mb-3"><span
+                class="material-symbols-outlined text-zinc-400">add</span></div>
+            <p class="font-bold text-sm text-zinc-400">Add org</p>
+            <p class="text-[10px] text-zinc-400 font-label uppercase mt-1">slot 3</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════ CONTACT ═══════════════════ -->
+  <section id="contact" class="py-20 px-6 max-w-7xl mx-auto">
+    <div class="text-center mb-12">
+      <h2 class="text-4xl font-extrabold font-headline tracking-tight mb-4">Get in Touch</h2>
+      <p class="text-zinc-600 max-w-2xl mx-auto">Have questions, feedback, or need help? We'd love to hear from you.</p>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
+      <a href="https://github.com/S3DFX-CYBER" target="_blank" rel="noopener noreferrer"
+        class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
+        <div
+          class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
+          <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">person</span>
+        </div>
+        <h3 class="font-bold mb-2">GitHub Profile</h3>
+        <p class="text-sm text-zinc-600">Follow the maintainer and check out other projects.</p>
       </a>
-      <a href="#" target="_blank" id="mRepoBtn" class="modal-cta modal-repo-link flex items-center justify-center gap-2">
-        <span class="material-symbols-outlined text-lg">code</span> Repository
+      <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/issues" target="_blank" rel="noopener noreferrer"
+        class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
+        <div
+          class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
+          <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">bug_report</span>
+        </div>
+        <h3 class="font-bold mb-2">Report Issues</h3>
+        <p class="text-sm text-zinc-600">Found a bug or have a feature request? Open an issue.</p>
       </a>
+      <a href="https://discord.gg/mgWV3xSV7" target="_blank" rel="noopener noreferrer"
+        class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
+        <div
+          class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
+          <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">forum</span>
+        </div>
+        <h3 class="font-bold mb-2">Join Discord</h3>
+        <p class="text-sm text-zinc-600">Connect with the community for discussions and support.</p>
+      </a>
+    </div>
+  </section>
+
+  <!-- ═══════════════════ FOOTER ═══════════════════ -->
+  <footer class="w-full border-t border-zinc-200 bg-zinc-100">
+    <div class="flex flex-col md:flex-row justify-between items-center px-8 py-12 gap-6 max-w-7xl mx-auto">
+      <div class="flex flex-col gap-2">
+        <div class="flex items-center gap-2">
+          <div
+            class="w-6 h-6 rounded bg-gradient-to-br from-primary to-primary-container flex items-center justify-center">
+            <span class="text-white font-bold text-[10px]">G</span>
+          </div>
+          <span class="text-lg font-bold text-zinc-900">FindMyGSoC</span>
+        </div>
+        <p class="text-[10px] font-bold uppercase tracking-widest text-zinc-400">© 2026 S3DFX-CYBER · Built for the Open
+          Source Community</p>
+      </div>
+      <nav class="flex flex-wrap gap-6">
+        <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all"
+          href="https://summerofcode.withgoogle.com/programs/2026/organizations" target="_blank">GSoC 2026</a>
+        <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all"
+          href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank">GitHub</a>
+        <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all"
+          href="#">Privacy</a>
+        <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all"
+          href="#contact">Contact</a>
+      </nav>
+    </div>
+  </footer>
+
+  <!-- ═══════════════════ MODAL ═══════════════════ -->
+  <div class="modal-bg" id="orgModal">
+    <div class="modal">
+      <button class="close-btn" onclick="closeModal()"><span class="material-symbols-outlined">close</span></button>
+      <div class="modal-header" id="mHeader">
+        <!-- Injected: Category, Name, Tagline -->
+      </div>
+      <div class="modal-body">
+        <div class="metrics-grid mb-8" id="mMetrics">
+          <!-- Injected: Years, Competition, First Year, etc. -->
+        </div>
+
+        <div class="github-stats-container mb-8">
+          <button class="gh-fetch" id="mFetchBtn">Fetch Live Stats</button>
+          <div class="gh-stat-item"><span class="material-symbols-outlined text-sm">star</span> <span
+              id="mStars">---</span></div>
+          <div class="gh-stat-item"><span class="material-symbols-outlined text-sm">fork_right</span> <span
+              id="mForks">---</span></div>
+          <div class="gh-stat-item"><span class="material-symbols-outlined text-sm">bug_report</span> <span
+              id="mIssues">---</span></div>
+          <div class="gh-stat-item text-blue-400"><span class="material-symbols-outlined text-sm">history</span> <span
+              id="mActivity">Moderate</span></div>
+        </div>
+
+        <div class="section-title">Description</div>
+        <p id="mDesc" class="text-sm text-zinc-600 leading-relaxed mb-6"></p>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div>
+            <div class="section-title">Technologies</div>
+            <div class="tech-tags" id="mTech"></div>
+          </div>
+          <div>
+            <div class="section-title">Ideal Fit</div>
+            <div class="fit-tags" id="mFit"></div>
+          </div>
+        </div>
+
+        <div class="section-title">Participation Timeline</div>
+        <div class="timeline-grid" id="mTimeline"></div>
+
+        <div class="section-title">Mentors &amp; Contact</div>
+        <div id="mMentorSection" class="space-y-4">
+          <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#" target="_blank" id="mIdeasBtn"
+          class="modal-cta modal-ideas-link flex items-center justify-center gap-2">
+          <span class="material-symbols-outlined text-lg">lightbulb</span> Project Ideas
+        </a>
+        <a href="#" target="_blank" id="mRepoBtn"
+          class="modal-cta modal-repo-link flex items-center justify-center gap-2">
+          <span class="material-symbols-outlined text-lg">code</span> Repository
+        </a>
+      </div>
     </div>
   </div>
-</div>
 
-<!-- ═══════════════════ COMPARE MODAL ═══════════════════ -->
-<div class="modal-bg compare-bg" id="compareModal">
-  <div class="modal w-full max-w-5xl">
-    <button class="close-btn" onclick="closeCompareModal()"><span class="material-symbols-outlined">close</span></button>
-    <div class="modal-header pb-4 border-b border-zinc-100">
-      <h2 class="text-3xl font-extrabold font-headline">Compare Organizations</h2>
-      <p class="text-zinc-500 text-sm mt-1">Side-by-side comparison of your selected projects</p>
-    </div>
-    <div class="modal-body p-6 overflow-x-auto" id="compareModalBody">
-      <!-- Injected table -->
+  <!-- ═══════════════════ COMPARE MODAL ═══════════════════ -->
+  <div class="modal-bg compare-bg" id="compareModal">
+    <div class="modal w-full max-w-5xl">
+      <button class="close-btn" onclick="closeCompareModal()"><span
+          class="material-symbols-outlined">close</span></button>
+      <div class="modal-header pb-4 border-b border-zinc-100">
+        <h2 class="text-3xl font-extrabold font-headline">Compare Organizations</h2>
+        <p class="text-zinc-500 text-sm mt-1">Side-by-side comparison of your selected projects</p>
+      </div>
+      <div class="modal-body p-6 overflow-x-auto" id="compareModalBody">
+        <!-- Injected table -->
+      </div>
     </div>
   </div>
-</div>
 
-<!-- ═══════════════════ JS ═══════════════════ -->
-<script src="agent/scripts/orgs.js"></script>
-<script>
-  // ══════════════════════════════════════════════
-  // THEME
-  // ══════════════════════════════════════════════
-  (function(){
-    const saved = localStorage.getItem('theme') || 'light';
-    document.documentElement.classList.toggle('dark', saved === 'dark');
-    updateThemeIcon();
-  })();
+  <!-- ═══════════════════ JS ═══════════════════ -->
+  <script src="agent/scripts/orgs.js"></script>
+  <script>
+      // ══════════════════════════════════════════════
+      // THEME
+      // ══════════════════════════════════════════════
+      (function () {
+        const saved = localStorage.getItem('theme') || 'light';
+        document.documentElement.classList.toggle('dark', saved === 'dark');
+        updateThemeIcon();
+      })();
 
-  window.toggleTheme = function(){
-    const isDark = document.documentElement.classList.toggle('dark');
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    updateThemeIcon();
-  };
+    window.toggleTheme = function () {
+      const isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      updateThemeIcon();
+    };
 
-  function updateThemeIcon(){
-    const btn = document.getElementById('themeToggleBtn');
-    const icon = btn ? btn.querySelector('.material-symbols-outlined') : null;
-    if(icon){
-      const isDark = document.documentElement.classList.contains('dark');
-      icon.textContent = isDark ? 'light_mode' : 'dark_mode';
-      btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
-      btn.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
-      btn.setAttribute('title', isDark ? 'Switch to light theme' : 'Switch to dark theme');
-    }
-  }
-
-  // ══════════════════════════════════════════════
-  // MOBILE MENU
-  // ══════════════════════════════════════════════
-  window.toggleMenu = function(){
-    const menu = document.getElementById('mobileMenu');
-    const panel = document.getElementById('menuPanel');
-    const menuBtn = document.getElementById('menuBtn');
-    
-    if(menu.classList.contains('hidden')){
-      // Open menu
-      menu.classList.remove('hidden');
-      menuBtn.setAttribute('aria-expanded', 'true');
-      menuBtn.setAttribute('aria-label', 'Close menu');
-      setTimeout(() => {
-        panel.style.transform = 'translateX(0)';
-      }, 10);
-      document.addEventListener('keydown', handleMenuEscape);
-    } else {
-      // Close menu
-      panel.style.transform = 'translateX(-100%)';
-      menuBtn.setAttribute('aria-expanded', 'false');
-      menuBtn.setAttribute('aria-label', 'Open menu');
-      document.removeEventListener('keydown', handleMenuEscape);
-      setTimeout(() => {
-        menu.classList.add('hidden');
-      }, 300);
-    }
-  };
-  
-  function handleMenuEscape(e){
-    if(e.key === 'Escape'){
-      const menu = document.getElementById('mobileMenu');
-      if(!menu.classList.contains('hidden')){
-        toggleMenu();
+    function updateThemeIcon() {
+      const btn = document.getElementById('themeToggleBtn');
+      const icon = btn ? btn.querySelector('.material-symbols-outlined') : null;
+      if (icon) {
+        const isDark = document.documentElement.classList.contains('dark');
+        icon.textContent = isDark ? 'light_mode' : 'dark_mode';
+        btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+        btn.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+        btn.setAttribute('title', isDark ? 'Switch to light theme' : 'Switch to dark theme');
       }
     }
-  }
 
-  // Set active menu item and update UI
-  window.setActiveMenu = function(clickedLink){
-    // Remove active class from all menu links
-    const allLinks = document.querySelectorAll('.mobile-menu-link');
-    allLinks.forEach(link => {
-      link.classList.remove('text-orange-600', 'bg-orange-50', 'font-bold');
-      link.classList.add('text-zinc-700', 'hover:bg-zinc-100', 'font-medium');
-    });
-    
-    // Add active class to clicked link
-    clickedLink.classList.remove('text-zinc-700', 'hover:bg-zinc-100', 'font-medium');
-    clickedLink.classList.add('text-orange-600', 'bg-orange-50', 'font-bold');
-    
-    // Close menu after a short delay
-    setTimeout(() => {
-      toggleMenu();
-    }, 300);
-  };
+    // ══════════════════════════════════════════════
+    // MOBILE MENU
+    // ══════════════════════════════════════════════
+    window.toggleMenu = function () {
+      const menu = document.getElementById('mobileMenu');
+      const panel = document.getElementById('menuPanel');
+      const menuBtn = document.getElementById('menuBtn');
 
-  // Update active state based on scroll position
-  function updateActiveSection() {
-    const sections = ['orgs', 'guide', 'watchlist', 'issues', 'mentors', 'timeline', 'ai-recommender'];
-    const scrollPosition = window.scrollY + 100; // Offset for fixed header
-    
-    let currentSection = 'orgs'; // Default
-    
-    sections.forEach(sectionId => {
-      const section = document.getElementById(sectionId);
-      if (section) {
-        const sectionTop = section.offsetTop;
-        const sectionBottom = sectionTop + section.offsetHeight;
-        
-        if (scrollPosition >= sectionTop && scrollPosition < sectionBottom) {
-          currentSection = sectionId;
+      if (menu.classList.contains('hidden')) {
+        // Open menu
+        menu.classList.remove('hidden');
+        menuBtn.setAttribute('aria-expanded', 'true');
+        menuBtn.setAttribute('aria-label', 'Close menu');
+        setTimeout(() => {
+          panel.style.transform = 'translateX(0)';
+        }, 10);
+        document.addEventListener('keydown', handleMenuEscape);
+      } else {
+        // Close menu
+        panel.style.transform = 'translateX(-100%)';
+        menuBtn.setAttribute('aria-expanded', 'false');
+        menuBtn.setAttribute('aria-label', 'Open menu');
+        document.removeEventListener('keydown', handleMenuEscape);
+        setTimeout(() => {
+          menu.classList.add('hidden');
+        }, 300);
+      }
+    };
+
+    function handleMenuEscape(e) {
+      if (e.key === 'Escape') {
+        const menu = document.getElementById('mobileMenu');
+        if (!menu.classList.contains('hidden')) {
+          toggleMenu();
         }
       }
-    });
-    
-    // Update mobile menu items
-    const allMobileLinks = document.querySelectorAll('.mobile-menu-link');
-    allMobileLinks.forEach(link => {
-      const linkSection = link.getAttribute('data-section');
-      if (linkSection === currentSection) {
-        link.classList.remove('text-zinc-700', 'hover:bg-zinc-100', 'font-medium');
-        link.classList.add('text-orange-600', 'bg-orange-50', 'font-bold');
-      } else {
+    }
+
+    // Set active menu item and update UI
+    window.setActiveMenu = function (clickedLink) {
+      // Remove active class from all menu links
+      const allLinks = document.querySelectorAll('.mobile-menu-link');
+      allLinks.forEach(link => {
         link.classList.remove('text-orange-600', 'bg-orange-50', 'font-bold');
         link.classList.add('text-zinc-700', 'hover:bg-zinc-100', 'font-medium');
-      }
-    });
-
-    // Update desktop navbar items
-    const allDesktopLinks = document.querySelectorAll('.desktop-nav-link');
-    allDesktopLinks.forEach(link => {
-      const linkSection = link.getAttribute('data-section');
-      if (linkSection === currentSection) {
-        link.classList.remove('text-zinc-600', 'hover:text-zinc-900');
-        link.classList.add('text-orange-600', 'font-bold', 'border-b-2', 'border-orange-600');
-      } else {
-        link.classList.remove('text-orange-600', 'font-bold', 'border-b-2', 'border-orange-600');
-        link.classList.add('text-zinc-600', 'hover:text-zinc-900');
-      }
-    });
-  }
-
-  // Listen for scroll events
-  window.addEventListener('scroll', updateActiveSection);
-  
-  // Initialize on page load
-  document.addEventListener('DOMContentLoaded', updateActiveSection);
-
-  // ══════════════════════════════════════════════
-  // Shared escaping helper (for all dynamic text used in HTML strings)
-  // Prevents HTML injection via <, >, &, quotes.
-  function escapeHtml(value) {
-    return String(value)
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;')
-      .replaceAll('"', '&quot;')
-      .replaceAll("'", '&#39;');
-  }
-
-  // Sanitize hrefs: only allow http(s) absolute URLs.
-  // Returns the original URL string when allowed, otherwise null.
-  function sanitizeHrefUrl(url) {
-    if (!url || !String(url).trim()) return null;
-    try {
-      const u = new URL(String(url).trim());
-      if (u.protocol === 'http:' || u.protocol === 'https:') return u.toString();
-    } catch (e) {
-      // invalid URL
-    }
-    return null;
-  }
-
-  // NOTE: For JS-string contexts inside inline event handlers,
-  // we must also escape quotes. Prefer removing inline handlers.
-
-  // ══════════════════════════════════════════════
-  // MAIN APP LOGIC
-  // ══════════════════════════════════════════════
-  let visibleCount = 12;
-
-  let filteredOrgs = [...ORGS];
-  let MENTOR_DATA = {};
-  let mentorDataState = 'idle';
-  let compareList = [];
-  const bookmarkedSet = new Set(JSON.parse(localStorage.getItem('bookmarks') || '[]'));
-  const selectedLanguages = new Set();
-  let matchAllLanguages = false;
-  let activeChip = null; // tracks the active quick-filter chip key ('veterans' | 'newcomers' | 'low-competition' | 'high-competition' | 'bookmarked' | 'active' | null)
-  const CHANNEL_ICONS = {
-    Slack: '💬',
-    Zulip: '💬',
-    Discord: '🎮',
-    Matrix: '🔗',
-    IRC: '🖥️',
-    'Mailing list': '📧'
-  };
-  const CONTACT_TIPS = {
-    Slack: 'Join and say hi in the GSoC channel before DMing mentors.',
-    Discord: 'Introduce yourself in the public channel before asking project-specific questions.',
-    Zulip: 'Post a new topic in the GSoC stream with your background and interest.',
-    Matrix: "Say hello in the public room and mention the project area you're exploring.",
-    IRC: 'Stay in the channel for a while; replies are often asynchronous.',
-    'Mailing list': "Send a short intro email with your background and the idea you're interested in."
-  };
-  const LANGUAGE_ALIASES = {
-    'python': ['python'],
-    'javascript': ['javascript', 'js'],
-    'typescript': ['typescript', 'ts'],
-    'c/c++': ['c', 'c++', 'cpp'],
-    'java': ['java'],
-    'rust': ['rust'],
-    'go': ['go', 'golang'],
-    'ruby': ['ruby'],
-    'haskell': ['haskell'],
-    'scala': ['scala'],
-    'ml/ai': ['ml', 'ai', 'machine learning', 'artificial intelligence'],
-    'robotics': ['robotics', 'robot', 'ros']
-  };
-
-  // Compatibility layer: expose a single LANGUAGE_MAP and shared `pills` set
-  // so the embedded script and any external `src/js/app.js` logic agree.
-  (function buildCompatibilityLayer(){
-    // Expose the selectedLanguages set as `pills` for compatibility
-    globalThis.pills = selectedLanguages;
-    // Expose matchAllLanguages as a global variable reference (kept in sync below)
-    globalThis.matchAllLanguages = matchAllLanguages;
-    globalThis.compareList = compareList;
-    globalThis.bookmarkedSet = bookmarkedSet;
-
-    // Build a LANGUAGE_MAP with display-label keys matching src/js/app.js expectations
-    const toDisplayKey = (k) => {
-      if (k === 'ml/ai') return 'ML/AI';
-      if (k === 'c/c++') return 'C/C++';
-      return k.split(/[\s\/]+/).map(p => p.charAt(0).toUpperCase()+p.slice(1)).join(' ');
-    };
-    const LANG_MAP = {};
-    Object.keys(LANGUAGE_ALIASES).forEach(k => {
-      LANG_MAP[toDisplayKey(k)] = LANGUAGE_ALIASES[k];
-    });
-    // Also expose the lowercase-keyed aliases for any consumers that expect that
-    Object.keys(LANGUAGE_ALIASES).forEach(k => { LANG_MAP[k] = LANGUAGE_ALIASES[k]; });
-    globalThis.LANGUAGE_MAP = globalThis.LANGUAGE_MAP || LANG_MAP;
-  })();
-
-  function updateLanguageModeHint() {
-    const hint = document.getElementById('languageLogicHint');
-    if (!hint) return;
-    hint.textContent = matchAllLanguages
-      ? 'Multiple language chips use AND (must match all selected).'
-      : 'Multiple language chips use OR (any selected).';
-  }
-
-  function languageMatchesSelection(tags, lang) {
-    const langKey = lang.toLowerCase();
-    const aliases = LANGUAGE_ALIASES[langKey] || [langKey];
-    // Use exact token matching to prevent false positives like "Go" matching "django"
-    // Tags are split on whitespace, commas, slashes, and plus signs before comparing
-    return aliases.some(alias => {
-      const a = alias.toLowerCase();
-      return tags.some(tag => {
-        const tokens = tag.toLowerCase().split(/[\s,/+]+/);
-        return tokens.includes(a);
       });
-    });
-  }
 
-  function clearSelectedLanguagePills() {
-    selectedLanguages.clear();
-    document.querySelectorAll('.pill.active').forEach(pill => {
-      pill.classList.remove('active');
-      pill.setAttribute('aria-pressed', 'false');
-    });
-    renderSelectedLanguages();
-  }
+      // Add active class to clicked link
+      clickedLink.classList.remove('text-zinc-700', 'hover:bg-zinc-100', 'font-medium');
+      clickedLink.classList.add('text-orange-600', 'bg-orange-50', 'font-bold');
 
-  function renderSelectedLanguages() {
-    const container = document.getElementById('selectedLangsStrip');
-    if (!container) return;
+      // Close menu after a short delay
+      setTimeout(() => {
+        toggleMenu();
+      }, 300);
+    };
 
-    if (selectedLanguages.size === 0) {
-      container.innerHTML = '<span class="empty-state">No languages selected</span>';
-      return;
+    // Update active state based on scroll position
+    function updateActiveSection() {
+      const sections = ['orgs', 'guide', 'watchlist', 'issues', 'mentors', 'timeline', 'ai-recommender'];
+      const scrollPosition = window.scrollY + 100; // Offset for fixed header
+
+      let currentSection = 'orgs'; // Default
+
+      sections.forEach(sectionId => {
+        const section = document.getElementById(sectionId);
+        if (section) {
+          const sectionTop = section.offsetTop;
+          const sectionBottom = sectionTop + section.offsetHeight;
+
+          if (scrollPosition >= sectionTop && scrollPosition < sectionBottom) {
+            currentSection = sectionId;
+          }
+        }
+      });
+
+      // Update mobile menu items
+      const allMobileLinks = document.querySelectorAll('.mobile-menu-link');
+      allMobileLinks.forEach(link => {
+        const linkSection = link.getAttribute('data-section');
+        if (linkSection === currentSection) {
+          link.classList.remove('text-zinc-700', 'hover:bg-zinc-100', 'font-medium');
+          link.classList.add('text-orange-600', 'bg-orange-50', 'font-bold');
+        } else {
+          link.classList.remove('text-orange-600', 'bg-orange-50', 'font-bold');
+          link.classList.add('text-zinc-700', 'hover:bg-zinc-100', 'font-medium');
+        }
+      });
+
+      // Update desktop navbar items
+      const allDesktopLinks = document.querySelectorAll('.desktop-nav-link');
+      allDesktopLinks.forEach(link => {
+        const linkSection = link.getAttribute('data-section');
+        if (linkSection === currentSection) {
+          link.classList.remove('text-zinc-600', 'hover:text-zinc-900');
+          link.classList.add('text-orange-600', 'font-bold', 'border-b-2', 'border-orange-600');
+        } else {
+          link.classList.remove('text-orange-600', 'font-bold', 'border-b-2', 'border-orange-600');
+          link.classList.add('text-zinc-600', 'hover:text-zinc-900');
+        }
+      });
     }
 
-    const badges = [...selectedLanguages].map(lang => {
-      return `<span class="selected-lang-badge" data-lang="${lang}">
+    // Listen for scroll events
+    window.addEventListener('scroll', updateActiveSection);
+
+    // Initialize on page load
+    document.addEventListener('DOMContentLoaded', updateActiveSection);
+
+    // ══════════════════════════════════════════════
+    // Shared escaping helper (for all dynamic text used in HTML strings)
+    // Prevents HTML injection via <, >, &, quotes.
+    function escapeHtml(value) {
+      return String(value)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+    }
+
+    // Sanitize hrefs: only allow http(s) absolute URLs.
+    // Returns the original URL string when allowed, otherwise null.
+    function sanitizeHrefUrl(url) {
+      if (!url || !String(url).trim()) return null;
+      try {
+        const u = new URL(String(url).trim());
+        if (u.protocol === 'http:' || u.protocol === 'https:') return u.toString();
+      } catch (e) {
+        // invalid URL
+      }
+      return null;
+    }
+
+    // NOTE: For JS-string contexts inside inline event handlers,
+    // we must also escape quotes. Prefer removing inline handlers.
+
+    // ══════════════════════════════════════════════
+    // MAIN APP LOGIC
+    // ══════════════════════════════════════════════
+    let visibleCount = 12;
+
+    let filteredOrgs = [...ORGS];
+    let MENTOR_DATA = {};
+    let mentorDataState = 'idle';
+    let compareList = [];
+    const bookmarkedSet = new Set(JSON.parse(localStorage.getItem('bookmarks') || '[]'));
+    const selectedLanguages = new Set();
+    let matchAllLanguages = false;
+    let activeChip = null; // tracks the active quick-filter chip key ('veterans' | 'newcomers' | 'low-competition' | 'high-competition' | 'bookmarked' | 'active' | null)
+    const CHANNEL_ICONS = {
+      Slack: '💬',
+      Zulip: '💬',
+      Discord: '🎮',
+      Matrix: '🔗',
+      IRC: '🖥️',
+      'Mailing list': '📧'
+    };
+    const CONTACT_TIPS = {
+      Slack: 'Join and say hi in the GSoC channel before DMing mentors.',
+      Discord: 'Introduce yourself in the public channel before asking project-specific questions.',
+      Zulip: 'Post a new topic in the GSoC stream with your background and interest.',
+      Matrix: "Say hello in the public room and mention the project area you're exploring.",
+      IRC: 'Stay in the channel for a while; replies are often asynchronous.',
+      'Mailing list': "Send a short intro email with your background and the idea you're interested in."
+    };
+    const LANGUAGE_ALIASES = {
+      'python': ['python'],
+      'javascript': ['javascript', 'js'],
+      'typescript': ['typescript', 'ts'],
+      'c/c++': ['c', 'c++', 'cpp'],
+      'java': ['java'],
+      'rust': ['rust'],
+      'go': ['go', 'golang'],
+      'ruby': ['ruby'],
+      'haskell': ['haskell'],
+      'scala': ['scala'],
+      'ml/ai': ['ml', 'ai', 'machine learning', 'artificial intelligence'],
+      'robotics': ['robotics', 'robot', 'ros']
+    };
+
+    // Compatibility layer: expose a single LANGUAGE_MAP and shared `pills` set
+    // so the embedded script and any external `src/js/app.js` logic agree.
+    (function buildCompatibilityLayer() {
+      // Expose the selectedLanguages set as `pills` for compatibility
+      globalThis.pills = selectedLanguages;
+      // Expose matchAllLanguages as a global variable reference (kept in sync below)
+      globalThis.matchAllLanguages = matchAllLanguages;
+      globalThis.compareList = compareList;
+      globalThis.bookmarkedSet = bookmarkedSet;
+
+      // Build a LANGUAGE_MAP with display-label keys matching src/js/app.js expectations
+      const toDisplayKey = (k) => {
+        if (k === 'ml/ai') return 'ML/AI';
+        if (k === 'c/c++') return 'C/C++';
+        return k.split(/[\s\/]+/).map(p => p.charAt(0).toUpperCase() + p.slice(1)).join(' ');
+      };
+      const LANG_MAP = {};
+      Object.keys(LANGUAGE_ALIASES).forEach(k => {
+        LANG_MAP[toDisplayKey(k)] = LANGUAGE_ALIASES[k];
+      });
+      // Also expose the lowercase-keyed aliases for any consumers that expect that
+      Object.keys(LANGUAGE_ALIASES).forEach(k => { LANG_MAP[k] = LANGUAGE_ALIASES[k]; });
+      globalThis.LANGUAGE_MAP = globalThis.LANGUAGE_MAP || LANG_MAP;
+    })();
+
+    function updateLanguageModeHint() {
+      const hint = document.getElementById('languageLogicHint');
+      if (!hint) return;
+      hint.textContent = matchAllLanguages
+        ? 'Multiple language chips use AND (must match all selected).'
+        : 'Multiple language chips use OR (any selected).';
+    }
+
+    function languageMatchesSelection(tags, lang) {
+      const langKey = lang.toLowerCase();
+      const aliases = LANGUAGE_ALIASES[langKey] || [langKey];
+      // Use exact token matching to prevent false positives like "Go" matching "django"
+      // Tags are split on whitespace, commas, slashes, and plus signs before comparing
+      return aliases.some(alias => {
+        const a = alias.toLowerCase();
+        return tags.some(tag => {
+          const tokens = tag.toLowerCase().split(/[\s,/+]+/);
+          return tokens.includes(a);
+        });
+      });
+    }
+
+    function clearSelectedLanguagePills() {
+      selectedLanguages.clear();
+      document.querySelectorAll('.pill.active').forEach(pill => {
+        pill.classList.remove('active');
+        pill.setAttribute('aria-pressed', 'false');
+      });
+      renderSelectedLanguages();
+    }
+
+    function renderSelectedLanguages() {
+      const container = document.getElementById('selectedLangsStrip');
+      if (!container) return;
+
+      if (selectedLanguages.size === 0) {
+        container.innerHTML = '<span class="empty-state">No languages selected</span>';
+        return;
+      }
+
+      const badges = [...selectedLanguages].map(lang => {
+        return `<span class="selected-lang-badge" data-lang="${lang}">
         ${lang}
         <button class="unselect-lang-btn" onclick="unselectLanguage('${lang}')" aria-label="Remove ${lang}">×</button>
       </span>`;
-    }).join('');
+      }).join('');
 
-    const clearAll = `<button class="clear-all-langs-btn" onclick="clearAllLanguages()">Clear all</button>`;
-    container.innerHTML = badges + clearAll;
-  }
-
-  window.unselectLanguage = function(lang) {
-    selectedLanguages.delete(lang);
-    const pillBtn = document.querySelector(`.pill[data-lang="${lang}"]`);
-    if (pillBtn) {
-      pillBtn.classList.remove('active');
-      pillBtn.setAttribute('aria-pressed', 'false');
+      const clearAll = `<button class="clear-all-langs-btn" onclick="clearAllLanguages()">Clear all</button>`;
+      container.innerHTML = badges + clearAll;
     }
-    renderSelectedLanguages();
-    applyFilters();
-  }
 
-  window.clearAllLanguages = function() {
-    selectedLanguages.clear();
-    document.querySelectorAll('.pill.active').forEach(p => {
-      p.classList.remove('active');
-      p.setAttribute('aria-pressed', 'false');
-    });
-    renderSelectedLanguages();
-    applyFilters();
-  }
+    window.unselectLanguage = function (lang) {
+      selectedLanguages.delete(lang);
+      const pillBtn = document.querySelector(`.pill[data-lang="${lang}"]`);
+      if (pillBtn) {
+        pillBtn.classList.remove('active');
+        pillBtn.setAttribute('aria-pressed', 'false');
+      }
+      renderSelectedLanguages();
+      applyFilters();
+    }
 
-  // NOTE: toggleLanguageMode removed — the matchAllLanguagesToggle checkbox
-  // uses a direct event listener (line ~1538) and does not use onclick=.
+    window.clearAllLanguages = function () {
+      selectedLanguages.clear();
+      document.querySelectorAll('.pill.active').forEach(p => {
+        p.classList.remove('active');
+        p.setAttribute('aria-pressed', 'false');
+      });
+      renderSelectedLanguages();
+      applyFilters();
+    }
 
-  window.togglePill = function(el) {
-    const langDisplay = el.dataset.lang || '';
-    const langKey = langDisplay.trim().toLowerCase();
-    if (!langKey) return;
-    const isActive = el.classList.toggle('active');
-    el.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-    if (selectedLanguages.has(langDisplay)) selectedLanguages.delete(langDisplay);
-    else selectedLanguages.add(langDisplay);
-    renderSelectedLanguages();
-    applyFilters();
-  };
+    // NOTE: toggleLanguageMode removed — the matchAllLanguagesToggle checkbox
+    // uses a direct event listener (line ~1538) and does not use onclick=.
 
-  function createDefaultMentorEntry(org) {
-    return {
-      org: org.name,
-      ideasUrl: org.ideas || '',
-      channels: [],
-      mentors: [],
-      mailingLists: [],
-      tip: '',
-      status: 'fetch-failed',
-      lastFetched: ''
+    window.togglePill = function (el) {
+      const langDisplay = el.dataset.lang || '';
+      const langKey = langDisplay.trim().toLowerCase();
+      if (!langKey) return;
+      const isActive = el.classList.toggle('active');
+      el.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      if (selectedLanguages.has(langDisplay)) selectedLanguages.delete(langDisplay);
+      else selectedLanguages.add(langDisplay);
+      renderSelectedLanguages();
+      applyFilters();
     };
-  }
 
-  function getMentorEntry(name) {
-    const org = ORGS.find(item => item.name === name);
-    if (!org) return null;
-    return MENTOR_DATA[name] || createDefaultMentorEntry(org);
-  }
+    function createDefaultMentorEntry(org) {
+      return {
+        org: org.name,
+        ideasUrl: org.ideas || '',
+        channels: [],
+        mentors: [],
+        mailingLists: [],
+        tip: '',
+        status: 'fetch-failed',
+        lastFetched: ''
+      };
+    }
 
-  function formatRelativeRefresh(isoString) {
-    if (!isoString) return 'Last updated: unavailable';
-    const timestamp = new Date(isoString).getTime();
-    if (Number.isNaN(timestamp)) return 'Last updated: unavailable';
-    const minutes = Math.max(1, Math.floor((Date.now() - timestamp) / 60000));
-    if (minutes < 60) return `Last updated: ${minutes} min ago`;
-    const hours = Math.floor(minutes / 60);
-    if (hours < 48) return `Last updated: ${hours} hour${hours === 1 ? '' : 's'} ago`;
-    const days = Math.floor(hours / 24);
-    return `Last updated: ${days} day${days === 1 ? '' : 's'} ago`;
-  }
+    function getMentorEntry(name) {
+      const org = ORGS.find(item => item.name === name);
+      if (!org) return null;
+      return MENTOR_DATA[name] || createDefaultMentorEntry(org);
+    }
 
-  function getPrimaryMentorContact(entry) {
-    if (entry.channels.length > 0) return entry.channels[0];
-    if (entry.mailingLists.length > 0) return entry.mailingLists[0];
-    return null;
-  }
+    function formatRelativeRefresh(isoString) {
+      if (!isoString) return 'Last updated: unavailable';
+      const timestamp = new Date(isoString).getTime();
+      if (Number.isNaN(timestamp)) return 'Last updated: unavailable';
+      const minutes = Math.max(1, Math.floor((Date.now() - timestamp) / 60000));
+      if (minutes < 60) return `Last updated: ${minutes} min ago`;
+      const hours = Math.floor(minutes / 60);
+      if (hours < 48) return `Last updated: ${hours} hour${hours === 1 ? '' : 's'} ago`;
+      const days = Math.floor(hours / 24);
+      return `Last updated: ${days} day${days === 1 ? '' : 's'} ago`;
+    }
 
-  function buildChannelChips(records) {
-    return records
-      .map((record) => {
-        const safe = sanitizeHrefUrl(record.url);
-        if (!safe) return '';
-        return `
+    function getPrimaryMentorContact(entry) {
+      if (entry.channels.length > 0) return entry.channels[0];
+      if (entry.mailingLists.length > 0) return entry.mailingLists[0];
+      return null;
+    }
+
+    function buildChannelChips(records) {
+      return records
+        .map((record) => {
+          const safe = sanitizeHrefUrl(record.url);
+          if (!safe) return '';
+          return `
           <a class="mentor-link-chip" href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer">
             <span>${CHANNEL_ICONS[record.type] || '💬'}</span>
             <span>${escapeHtml(record.label || record.type)}</span>
           </a>
         `;
-      })
-      .filter(Boolean)
-      .join('');
-  }
+        })
+        .filter(Boolean)
+        .join('');
+    }
 
-  function buildMentorChips(mentors) {
-    return mentors
-      .map((mentor) => {
-        if (mentor.githubUrl) {
-          const safe = sanitizeHrefUrl(mentor.githubUrl);
-          const label = mentor.github ? `@${mentor.github}` : (mentor.name || mentor.githubUrl);
-          if (safe) {
-            return `
+    function buildMentorChips(mentors) {
+      return mentors
+        .map((mentor) => {
+          if (mentor.githubUrl) {
+            const safe = sanitizeHrefUrl(mentor.githubUrl);
+            const label = mentor.github ? `@${mentor.github}` : (mentor.name || mentor.githubUrl);
+            if (safe) {
+              return `
               <a class="mentor-handle-chip" href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer">
                 <span>🐙</span>
                 <span>${escapeHtml(label)}</span>
               </a>
             `;
+            }
           }
-        }
 
-        return `
+          return `
           <span class="mentor-handle-chip">
             <span>👤</span>
             <span>${escapeHtml(mentor.name || 'Mentor')}</span>
           </span>
         `;
-      })
-      .join('');
-  }
-
-  function buildMentorPreviewChips(mentorPreview) {
-    if (mentorPreview.length === 0) {
-      return '<p class="text-sm text-zinc-600">No mentor handles parsed yet.</p>';
+        })
+        .join('');
     }
 
-    const chips = mentorPreview.map((mentor) => {
-      if (mentor.githubUrl) {
-        const safe = sanitizeHrefUrl(mentor.githubUrl);
-        if (safe) return `<a class="mentor-handle-chip" href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer"><span>🐙</span><span>${escapeHtml(mentor.displayLabel)}</span></a>`;
+    function buildMentorPreviewChips(mentorPreview) {
+      if (mentorPreview.length === 0) {
+        return '<p class="text-sm text-zinc-600">No mentor handles parsed yet.</p>';
       }
 
-      return `<span class="mentor-handle-chip"><span>👤</span><span>${escapeHtml(mentor.displayLabel)}</span></span>`;
-    }).join('');
+      const chips = mentorPreview.map((mentor) => {
+        if (mentor.githubUrl) {
+          const safe = sanitizeHrefUrl(mentor.githubUrl);
+          if (safe) return `<a class="mentor-handle-chip" href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer"><span>🐙</span><span>${escapeHtml(mentor.displayLabel)}</span></a>`;
+        }
 
-    return `<div class="flex flex-wrap gap-2">${chips}</div>`;
-  }
+        return `<span class="mentor-handle-chip"><span>👤</span><span>${escapeHtml(mentor.displayLabel)}</span></span>`;
+      }).join('');
 
-  function renderMentorContactSection(org) {
-    const container = document.getElementById('mMentorSection');
-    if (!container) return;
-
-    if (mentorDataState === 'idle' || mentorDataState === 'loading') {
-      container.innerHTML = '<p class="text-sm text-zinc-500">Loading mentor contact data...</p>';
-      return;
+      return `<div class="flex flex-wrap gap-2">${chips}</div>`;
     }
 
-    const entry = getMentorEntry(org.name);
-    if (!entry) {
-      container.innerHTML = '<p class="text-sm text-zinc-500">Mentor data unavailable right now.</p>';
-      return;
-    }
+    function renderMentorContactSection(org) {
+      const container = document.getElementById('mMentorSection');
+      if (!container) return;
 
-    const fallbackIdeasLink = (function(){
-      const u = sanitizeHrefUrl(org.ideas);
-      return u ? `<a href="${escapeHtml(u)}" target="_blank" rel="noopener noreferrer" class="mentor-link-chip"><span>💡</span><span>Visit ideas page</span></a>` : '';
-    })();
+      if (mentorDataState === 'idle' || mentorDataState === 'loading') {
+        container.innerHTML = '<p class="text-sm text-zinc-500">Loading mentor contact data...</p>';
+        return;
+      }
 
-    const sections = [];
-    if (entry.status === 'ok' && entry.channels.length > 0) {
-      sections.push(`
+      const entry = getMentorEntry(org.name);
+      if (!entry) {
+        container.innerHTML = '<p class="text-sm text-zinc-500">Mentor data unavailable right now.</p>';
+        return;
+      }
+
+      const fallbackIdeasLink = (function () {
+        const u = sanitizeHrefUrl(org.ideas);
+        return u ? `<a href="${escapeHtml(u)}" target="_blank" rel="noopener noreferrer" class="mentor-link-chip"><span>💡</span><span>Visit ideas page</span></a>` : '';
+      })();
+
+      const sections = [];
+      if (entry.status === 'ok' && entry.channels.length > 0) {
+        sections.push(`
         <div>
           <p class="text-xs font-bold uppercase tracking-widest text-zinc-400 mb-3">Channels</p>
           <div class="flex flex-wrap gap-2">${buildChannelChips(entry.channels)}</div>
         </div>
       `);
-    }
+      }
 
-    if (entry.status === 'ok' && entry.mentors.length > 0) {
-      sections.push(`
+      if (entry.status === 'ok' && entry.mentors.length > 0) {
+        sections.push(`
         <div>
           <p class="text-xs font-bold uppercase tracking-widest text-zinc-400 mb-3">Mentors</p>
           <div class="flex flex-wrap gap-2">${buildMentorChips(entry.mentors)}</div>
         </div>
       `);
-    }
+      }
 
-    if (entry.status === 'ok' && entry.mailingLists.length > 0) {
-      sections.push(`
+      if (entry.status === 'ok' && entry.mailingLists.length > 0) {
+        sections.push(`
         <div>
           <p class="text-xs font-bold uppercase tracking-widest text-zinc-400 mb-3">Mailing Lists</p>
           <div class="flex flex-wrap gap-2">${buildChannelChips(entry.mailingLists.map((list) => ({ ...list, type: 'Mailing list' })))}</div>
         </div>
       `);
-    }
+      }
 
-    if (entry.tip) {
-      sections.push(`
+      if (entry.tip) {
+        sections.push(`
         <div class="rounded-2xl bg-orange-50 border border-orange-100 p-4">
           <p class="text-xs font-bold uppercase tracking-widest text-primary mb-1">Contact Tip</p>
           <p class="text-sm text-zinc-700">${escapeHtml(entry.tip)}</p>
         </div>
       `);
-    }
-
-    if (sections.length === 0) {
-      let message = 'No contact info parsed yet.';
-      if (entry.status === 'fetch-failed') {
-        message = 'Mentor data unavailable right now.';
       }
-      container.innerHTML = `
+
+      if (sections.length === 0) {
+        let message = 'No contact info parsed yet.';
+        if (entry.status === 'fetch-failed') {
+          message = 'Mentor data unavailable right now.';
+        }
+        container.innerHTML = `
         <div class="rounded-2xl border border-dashed border-zinc-200 p-5">
           <p class="text-sm text-zinc-600 mb-3">${message}</p>
           <div class="flex flex-wrap gap-2">${fallbackIdeasLink || '<span class="text-xs text-zinc-400">No ideas page listed.</span>'}</div>
         </div>
       `;
-      return;
-    }
+        return;
+      }
 
-    container.innerHTML = `
+      container.innerHTML = `
       <div class="space-y-4">
         ${sections.join('')}
         ${fallbackIdeasLink ? `<div class="flex flex-wrap gap-2">${fallbackIdeasLink}</div>` : ''}
       </div>
     `;
-  }
+    }
 
-  function getMentorFinderRecords() {
-    return ORGS.map((org) => ({
-      org,
-      entry: getMentorEntry(org.name)
-    }));
-  }
+    function getMentorFinderRecords() {
+      return ORGS.map((org) => ({
+        org,
+        entry: getMentorEntry(org.name)
+      }));
+    }
 
-  function renderMentorFinder() {
-    const grid = document.getElementById('mentorGrid');
-    const lastUpdatedEl = document.getElementById('mentorLastUpdated');
-    if (!grid) return;
+    function renderMentorFinder() {
+      const grid = document.getElementById('mentorGrid');
+      const lastUpdatedEl = document.getElementById('mentorLastUpdated');
+      if (!grid) return;
 
-    if (mentorDataState === 'loading' || mentorDataState === 'idle') {
-      grid.innerHTML = `
+      if (mentorDataState === 'loading' || mentorDataState === 'idle') {
+        grid.innerHTML = `
         <div class="col-span-full mentor-empty">
           <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
         </div>
       `;
-      return;
-    }
+        return;
+      }
 
-    if (mentorDataState === 'error') {
-      grid.innerHTML = `
+      if (mentorDataState === 'error') {
+        grid.innerHTML = `
         <div class="col-span-full mentor-empty">
           <p class="font-bold text-zinc-900 mb-2">Mentor data unavailable right now.</p>
           <p class="text-sm text-zinc-600">The cached mentor snapshot could not be loaded. Please try again later.</p>
         </div>
       `;
-      if (lastUpdatedEl?.textContent !== undefined) lastUpdatedEl.textContent = 'Last updated: unavailable';
-      return;
-    }
+        if (lastUpdatedEl?.textContent !== undefined) lastUpdatedEl.textContent = 'Last updated: unavailable';
+        return;
+      }
 
-    const search = (document.getElementById('mentorSearchInput')?.value || '').trim().toLowerCase();
-    const channelFilter = document.getElementById('mentorChannelFilter')?.value || 'all';
-    const records = getMentorFinderRecords();
-    const lastFetched = records.map((record) => record.entry.lastFetched).find(Boolean);
-    if (lastUpdatedEl?.textContent !== undefined) {
-      lastUpdatedEl.textContent = formatRelativeRefresh(lastFetched);
-    }
+      const search = (document.getElementById('mentorSearchInput')?.value || '').trim().toLowerCase();
+      const channelFilter = document.getElementById('mentorChannelFilter')?.value || 'all';
+      const records = getMentorFinderRecords();
+      const lastFetched = records.map((record) => record.entry.lastFetched).find(Boolean);
+      if (lastUpdatedEl?.textContent !== undefined) {
+        lastUpdatedEl.textContent = formatRelativeRefresh(lastFetched);
+      }
 
-    const filteredRecords = records.filter(({ org, entry }) => {
-      const searchHaystack = [
-        org.name,
-        ...(entry.mentors || []).flatMap((mentor) => [mentor.name || '', mentor.github || ''])
-      ].join(' ').toLowerCase();
+      const filteredRecords = records.filter(({ org, entry }) => {
+        const searchHaystack = [
+          org.name,
+          ...(entry.mentors || []).flatMap((mentor) => [mentor.name || '', mentor.github || ''])
+        ].join(' ').toLowerCase();
 
-      const matchesSearch = !search || searchHaystack.includes(search);
-      const allContacts = [...(entry.channels || []), ...(entry.mailingLists || []).map((list) => ({ ...list, type: 'Mailing list' }))];
-      const matchesChannel = channelFilter === 'all' || allContacts.some((contact) => contact.type === channelFilter);
+        const matchesSearch = !search || searchHaystack.includes(search);
+        const allContacts = [...(entry.channels || []), ...(entry.mailingLists || []).map((list) => ({ ...list, type: 'Mailing list' }))];
+        const matchesChannel = channelFilter === 'all' || allContacts.some((contact) => contact.type === channelFilter);
 
-      return matchesSearch && matchesChannel;
-    });
+        return matchesSearch && matchesChannel;
+      });
 
-    if (filteredRecords.length === 0) {
-      grid.innerHTML = `
+      if (filteredRecords.length === 0) {
+        grid.innerHTML = `
         <div class="col-span-full mentor-empty">
           <p class="font-bold text-zinc-900 mb-2">No mentor matches found.</p>
           <p class="text-sm text-zinc-600">Try a different org name, GitHub handle, or channel filter.</p>
         </div>
       `;
-      return;
-    }
-
-    grid.innerHTML = filteredRecords.map(({ org, entry }) => {
-      const primary = getPrimaryMentorContact(entry);
-      const mentorPreview = entry.mentors
-        .slice(0, 3)
-        .filter((mentor) => mentor.github || mentor.name)
-        .map((mentor) => ({
-          ...mentor,
-          displayLabel: mentor.github ? `@${mentor.github}` : mentor.name
-        }));
-      const mentorPreviewHtml = buildMentorPreviewChips(mentorPreview);
-      const primaryType = primary?.type || 'Not specified';
-      let statusClass = 'bg-red-100 text-red-700';
-      if (entry.status === 'ok') {
-        statusClass = 'bg-green-100 text-green-700';
-      } else if (entry.status === 'no-contact-found') {
-        statusClass = 'bg-zinc-100 text-zinc-600';
+        return;
       }
 
-      const contactLabel = entry.status === 'ok' ? 'Contact' : 'Ideas page';
-      const helperText = entry.status === 'ok'
-        ? 'Ideas page remains available from the org modal.'
-        : 'Use the ideas page to find the latest contact guidance.';
+      grid.innerHTML = filteredRecords.map(({ org, entry }) => {
+        const primary = getPrimaryMentorContact(entry);
+        const mentorPreview = entry.mentors
+          .slice(0, 3)
+          .filter((mentor) => mentor.github || mentor.name)
+          .map((mentor) => ({
+            ...mentor,
+            displayLabel: mentor.github ? `@${mentor.github}` : mentor.name
+          }));
+        const mentorPreviewHtml = buildMentorPreviewChips(mentorPreview);
+        const primaryType = primary?.type || 'Not specified';
+        let statusClass = 'bg-red-100 text-red-700';
+        if (entry.status === 'ok') {
+          statusClass = 'bg-green-100 text-green-700';
+        } else if (entry.status === 'no-contact-found') {
+          statusClass = 'bg-zinc-100 text-zinc-600';
+        }
 
-      let bodyHtml = '';
-      if (entry.status === 'ok') {
-        const channelLinks = [
-          ...(entry.channels || []),
-          ...(entry.mailingLists || []).map((list) => ({ ...list, type: 'Mailing list' }))
-        ];
-        bodyHtml = `
+        const contactLabel = entry.status === 'ok' ? 'Contact' : 'Ideas page';
+        const helperText = entry.status === 'ok'
+          ? 'Ideas page remains available from the org modal.'
+          : 'Use the ideas page to find the latest contact guidance.';
+
+        let bodyHtml = '';
+        if (entry.status === 'ok') {
+          const channelLinks = [
+            ...(entry.channels || []),
+            ...(entry.mailingLists || []).map((list) => ({ ...list, type: 'Mailing list' }))
+          ];
+          bodyHtml = `
           <div class="space-y-3">
             <div class="flex flex-wrap gap-2">${buildChannelChips(channelLinks.slice(0, 2))}</div>
             ${mentorPreviewHtml}
@@ -1776,16 +2563,16 @@
             ${entry.tip ? `<p class="text-sm text-zinc-600 line-clamp-3">${escapeHtml(entry.tip)}</p>` : ''}
           </div>
         `;
-      } else if (entry.status === 'no-contact-found') {
-        bodyHtml = '<p class="text-sm text-zinc-600">No mentor contact info parsed yet for this org.</p>';
-      } else {
-        bodyHtml = '<p class="text-sm text-zinc-600">Mentor data unavailable right now.</p>';
-      }
+        } else if (entry.status === 'no-contact-found') {
+          bodyHtml = '<p class="text-sm text-zinc-600">No mentor contact info parsed yet for this org.</p>';
+        } else {
+          bodyHtml = '<p class="text-sm text-zinc-600">Mentor data unavailable right now.</p>';
+        }
 
-      const contactHref = primary?.url || org.ideas || `https://github.com/${org.github}`;
-      const safeContactHref = sanitizeHrefUrl(contactHref);
+        const contactHref = primary?.url || org.ideas || `https://github.com/${org.github}`;
+        const safeContactHref = sanitizeHrefUrl(contactHref);
 
-      return `
+        return `
         <article class="mentor-card">
           <div class="flex items-start justify-between gap-3 mb-4">
             <div>
@@ -1801,72 +2588,72 @@
           </div>
         </article>
       `;
-    }).join('');
+      }).join('');
 
-    attachOrgCardListeners(grid);
-  }
-
-  async function loadMentorData() {
-    mentorDataState = 'loading';
-    renderMentorFinder();
-
-    try {
-      const res = await fetch(`/data/mentors.json?v=${Date.now()}`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      if (!data || typeof data !== 'object' || Array.isArray(data)) {
-        throw new Error('Invalid mentors.json payload');
-      }
-      MENTOR_DATA = data;
-      mentorDataState = 'loaded';
-    } catch (error) {
-      console.error('Mentor data load failed:', error);
-      MENTOR_DATA = {};
-      mentorDataState = 'error';
+      attachOrgCardListeners(grid);
     }
 
-    renderMentorFinder();
-    const openModalEl = document.getElementById('orgModal');
-    if (openModalEl?.classList.contains('open')) {
-      const orgName = document.querySelector('#mHeader h2')?.textContent;
-      if (orgName) {
-        const org = ORGS.find((item) => item.name === orgName);
-        if (org) renderMentorContactSection(org);
-      }
-    }
-  }
+    async function loadMentorData() {
+      mentorDataState = 'loading';
+      renderMentorFinder();
 
-  // Dynamic timeline milestones
-  const MILESTONES = [
-    { date: new Date('2026-02-19T00:00:00Z'), label: 'Accepted Orgs Announced', note: null },
-    { date: new Date('2026-03-16T00:00:00Z'), label: 'Contributor Proposals Open', note: null },
-    { date: new Date('2026-03-31T23:30:00+05:30'), label: 'Proposal Submission Deadline', note: 'Submit your project proposals by 11:30 PM!' },
-    { date: new Date('2026-04-30T00:00:00Z'), label: 'Accepted Projects Announced', note: null },
-  ].filter(m => !isNaN(m.date.getTime())); 
-
-  function renderTimeline() {
-    const container = document.getElementById('timeline-milestones');
-    if (!container || MILESTONES.length === 0) return;
-
-    try {
-      const now = new Date();
-      if (isNaN(now.getTime())) return;
-
-      let activeIdx = MILESTONES.findIndex(m => m.date > now);
-      if (activeIdx === -1) activeIdx = MILESTONES.length - 1;
-
-      const allPast = MILESTONES[MILESTONES.length - 1].date <= now;
-
-      container.innerHTML = MILESTONES.map((m, i) => {
-        const isActive = i === activeIdx;
-        const isLast = i === MILESTONES.length - 1;
-        const connector = !isLast ? `<div class="w-0.5 h-10 bg-zinc-200"></div>` : '';
-        let dateStr;
-        try {
-          dateStr = m.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).toUpperCase();
-        } catch (_) {
-          dateStr = m.date.toISOString().slice(0, 10);
+      try {
+        const res = await fetch(`/data/mentors.json?v=${Date.now()}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        if (!data || typeof data !== 'object' || Array.isArray(data)) {
+          throw new Error('Invalid mentors.json payload');
         }
+        MENTOR_DATA = data;
+        mentorDataState = 'loaded';
+      } catch (error) {
+        console.error('Mentor data load failed:', error);
+        MENTOR_DATA = {};
+        mentorDataState = 'error';
+      }
+
+      renderMentorFinder();
+      const openModalEl = document.getElementById('orgModal');
+      if (openModalEl?.classList.contains('open')) {
+        const orgName = document.querySelector('#mHeader h2')?.textContent;
+        if (orgName) {
+          const org = ORGS.find((item) => item.name === orgName);
+          if (org) renderMentorContactSection(org);
+        }
+      }
+    }
+
+    // Dynamic timeline milestones
+    const MILESTONES = [
+      { date: new Date('2026-02-19T00:00:00Z'), label: 'Accepted Orgs Announced', note: null },
+      { date: new Date('2026-03-16T00:00:00Z'), label: 'Contributor Proposals Open', note: null },
+      { date: new Date('2026-03-31T23:30:00+05:30'), label: 'Proposal Submission Deadline', note: 'Submit your project proposals by 11:30 PM!' },
+      { date: new Date('2026-04-30T00:00:00Z'), label: 'Accepted Projects Announced', note: null },
+    ].filter(m => !isNaN(m.date.getTime()));
+
+    function renderTimeline() {
+      const container = document.getElementById('timeline-milestones');
+      if (!container || MILESTONES.length === 0) return;
+
+      try {
+        const now = new Date();
+        if (isNaN(now.getTime())) return;
+
+        let activeIdx = MILESTONES.findIndex(m => m.date > now);
+        if (activeIdx === -1) activeIdx = MILESTONES.length - 1;
+
+        const allPast = MILESTONES[MILESTONES.length - 1].date <= now;
+
+        container.innerHTML = MILESTONES.map((m, i) => {
+          const isActive = i === activeIdx;
+          const isLast = i === MILESTONES.length - 1;
+          const connector = !isLast ? `<div class="w-0.5 h-10 bg-zinc-200"></div>` : '';
+          let dateStr;
+          try {
+            dateStr = m.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).toUpperCase();
+          } catch (_) {
+            dateStr = m.date.toISOString().slice(0, 10);
+          }
 
           if (isActive && !allPast) {
             return `<div class="flex gap-3 sm:gap-4">
@@ -1889,92 +2676,92 @@
               <p class="text-sm font-bold text-zinc-500">${escapeHtml(m.label)}</p></div>
             </div>`;
           }
-      }).join('');
-    } catch (err) {
-      console.warn('[Timeline] renderTimeline failed:', err);
+        }).join('');
+      } catch (err) {
+        console.warn('[Timeline] renderTimeline failed:', err);
+      }
     }
-  }
 
-  // Countdown to the next upcoming milestone
-  function updateCountdown() {
-    const countdownEl = document.getElementById('countdown');
-    const labelEl = document.getElementById('countdown-label');
-    if (!countdownEl || !labelEl || MILESTONES.length === 0) return;
+    // Countdown to the next upcoming milestone
+    function updateCountdown() {
+      const countdownEl = document.getElementById('countdown');
+      const labelEl = document.getElementById('countdown-label');
+      if (!countdownEl || !labelEl || MILESTONES.length === 0) return;
 
-    try {
-      const now = new Date();
-      if (isNaN(now.getTime())) return;
+      try {
+        const now = new Date();
+        if (isNaN(now.getTime())) return;
 
-      const next = MILESTONES.find(m => m.date > now);
+        const next = MILESTONES.find(m => m.date > now);
 
-      if (!next) {
-        labelEl.textContent = 'GSoC 2026 selection complete';
-        countdownEl.textContent = '🎉 All done!';
-        countdownEl.classList.remove('text-primary');
-        countdownEl.classList.add('text-green-600');
+        if (!next) {
+          labelEl.textContent = 'GSoC 2026 selection complete';
+          countdownEl.textContent = '🎉 All done!';
+          countdownEl.classList.remove('text-primary');
+          countdownEl.classList.add('text-green-600');
+          return;
+        }
+
+        labelEl.textContent = `Until: ${next.label}`;
+        countdownEl.classList.remove('text-green-600');
+        countdownEl.classList.add('text-primary');
+        const diff = next.date - now;
+        if (diff <= 0) { renderTimeline(); updateCountdown(); return; }
+        const d = Math.floor(diff / 864e5), h = Math.floor((diff % 864e5) / 36e5), m = Math.floor((diff % 36e5) / 6e4);
+        countdownEl.textContent = `${d}d ${h}h ${m}m`;
+      } catch (err) {
+        console.warn('[Timeline] updateCountdown failed:', err);
+      }
+    }
+
+    // Organizational Logo Fallbacks
+    window.handleImgError = function (img, orgName) {
+      if (!img.dataset.triedClearbit) {
+        img.dataset.triedClearbit = 'true';
+        const domain = orgName.toLowerCase().replace(/[^a-z0-9]/g, '') + '.org';
+        img.src = `https://logo.clearbit.com/${domain}`;
+      } else {
+        img.style.display = 'none';
+        const placeholder = img.parentElement.querySelector('.logo-placeholder');
+        if (placeholder) {
+          placeholder.style.display = 'flex';
+          placeholder.textContent = orgName.split(' ').map(n => n[0]).join('').substring(0, 2).toUpperCase();
+        }
+      }
+    };
+
+    function renderOrgs(reset = true) {
+      const grid = document.getElementById('orgGrid');
+
+      const emptyState = document.getElementById('emptyState');
+      if (reset) {
+        grid.innerHTML = '';
+        visibleCount = 12;
+      }
+
+      if (filteredOrgs.length === 0) {
+        grid.classList.add('hidden');
+        if (emptyState) emptyState.classList.remove('hidden');
+        document.getElementById('orgCount').textContent = '0';
+        document.getElementById('loadMoreContainer').style.display = 'none';
         return;
+      } else {
+        grid.classList.remove('hidden');
+        if (emptyState) emptyState.classList.add('hidden');
       }
 
-      labelEl.textContent = `Until: ${next.label}`;
-      countdownEl.classList.remove('text-green-600');
-      countdownEl.classList.add('text-primary');
-      const diff = next.date - now;
-      if (diff <= 0) { renderTimeline(); updateCountdown(); return; }
-      const d = Math.floor(diff / 864e5), h = Math.floor((diff % 864e5) / 36e5), m = Math.floor((diff % 36e5) / 6e4);
-      countdownEl.textContent = `${d}d ${h}h ${m}m`;
-    } catch (err) {
-      console.warn('[Timeline] updateCountdown failed:', err);
-    }
-  }
+      const slice = filteredOrgs.slice(visibleCount - 12, visibleCount);
+      slice.forEach(org => {
+        const isBookmarked = bookmarkedSet.has(org.name);
+        const isComparing = compareList.includes(org.name);
+        const card = document.createElement('article');
+        card.className = 'group bg-white rounded-2xl p-6 border border-zinc-100 transition-all hover:shadow-xl hover:border-primary/20 animate-fade-up';
+        card.dataset.org = org.name;
 
-  // Organizational Logo Fallbacks
-  window.handleImgError = function(img, orgName) {
-    if (!img.dataset.triedClearbit) {
-      img.dataset.triedClearbit = 'true';
-      const domain = orgName.toLowerCase().replace(/[^a-z0-9]/g, '') + '.org';
-      img.src = `https://logo.clearbit.com/${domain}`;
-    } else {
-      img.style.display = 'none';
-      const placeholder = img.parentElement.querySelector('.logo-placeholder');
-      if (placeholder) {
-        placeholder.style.display = 'flex';
-        placeholder.textContent = orgName.split(' ').map(n => n[0]).join('').substring(0,2).toUpperCase();
-      }
-    }
-  };
+        const githubOwner = org.github.split('/')[0];
+        const logoUrl = `https://github.com/${githubOwner}.png?size=80`;
 
-  function renderOrgs(reset = true) {
-    const grid = document.getElementById('orgGrid');
-
-    const emptyState = document.getElementById('emptyState');
-    if (reset) {
-      grid.innerHTML = '';
-      visibleCount = 12;
-    }
-
-    if (filteredOrgs.length === 0) {
-      grid.classList.add('hidden');
-      if (emptyState) emptyState.classList.remove('hidden');
-      document.getElementById('orgCount').textContent = '0';
-      document.getElementById('loadMoreContainer').style.display = 'none';
-      return;
-    } else {
-      grid.classList.remove('hidden');
-      if (emptyState) emptyState.classList.add('hidden');
-    }
-    
-    const slice = filteredOrgs.slice(visibleCount - 12, visibleCount);
-    slice.forEach(org => {
-      const isBookmarked = bookmarkedSet.has(org.name);
-      const isComparing = compareList.includes(org.name);
-      const card = document.createElement('article');
-      card.className = 'group bg-white rounded-2xl p-6 border border-zinc-100 transition-all hover:shadow-xl hover:border-primary/20 animate-fade-up';
-      card.dataset.org = org.name;
-      
-      const githubOwner = org.github.split('/')[0];
-      const logoUrl = `https://github.com/${githubOwner}.png?size=80`;
-      
-      card.innerHTML = `
+        card.innerHTML = `
         <div class="flex justify-between items-start mb-4">
           <div class="w-14 h-14 rounded-xl bg-surface-container-low flex items-center justify-center p-2 overflow-hidden">
             <img src="${escapeHtml(logoUrl)}" data-org-name="${escapeHtml(org.name)}" alt="${escapeHtml(org.name + ' logo')}" class="w-full h-full object-contain rounded-lg" />
@@ -2005,81 +2792,81 @@
            <button data-open-org="${escapeHtml(org.name)}" class="text-primary font-bold text-xs uppercase tracking-widest flex items-center gap-1 group-hover:gap-2 transition-all">View <span class="material-symbols-outlined text-sm">arrow_forward</span></button>
         </div>
       `;
-      grid.appendChild(card);
+        grid.appendChild(card);
         // Attach per-card listeners for non-bubbling events and data-driven actions
         attachOrgCardListeners(card);
-    });
-
-    document.getElementById('orgCount').textContent = filteredOrgs.length;
-    document.getElementById('loadMoreContainer').style.display = (visibleCount < filteredOrgs.length) ? 'flex' : 'none';
-  }
-
-  // Attach listeners to elements created from org templates.
-  // Uses data-* attributes to avoid injecting user data into inline JS handlers.
-  function attachOrgCardListeners(root = document) {
-    // image error fallback (error doesn't bubble reliably)
-    (root.querySelectorAll ? root.querySelectorAll('img[data-org-name]') : []).forEach(img => {
-      if (img.__orgListenerAttached) return;
-      img.addEventListener('error', (e) => {
-        handleImgError(e.target, e.target.dataset.orgName);
       });
-      img.__orgListenerAttached = true;
-    });
 
-    // bookmark buttons
-    (root.querySelectorAll ? root.querySelectorAll('.bookmark-btn[data-bookmark-org]') : []).forEach(btn => {
-      if (btn.__orgListenerAttached) return;
-      btn.addEventListener('click', (e) => toggleBookmark(e, btn.dataset.bookmarkOrg));
-      btn.__orgListenerAttached = true;
-    });
-
-    // compare buttons
-    (root.querySelectorAll ? root.querySelectorAll('[data-compare-org]') : []).forEach(btn => {
-      if (btn.__orgListenerAttached) return;
-      btn.addEventListener('click', (e) => toggleCompare(e, btn.dataset.compareOrg));
-      btn.__orgListenerAttached = true;
-    });
-
-    // open modal buttons
-    (root.querySelectorAll ? root.querySelectorAll('[data-open-org]') : []).forEach(btn => {
-      if (btn.__orgListenerAttached) return;
-      btn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        openModal(btn.dataset.openOrg);
-      });
-      btn.__orgListenerAttached = true;
-    });
-  }
-
-  function toggleCompare(e, name) {
-    if (e) e.stopPropagation();
-    const idx = compareList.indexOf(name);
-    if (idx > -1) {
-      compareList.splice(idx, 1);
-    } else {
-      if (compareList.length >= 3) {
-        alert("You can only compare up to 3 organizations at a time.");
-        return;
-      }
-      compareList.push(name);
+      document.getElementById('orgCount').textContent = filteredOrgs.length;
+      document.getElementById('loadMoreContainer').style.display = (visibleCount < filteredOrgs.length) ? 'flex' : 'none';
     }
-    renderOrgs(true);
-    renderCompare();
-  }
 
-  function renderCompare() {
-    const container = document.querySelector('#compare .grid');
-    if (!container) return;
-    container.innerHTML = '';
-    
-    compareList.forEach(name => {
-      const org = ORGS.find(o => o.name === name);
-      const githubOwner = org.github.split('/')[0];
-      const logoUrl = `https://github.com/${githubOwner}.png?size=80`;
-      
-      const item = document.createElement('div');
-      item.className = 'bg-white rounded-xl p-4 border border-zinc-100';
-      item.innerHTML = `
+    // Attach listeners to elements created from org templates.
+    // Uses data-* attributes to avoid injecting user data into inline JS handlers.
+    function attachOrgCardListeners(root = document) {
+      // image error fallback (error doesn't bubble reliably)
+      (root.querySelectorAll ? root.querySelectorAll('img[data-org-name]') : []).forEach(img => {
+        if (img.__orgListenerAttached) return;
+        img.addEventListener('error', (e) => {
+          handleImgError(e.target, e.target.dataset.orgName);
+        });
+        img.__orgListenerAttached = true;
+      });
+
+      // bookmark buttons
+      (root.querySelectorAll ? root.querySelectorAll('.bookmark-btn[data-bookmark-org]') : []).forEach(btn => {
+        if (btn.__orgListenerAttached) return;
+        btn.addEventListener('click', (e) => toggleBookmark(e, btn.dataset.bookmarkOrg));
+        btn.__orgListenerAttached = true;
+      });
+
+      // compare buttons
+      (root.querySelectorAll ? root.querySelectorAll('[data-compare-org]') : []).forEach(btn => {
+        if (btn.__orgListenerAttached) return;
+        btn.addEventListener('click', (e) => toggleCompare(e, btn.dataset.compareOrg));
+        btn.__orgListenerAttached = true;
+      });
+
+      // open modal buttons
+      (root.querySelectorAll ? root.querySelectorAll('[data-open-org]') : []).forEach(btn => {
+        if (btn.__orgListenerAttached) return;
+        btn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          openModal(btn.dataset.openOrg);
+        });
+        btn.__orgListenerAttached = true;
+      });
+    }
+
+    function toggleCompare(e, name) {
+      if (e) e.stopPropagation();
+      const idx = compareList.indexOf(name);
+      if (idx > -1) {
+        compareList.splice(idx, 1);
+      } else {
+        if (compareList.length >= 3) {
+          alert("You can only compare up to 3 organizations at a time.");
+          return;
+        }
+        compareList.push(name);
+      }
+      renderOrgs(true);
+      renderCompare();
+    }
+
+    function renderCompare() {
+      const container = document.querySelector('#compare .grid');
+      if (!container) return;
+      container.innerHTML = '';
+
+      compareList.forEach(name => {
+        const org = ORGS.find(o => o.name === name);
+        const githubOwner = org.github.split('/')[0];
+        const logoUrl = `https://github.com/${githubOwner}.png?size=80`;
+
+        const item = document.createElement('div');
+        item.className = 'bg-white rounded-xl p-4 border border-zinc-100';
+        item.innerHTML = `
         <div class="w-10 h-10 rounded-lg bg-orange-100 flex items-center justify-center mx-auto mb-3 overflow-hidden">
           <img src="${escapeHtml(logoUrl)}" data-org-name="${escapeHtml(org.name)}" class="w-full h-full object-contain" />
         </div>
@@ -2087,57 +2874,57 @@
         <p class="text-[10px] text-zinc-500 font-label uppercase mt-1">${escapeHtml(String(org.years))}y · ${escapeHtml(org.competition)}</p>
         <button data-compare-org="${escapeHtml(org.name)}" class="text-[9px] text-red-500 font-bold uppercase mt-2 hover:underline">Remove</button>
       `;
-      container.appendChild(item);
-      attachOrgCardListeners(item);
-    });
+        container.appendChild(item);
+        attachOrgCardListeners(item);
+      });
 
-    // Add empty slots
-    for (let i = compareList.length; i < 3; i++) {
-      const empty = document.createElement('div');
-      empty.className = 'bg-white rounded-xl p-4 border border-zinc-100 border-dashed border-zinc-300 flex flex-col items-center justify-center opacity-50';
-      empty.innerHTML = `
+      // Add empty slots
+      for (let i = compareList.length; i < 3; i++) {
+        const empty = document.createElement('div');
+        empty.className = 'bg-white rounded-xl p-4 border border-zinc-100 border-dashed border-zinc-300 flex flex-col items-center justify-center opacity-50';
+        empty.innerHTML = `
         <div class="w-10 h-10 rounded-lg bg-zinc-100 flex items-center justify-center mb-3"><span class="material-symbols-outlined text-zinc-400">add</span></div>
         <p class="font-bold text-sm text-zinc-400">Add org</p>
-        <p class="text-[10px] text-zinc-400 font-label uppercase mt-1">Slot ${i+1}</p>
+        <p class="text-[10px] text-zinc-400 font-label uppercase mt-1">Slot ${i + 1}</p>
       `;
-      container.appendChild(empty);
+        container.appendChild(empty);
+      }
     }
-  }
 
-  function renderCompareModal() {
-    const body = document.getElementById('compareModalBody');
-    if (!body) return;
-    const escapeHtml = (value) => String(value)
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;')
-      .replaceAll('"', '&quot;')
-      .replaceAll("'", '&#39;');
+    function renderCompareModal() {
+      const body = document.getElementById('compareModalBody');
+      if (!body) return;
+      const escapeHtml = (value) => String(value)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
 
-    const selectedOrgs = compareList.map(name => ORGS.find(o => o.name === name)).filter(Boolean);
-    if (selectedOrgs.length < 2) {
-      body.innerHTML = `
+      const selectedOrgs = compareList.map(name => ORGS.find(o => o.name === name)).filter(Boolean);
+      if (selectedOrgs.length < 2) {
+        body.innerHTML = `
         <div class="py-12 text-center border-2 border-dashed border-zinc-200 rounded-2xl">
           <span class="material-symbols-outlined text-4xl text-zinc-300 mb-3">compare_arrows</span>
           <p class="font-bold text-zinc-700">Select at least 2 organizations to compare.</p>
           <p class="text-sm text-zinc-500 mt-2">Use the Compare button on organization cards, then open this tool again.</p>
         </div>
       `;
-      return;
-    }
+        return;
+      }
 
-    const rows = [
-      ['Category', org => org.cat],
-      ['GSoC Years', org => org.years],
-      ['First Year', org => org.firstYear],
-      ['Competition', org => org.competition],
-      ['Codebase', org => org.codebase],
-      ['Tech Stack', org => org.tags.join(', ')],
-      ['Best Fit', org => org.fit.join(', ')],
-      ['Repository', org => org.github],
-    ];
+      const rows = [
+        ['Category', org => org.cat],
+        ['GSoC Years', org => org.years],
+        ['First Year', org => org.firstYear],
+        ['Competition', org => org.competition],
+        ['Codebase', org => org.codebase],
+        ['Tech Stack', org => org.tags.join(', ')],
+        ['Best Fit', org => org.fit.join(', ')],
+        ['Repository', org => org.github],
+      ];
 
-    body.innerHTML = `
+      body.innerHTML = `
       <table class="w-full min-w-[720px] text-sm">
         <thead>
           <tr class="border-b border-zinc-200">
@@ -2155,77 +2942,77 @@
         </tbody>
       </table>
     `;
-  }
-
-  function openCompareModal() {
-    renderCompare();
-    renderCompareModal();
-    document.getElementById('compareModal')?.classList.add('open');
-    document.body.style.overflow = 'hidden';
-  }
-
-  function closeCompareModal() {
-    document.getElementById('compareModal')?.classList.remove('open');
-    document.body.style.overflow = 'auto';
-  }
-
-  document.getElementById('compareModal')?.addEventListener('click', (e) => {
-    if (e.target.id === 'compareModal') closeCompareModal();
-  });
-
-  document.addEventListener('keydown', (e) => {
-    if (e.key !== 'Escape') return;
-    if (document.getElementById('compareModal')?.classList.contains('open')) {
-      closeCompareModal();
-    } else if (document.getElementById('orgModal')?.classList.contains('open')) {
-      closeModal();
     }
-  });
 
-  function refreshOrgGridPreservingVisibleCount() {
-    const savedCount = visibleCount;
-    const grid = document.getElementById('orgGrid');
-    if (!grid) return;
-    // renderOrgs(true) clears the grid and resets visibleCount to 12, rendering
-    // the first page. We then keep appending subsequent pages until we reach
-    // the count the user had previously scrolled to, so no cards are lost.
-    renderOrgs(true);
-    while (visibleCount < savedCount && visibleCount < filteredOrgs.length) {
-      visibleCount += 12;
-      renderOrgs(false);
+    function openCompareModal() {
+      renderCompare();
+      renderCompareModal();
+      document.getElementById('compareModal')?.classList.add('open');
+      document.body.style.overflow = 'hidden';
     }
-  }
 
-  function toggleBookmark(e, name) {
-    if (e) e.stopPropagation();
-    if (bookmarkedSet.has(name)) bookmarkedSet.delete(name);
-    else bookmarkedSet.add(name);
-    localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
-    refreshOrgGridPreservingVisibleCount();
-    renderWatchlist();
-  }
+    function closeCompareModal() {
+      document.getElementById('compareModal')?.classList.remove('open');
+      document.body.style.overflow = 'auto';
+    }
 
-  function renderWatchlist() {
-    const container = document.getElementById('watchlistContainer');
-    if (!container) return;
-    container.innerHTML = '';
-    
-    const bookmarks = Array.from(bookmarkedSet).map(name => ORGS.find(o => o.name === name)).filter(Boolean);
-    
-    if (bookmarks.length === 0) {
-      container.innerHTML = `
+    document.getElementById('compareModal')?.addEventListener('click', (e) => {
+      if (e.target.id === 'compareModal') closeCompareModal();
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key !== 'Escape') return;
+      if (document.getElementById('compareModal')?.classList.contains('open')) {
+        closeCompareModal();
+      } else if (document.getElementById('orgModal')?.classList.contains('open')) {
+        closeModal();
+      }
+    });
+
+    function refreshOrgGridPreservingVisibleCount() {
+      const savedCount = visibleCount;
+      const grid = document.getElementById('orgGrid');
+      if (!grid) return;
+      // renderOrgs(true) clears the grid and resets visibleCount to 12, rendering
+      // the first page. We then keep appending subsequent pages until we reach
+      // the count the user had previously scrolled to, so no cards are lost.
+      renderOrgs(true);
+      while (visibleCount < savedCount && visibleCount < filteredOrgs.length) {
+        visibleCount += 12;
+        renderOrgs(false);
+      }
+    }
+
+    function toggleBookmark(e, name) {
+      if (e) e.stopPropagation();
+      if (bookmarkedSet.has(name)) bookmarkedSet.delete(name);
+      else bookmarkedSet.add(name);
+      localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
+      refreshOrgGridPreservingVisibleCount();
+      renderWatchlist();
+    }
+
+    function renderWatchlist() {
+      const container = document.getElementById('watchlistContainer');
+      if (!container) return;
+      container.innerHTML = '';
+
+      const bookmarks = Array.from(bookmarkedSet).map(name => ORGS.find(o => o.name === name)).filter(Boolean);
+
+      if (bookmarks.length === 0) {
+        container.innerHTML = `
         <div class="py-12 text-center border-2 border-dashed border-zinc-200 rounded-2xl">
           <p class="text-zinc-400 italic">Your watchlist is empty. Star organizations to track them here.</p>
         </div>
       `;
-      document.getElementById('aiInsightText').textContent = 'Star organizations to get personalized contribution advice.';
-      return;
-    }
+        document.getElementById('aiInsightText').textContent = 'Star organizations to get personalized contribution advice.';
+        return;
+      }
 
-    bookmarks.forEach(org => {
-      const item = document.createElement('div');
-      item.className = 'bg-white rounded-2xl p-6 border border-zinc-100 flex flex-col sm:flex-row gap-4 items-start hover:shadow-lg transition-all animate-fade-up';
-      item.innerHTML = `
+      bookmarks.forEach(org => {
+        const item = document.createElement('div');
+        item.className = 'bg-white rounded-2xl p-6 border border-zinc-100 flex flex-col sm:flex-row gap-4 items-start hover:shadow-lg transition-all animate-fade-up';
+        item.innerHTML = `
         <div class="w-12 h-12 rounded-xl bg-orange-100 flex items-center justify-center flex-shrink-0">
           <span class="material-symbols-outlined text-orange-600">psychology</span>
         </div>
@@ -2242,273 +3029,273 @@
           </div>
         </div>
       `;
-      container.appendChild(item);
-      attachOrgCardListeners(item);
-    });
+        container.appendChild(item);
+        attachOrgCardListeners(item);
+      });
 
-    // Data-driven AI Insight
-    const allTags = bookmarks.flatMap(o => o.tags);
-    const topTag = [...new Set(allTags)].sort((a,b) => allTags.filter(t => t===b).length - allTags.filter(t => t===a).length)[0];
-    const skillFocus = topTag ? `Focus on mastering **${escapeHtml(topTag)}**` : "Start contributing to Good First Issues";
-    const safeTopTag = topTag ? escapeHtml(topTag) : null;
+      // Data-driven AI Insight
+      const allTags = bookmarks.flatMap(o => o.tags);
+      const topTag = [...new Set(allTags)].sort((a, b) => allTags.filter(t => t === b).length - allTags.filter(t => t === a).length)[0];
+      const skillFocus = topTag ? `Focus on mastering **${escapeHtml(topTag)}**` : "Start contributing to Good First Issues";
+      const safeTopTag = topTag ? escapeHtml(topTag) : null;
 
-    document.getElementById('aiInsightText').innerHTML = `
+      document.getElementById('aiInsightText').innerHTML = `
       <span class="flex items-center gap-2">
         <span class="material-symbols-outlined text-primary text-sm">sparkles</span>
         <span>Insight: Your watchlist highlights a strong interest in <strong>${safeTopTag || 'diverse stacks'}</strong>. ${skillFocus} to increase your acceptance odds for GSoC 2026.</span>
       </span>
     `;
-  }
+    }
 
-  function openModal(name) {
-    const org = ORGS.find(o => o.name === name);
-    if (!org) return;
+    function openModal(name) {
+      const org = ORGS.find(o => o.name === name);
+      if (!org) return;
 
-    document.getElementById('mHeader').innerHTML = `
+      document.getElementById('mHeader').innerHTML = `
       <span class="category-tag">${escapeHtml(String(org.cat).toUpperCase())}</span>
       <h2>${escapeHtml(org.name)}</h2>
       <p class="text-zinc-500">GSoC Partner for ${escapeHtml(String(org.years))} Years</p>
     `;
 
-    document.getElementById('mMetrics').innerHTML = `
+      document.getElementById('mMetrics').innerHTML = `
       <div class="metric-card"><p class="metric-value">${escapeHtml(String(org.years))}</p><p class="metric-label">Years In</p></div>
       <div class="metric-card"><p class="metric-value">${escapeHtml(String(org.firstYear))}</p><p class="metric-label">First Year</p></div>
       <div class="metric-card"><p class="metric-value font-mono text-sm">${escapeHtml(String(org.competition).toUpperCase())}</p><p class="metric-label">Competition</p></div>
       <div class="metric-card"><p class="metric-value font-mono text-sm">${escapeHtml(String(org.codebase).toUpperCase())}</p><p class="metric-label">Codebase</p></div>
     `;
 
-    document.getElementById('mDesc').textContent = org.desc;
-    document.getElementById('mTech').innerHTML = org.tags.map(t => `<span class="tech-tag">${escapeHtml(t)}</span>`).join('');
-    document.getElementById('mFit').innerHTML = org.fit.map(f => `<span class="fit-tag">${escapeHtml(f)}</span>`).join('');
+      document.getElementById('mDesc').textContent = org.desc;
+      document.getElementById('mTech').innerHTML = org.tags.map(t => `<span class="tech-tag">${escapeHtml(t)}</span>`).join('');
+      document.getElementById('mFit').innerHTML = org.fit.map(f => `<span class="fit-tag">${escapeHtml(f)}</span>`).join('');
 
-    // Timeline
-    let timelineHtml = '';
-    for(let y=2020; y<=2026; y++) {
-       const active = (y >= org.firstYear);
-       timelineHtml += `<span class="${y===2026?'current-year':''} ${active?'opacity-100':'opacity-30'}">${y}</span>`;
-    }
-    document.getElementById('mTimeline').innerHTML = timelineHtml;
+      // Timeline
+      let timelineHtml = '';
+      for (let y = 2020; y <= 2026; y++) {
+        const active = (y >= org.firstYear);
+        timelineHtml += `<span class="${y === 2026 ? 'current-year' : ''} ${active ? 'opacity-100' : 'opacity-30'}">${y}</span>`;
+      }
+      document.getElementById('mTimeline').innerHTML = timelineHtml;
 
-    // Sanitize and set idea/repo links
-    const ideasUrl = sanitizeHrefUrl(org.ideas);
-    const repoUrl = sanitizeHrefUrl(`https://github.com/${org.github}`);
-    const ideasBtn = document.getElementById('mIdeasBtn');
-    const repoBtn = document.getElementById('mRepoBtn');
-    if (ideasBtn) {
-      if (ideasUrl) ideasBtn.href = ideasUrl; else ideasBtn.removeAttribute('href');
-    }
-    if (repoBtn) {
-      if (repoUrl) repoBtn.href = repoUrl; else repoBtn.removeAttribute('href');
-    }
-
-// Copy link button
-const oldCopy = document.getElementById('mIdeasCopyBtn');
-if(oldCopy) oldCopy.remove();
-if(org.ideas){
-  const copyBtn = document.createElement('button');
-  copyBtn.id = 'mIdeasCopyBtn';
-  copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">content_copy</span> Copy Link';
-  copyBtn.className = 'modal-cta modal-repo-link flex items-center justify-center gap-2';
-  copyBtn.onclick = function(){
-    navigator.clipboard.writeText(org.ideas).then(()=>{
-      copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">check_circle</span> Copied!';
-      copyBtn.style.background = '#dcfce7';
-      copyBtn.style.color = '#166534';
-      setTimeout(()=>{
-        copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">content_copy</span> Copy Link';
-        copyBtn.style.background = '';
-        copyBtn.style.color = '';
-      }, 2000);
-    });
-  };
-  document.getElementById('mIdeasBtn').after(copyBtn);
-}
-    renderMentorContactSection(org);
-     
-    document.getElementById('orgModal').classList.add('open');
-    document.body.style.overflow = 'hidden';
-  }
-
-  function closeModal() {
-    document.getElementById('orgModal').classList.remove('open');
-    document.body.style.overflow = 'auto';
-  }
-
-  function openRandomOrg() {
-    const orgsToUse = filteredOrgs.length > 0 ? filteredOrgs : ORGS;
-    
-    if (!orgsToUse.length) {
-      alert('No organizations match your filters — try clearing some!');
-      return;
-    }
-
-    const randomIdx = Math.floor(Math.random() * orgsToUse.length);
-    const randomOrg = orgsToUse[randomIdx];
-    
-    openModal(randomOrg.name);
-  }
-
-  // Filters — all conditions are additive (chip + language pills + search + dropdowns compose)
-  function applyFilters() {
-    const query = document.getElementById('searchInput').value.trim().toLowerCase();
-    const categoryValue = document.getElementById('categoryFilter')?.value || 'all';
-    const cat = categoryValue === 'all' ? '' : categoryValue;
-    const comp = document.getElementById('complexityFilter').value;
-    const sort = document.getElementById('sortSelect')?.value || 'alpha';
-
-    filteredOrgs = ORGS.filter(o => {
-      const matchSearch = o.name.toLowerCase().includes(query);
-      const matchCat = !cat || o.cat === cat;
-      const matchComp = comp === 'all' || o.codebase === comp;
-      const tags = (o.tags || []).map(t => String(t).toLowerCase());
-      const matchLang = selectedLanguages.size === 0
-        || (matchAllLanguages
-          ? [...selectedLanguages].every(lang => languageMatchesSelection(tags, lang))
-          : [...selectedLanguages].some(lang => languageMatchesSelection(tags, lang)));
-
-      let matchChip = true;
-      if (activeChip === 'bookmarked')  matchChip = bookmarkedSet.has(o.name);
-      else if (activeChip === 'veterans')         matchChip = o.years >= 10;
-      else if (activeChip === 'newcomers')   matchChip = o.years <= 3;
-      else if (activeChip === 'low-competition')  matchChip = o.competition === 'chill';
-      else if (activeChip === 'high-competition') matchChip = o.competition === 'hot';
-
-      return matchSearch && matchCat && matchComp && matchLang && matchChip;
-    });
-
-    if(query){
-      filteredOrgs.sort((a,b)=>{
-        const nameA=a.name.toLowerCase();
-        const nameB=b.name.toLowerCase();
-        if(nameA===query && nameB!==query) return -1;
-        if(nameB===query && nameA!==query) return 1;
-        if(nameA.startsWith(query) && !nameB.startsWith(query)) return -1;
-        if(nameB.startsWith(query) && !nameA.startsWith(query)) return 1;
-        return applySecondarySort(a, b, sort);
-      });
-    } else {
-      filteredOrgs.sort((a, b) => applySecondarySort(a, b, sort));
-    }
-
-    renderOrgs(true);
-  }
-
-  function applySecondarySort(a, b, sortType) {
-    if(sortType==='years-desc') return b.years - a.years;
-    if(sortType==='years-asc') return a.years - b.years;
-    if(sortType==='comp-low') return ['chill','moderate','hot'].indexOf(a.competition) - ['chill','moderate','hot'].indexOf(b.competition);
-    if(sortType==='stars') return (b._gh?.stars||0) - (a._gh?.stars||0);
-    if(sortType==='gfi') return (b._gh?.gfi||0) - (a._gh?.gfi||0);
-    return a.name.localeCompare(b.name);
-  }
-
-  window.clearAllFilters = function() {
-    document.getElementById('searchInput').value = '';
-    document.getElementById('categoryFilter').value = 'all';
-    document.getElementById('complexityFilter').value = 'all';
-    if (document.getElementById('sortSelect')) document.getElementById('sortSelect').value = 'alpha';
-    const heroSearch = document.getElementById('hero-search');
-    if (heroSearch) heroSearch.value = '';
-    
-    // Reset chips
-    document.querySelectorAll('.filter-chip').forEach(chip => {
-      chip.classList.remove('bg-orange-600', 'text-white');
-      chip.classList.add('bg-surface-container-highest');
-    });
-
-    filteredOrgs = [...ORGS];
-    renderOrgs(true);
-  };
-
-  document.getElementById('searchInput').addEventListener('input', applyFilters);
-  document.getElementById('categoryFilter').addEventListener('change', applyFilters);
-  document.getElementById('complexityFilter').addEventListener('change', applyFilters);
-  document.getElementById('sortSelect')?.addEventListener('change', applyFilters);
-  document.getElementById('mentorSearchInput')?.addEventListener('input', renderMentorFinder);
-  document.getElementById('mentorChannelFilter')?.addEventListener('change', renderMentorFinder);
-  document.getElementById('matchAllLanguagesToggle')?.addEventListener('change', (e) => {
-    matchAllLanguages = e.target.checked;
-    // keep global in sync for any external code expecting `matchAllLanguages`
-    globalThis.matchAllLanguages = matchAllLanguages;
-    applyFilters();
-  });
-  document.getElementById('loadMoreBtn').addEventListener('click', () => {
-    visibleCount += 12;
-    renderOrgs(false);
-  });
-
-  // Surprise button event listener
-  document.getElementById('surpriseBtn')?.addEventListener('click', openRandomOrg);
-
-  // Hero Search Link
-  const heroSearch = document.getElementById('hero-search');
-  if (heroSearch) {
-    heroSearch.value = document.getElementById('searchInput')?.value || new URLSearchParams(location.search).get('q') || '';
-    heroSearch.addEventListener('input', (e) => {
-      document.getElementById('searchInput').value = e.target.value;
-      document.getElementById('orgs').scrollIntoView({ behavior: 'smooth' });
-      applyFilters();
-    });
-  }
-
-  // Quick-filter chips — mutually exclusive with each other, but additive with
-  // language pills, search, and dropdown filters. applyFilters() reads activeChip.
-  document.querySelectorAll('.filter-chip').forEach(chip => {
-    chip.addEventListener('click', () => {
-      const text = chip.textContent.trim().toLowerCase();
-      const isCurrentlyActive = chip.classList.contains('bg-orange-600');
-
-      // Reset all chips to inactive state
-      document.querySelectorAll('.filter-chip').forEach(c => {
-        c.classList.remove('bg-orange-600', 'text-white');
-        c.classList.add('bg-surface-container-highest');
-      });
-
-      if (!isCurrentlyActive) {
-        // Activate the clicked chip
-        chip.classList.add('bg-orange-600', 'text-white');
-        chip.classList.remove('bg-surface-container-highest');
-
-        // Map chip text → activeChip key used by applyFilters()
-        if (text.includes('bookmarked'))         activeChip = 'bookmarked';
-        else if (text.includes('veteran'))       activeChip = 'veterans';
-        else if (text.includes('newcomer'))      activeChip = 'newcomers';
-        else if (text.includes('low competition'))  activeChip = 'low-competition';
-        else if (text.includes('high competition')) activeChip = 'high-competition';
-        else if (text.includes('actively'))      activeChip = 'active';
-        else                                     activeChip = null;
-      } else {
-        // Chip was active — clicking again deactivates it
-        activeChip = null;
+      // Sanitize and set idea/repo links
+      const ideasUrl = sanitizeHrefUrl(org.ideas);
+      const repoUrl = sanitizeHrefUrl(`https://github.com/${org.github}`);
+      const ideasBtn = document.getElementById('mIdeasBtn');
+      const repoBtn = document.getElementById('mRepoBtn');
+      if (ideasBtn) {
+        if (ideasUrl) ideasBtn.href = ideasUrl; else ideasBtn.removeAttribute('href');
+      }
+      if (repoBtn) {
+        if (repoUrl) repoBtn.href = repoUrl; else repoBtn.removeAttribute('href');
       }
 
+      // Copy link button
+      const oldCopy = document.getElementById('mIdeasCopyBtn');
+      if (oldCopy) oldCopy.remove();
+      if (org.ideas) {
+        const copyBtn = document.createElement('button');
+        copyBtn.id = 'mIdeasCopyBtn';
+        copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">content_copy</span> Copy Link';
+        copyBtn.className = 'modal-cta modal-repo-link flex items-center justify-center gap-2';
+        copyBtn.onclick = function () {
+          navigator.clipboard.writeText(org.ideas).then(() => {
+            copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">check_circle</span> Copied!';
+            copyBtn.style.background = '#dcfce7';
+            copyBtn.style.color = '#166534';
+            setTimeout(() => {
+              copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">content_copy</span> Copy Link';
+              copyBtn.style.background = '';
+              copyBtn.style.color = '';
+            }, 2000);
+          });
+        };
+        document.getElementById('mIdeasBtn').after(copyBtn);
+      }
+      renderMentorContactSection(org);
+
+      document.getElementById('orgModal').classList.add('open');
+      document.body.style.overflow = 'hidden';
+    }
+
+    function closeModal() {
+      document.getElementById('orgModal').classList.remove('open');
+      document.body.style.overflow = 'auto';
+    }
+
+    function openRandomOrg() {
+      const orgsToUse = filteredOrgs.length > 0 ? filteredOrgs : ORGS;
+
+      if (!orgsToUse.length) {
+        alert('No organizations match your filters — try clearing some!');
+        return;
+      }
+
+      const randomIdx = Math.floor(Math.random() * orgsToUse.length);
+      const randomOrg = orgsToUse[randomIdx];
+
+      openModal(randomOrg.name);
+    }
+
+    // Filters — all conditions are additive (chip + language pills + search + dropdowns compose)
+    function applyFilters() {
+      const query = document.getElementById('searchInput').value.trim().toLowerCase();
+      const categoryValue = document.getElementById('categoryFilter')?.value || 'all';
+      const cat = categoryValue === 'all' ? '' : categoryValue;
+      const comp = document.getElementById('complexityFilter').value;
+      const sort = document.getElementById('sortSelect')?.value || 'alpha';
+
+      filteredOrgs = ORGS.filter(o => {
+        const matchSearch = o.name.toLowerCase().includes(query);
+        const matchCat = !cat || o.cat === cat;
+        const matchComp = comp === 'all' || o.codebase === comp;
+        const tags = (o.tags || []).map(t => String(t).toLowerCase());
+        const matchLang = selectedLanguages.size === 0
+          || (matchAllLanguages
+            ? [...selectedLanguages].every(lang => languageMatchesSelection(tags, lang))
+            : [...selectedLanguages].some(lang => languageMatchesSelection(tags, lang)));
+
+        let matchChip = true;
+        if (activeChip === 'bookmarked') matchChip = bookmarkedSet.has(o.name);
+        else if (activeChip === 'veterans') matchChip = o.years >= 10;
+        else if (activeChip === 'newcomers') matchChip = o.years <= 3;
+        else if (activeChip === 'low-competition') matchChip = o.competition === 'chill';
+        else if (activeChip === 'high-competition') matchChip = o.competition === 'hot';
+
+        return matchSearch && matchCat && matchComp && matchLang && matchChip;
+      });
+
+      if (query) {
+        filteredOrgs.sort((a, b) => {
+          const nameA = a.name.toLowerCase();
+          const nameB = b.name.toLowerCase();
+          if (nameA === query && nameB !== query) return -1;
+          if (nameB === query && nameA !== query) return 1;
+          if (nameA.startsWith(query) && !nameB.startsWith(query)) return -1;
+          if (nameB.startsWith(query) && !nameA.startsWith(query)) return 1;
+          return applySecondarySort(a, b, sort);
+        });
+      } else {
+        filteredOrgs.sort((a, b) => applySecondarySort(a, b, sort));
+      }
+
+      renderOrgs(true);
+    }
+
+    function applySecondarySort(a, b, sortType) {
+      if (sortType === 'years-desc') return b.years - a.years;
+      if (sortType === 'years-asc') return a.years - b.years;
+      if (sortType === 'comp-low') return ['chill', 'moderate', 'hot'].indexOf(a.competition) - ['chill', 'moderate', 'hot'].indexOf(b.competition);
+      if (sortType === 'stars') return (b._gh?.stars || 0) - (a._gh?.stars || 0);
+      if (sortType === 'gfi') return (b._gh?.gfi || 0) - (a._gh?.gfi || 0);
+      return a.name.localeCompare(b.name);
+    }
+
+    window.clearAllFilters = function () {
+      document.getElementById('searchInput').value = '';
+      document.getElementById('categoryFilter').value = 'all';
+      document.getElementById('complexityFilter').value = 'all';
+      if (document.getElementById('sortSelect')) document.getElementById('sortSelect').value = 'alpha';
+      const heroSearch = document.getElementById('hero-search');
+      if (heroSearch) heroSearch.value = '';
+
+      // Reset chips
+      document.querySelectorAll('.filter-chip').forEach(chip => {
+        chip.classList.remove('bg-orange-600', 'text-white');
+        chip.classList.add('bg-surface-container-highest');
+      });
+
+      filteredOrgs = [...ORGS];
+      renderOrgs(true);
+    };
+
+    document.getElementById('searchInput').addEventListener('input', applyFilters);
+    document.getElementById('categoryFilter').addEventListener('change', applyFilters);
+    document.getElementById('complexityFilter').addEventListener('change', applyFilters);
+    document.getElementById('sortSelect')?.addEventListener('change', applyFilters);
+    document.getElementById('mentorSearchInput')?.addEventListener('input', renderMentorFinder);
+    document.getElementById('mentorChannelFilter')?.addEventListener('change', renderMentorFinder);
+    document.getElementById('matchAllLanguagesToggle')?.addEventListener('change', (e) => {
+      matchAllLanguages = e.target.checked;
+      // keep global in sync for any external code expecting `matchAllLanguages`
+      globalThis.matchAllLanguages = matchAllLanguages;
       applyFilters();
     });
-  });
+    document.getElementById('loadMoreBtn').addEventListener('click', () => {
+      visibleCount += 12;
+      renderOrgs(false);
+    });
 
-  function buildGfiSearchUrl(github) {
-    const query = github.includes('/')
-      ? `repo:${github} is:issue is:open label:\"good first issue\"`
-      : `user:${github} is:issue is:open label:\"good first issue\"`;
-    return `https://github.com/issues?q=${encodeURIComponent(query)}`;
-  }
+    // Surprise button event listener
+    document.getElementById('surpriseBtn')?.addEventListener('click', openRandomOrg);
 
-  function renderFallbackOrgSearchCards(container) {
-    const orgsWithGithub = ORGS.filter(o => typeof o.github === 'string' && o.github.trim());
-    container.innerHTML = '';
+    // Hero Search Link
+    const heroSearch = document.getElementById('hero-search');
+    if (heroSearch) {
+      heroSearch.value = document.getElementById('searchInput')?.value || new URLSearchParams(location.search).get('q') || '';
+      heroSearch.addEventListener('input', (e) => {
+        document.getElementById('searchInput').value = e.target.value;
+        document.getElementById('orgs').scrollIntoView({ behavior: 'smooth' });
+        applyFilters();
+      });
+    }
 
-    const notice = document.createElement('p');
-    notice.className = 'col-span-full text-sm text-zinc-500';
-    notice.textContent = 'Live pre-fetched issues are still syncing. Browse open Good First Issues for all organizations below.';
-    container.appendChild(notice);
+    // Quick-filter chips — mutually exclusive with each other, but additive with
+    // language pills, search, and dropdown filters. applyFilters() reads activeChip.
+    document.querySelectorAll('.filter-chip').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const text = chip.textContent.trim().toLowerCase();
+        const isCurrentlyActive = chip.classList.contains('bg-orange-600');
 
-    orgsWithGithub.forEach(org => {
-      const card = document.createElement('a');
-      card.href = buildGfiSearchUrl(org.github.trim());
-      card.target = '_blank';
-      card.rel = 'noopener noreferrer';
-      card.className = 'bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer block';
-      card.innerHTML = `
+        // Reset all chips to inactive state
+        document.querySelectorAll('.filter-chip').forEach(c => {
+          c.classList.remove('bg-orange-600', 'text-white');
+          c.classList.add('bg-surface-container-highest');
+        });
+
+        if (!isCurrentlyActive) {
+          // Activate the clicked chip
+          chip.classList.add('bg-orange-600', 'text-white');
+          chip.classList.remove('bg-surface-container-highest');
+
+          // Map chip text → activeChip key used by applyFilters()
+          if (text.includes('bookmarked')) activeChip = 'bookmarked';
+          else if (text.includes('veteran')) activeChip = 'veterans';
+          else if (text.includes('newcomer')) activeChip = 'newcomers';
+          else if (text.includes('low competition')) activeChip = 'low-competition';
+          else if (text.includes('high competition')) activeChip = 'high-competition';
+          else if (text.includes('actively')) activeChip = 'active';
+          else activeChip = null;
+        } else {
+          // Chip was active — clicking again deactivates it
+          activeChip = null;
+        }
+
+        applyFilters();
+      });
+    });
+
+    function buildGfiSearchUrl(github) {
+      const query = github.includes('/')
+        ? `repo:${github} is:issue is:open label:\"good first issue\"`
+        : `user:${github} is:issue is:open label:\"good first issue\"`;
+      return `https://github.com/issues?q=${encodeURIComponent(query)}`;
+    }
+
+    function renderFallbackOrgSearchCards(container) {
+      const orgsWithGithub = ORGS.filter(o => typeof o.github === 'string' && o.github.trim());
+      container.innerHTML = '';
+
+      const notice = document.createElement('p');
+      notice.className = 'col-span-full text-sm text-zinc-500';
+      notice.textContent = 'Live pre-fetched issues are still syncing. Browse open Good First Issues for all organizations below.';
+      container.appendChild(notice);
+
+      orgsWithGithub.forEach(org => {
+        const card = document.createElement('a');
+        card.href = buildGfiSearchUrl(org.github.trim());
+        card.target = '_blank';
+        card.rel = 'noopener noreferrer';
+        card.className = 'bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer block';
+        card.innerHTML = `
         <div class="flex items-start justify-between mb-3">
           <h4 class="font-bold text-sm group-hover:text-primary transition-colors line-clamp-1">Browse open Good First Issues</h4>
           <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
@@ -2519,45 +3306,45 @@ if(org.ideas){
           <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
         </div>
       `;
-      container.appendChild(card);
-    });
-  }
+        container.appendChild(card);
+      });
+    }
 
-  // Dynamic GFIs
-  async function renderGoodFirstIssues() {
-    try {
-      const res = await fetch('/data/issues.json?v=' + Date.now());
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      const container = document.querySelector('#issues .grid');
-      if (!container) return;
-      const issues = Array.isArray(data.issues) ? data.issues : [];
-      const lastUpdatedEl = document.getElementById('issuesLastUpdated');
-      if (lastUpdatedEl) {
-        if (data.updated_at) {
-          const mins = Math.max(1, Math.floor((Date.now() - new Date(data.updated_at).getTime()) / 60000));
-          const relative = mins < 60 ? `${mins} min ago` : `${Math.floor(mins / 60)} hours ago`;
-          lastUpdatedEl.textContent = `Last updated: ${relative}`;
-        } else {
-          lastUpdatedEl.textContent = 'Last updated: unavailable';
+    // Dynamic GFIs
+    async function renderGoodFirstIssues() {
+      try {
+        const res = await fetch('/data/issues.json?v=' + Date.now());
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        const container = document.querySelector('#issues .grid');
+        if (!container) return;
+        const issues = Array.isArray(data.issues) ? data.issues : [];
+        const lastUpdatedEl = document.getElementById('issuesLastUpdated');
+        if (lastUpdatedEl) {
+          if (data.updated_at) {
+            const mins = Math.max(1, Math.floor((Date.now() - new Date(data.updated_at).getTime()) / 60000));
+            const relative = mins < 60 ? `${mins} min ago` : `${Math.floor(mins / 60)} hours ago`;
+            lastUpdatedEl.textContent = `Last updated: ${relative}`;
+          } else {
+            lastUpdatedEl.textContent = 'Last updated: unavailable';
+          }
         }
-      }
 
-      if (!issues.length) {
-        renderFallbackOrgSearchCards(container);
-        return;
-      }
+        if (!issues.length) {
+          renderFallbackOrgSearchCards(container);
+          return;
+        }
 
-      container.innerHTML = '';
-      issues.slice(0, 6).forEach(issue => {
-        const card = document.createElement('div');
-        card.className = 'bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer';
-        const safeUrl = sanitizeHrefUrl(issue.url);
-        if (safeUrl) card.onclick = () => window.open(safeUrl, '_blank');
-        const safeRepo = escapeHtml(issue.repo || '');
-        const safeTitle = escapeHtml(issue.title || '');
-        const labelsHtml = (issue.labels || []).slice(0,2).map(l => `<span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">${escapeHtml(l)}</span>`).join('');
-        card.innerHTML = `
+        container.innerHTML = '';
+        issues.slice(0, 6).forEach(issue => {
+          const card = document.createElement('div');
+          card.className = 'bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer';
+          const safeUrl = sanitizeHrefUrl(issue.url);
+          if (safeUrl) card.onclick = () => window.open(safeUrl, '_blank');
+          const safeRepo = escapeHtml(issue.repo || '');
+          const safeTitle = escapeHtml(issue.title || '');
+          const labelsHtml = (issue.labels || []).slice(0, 2).map(l => `<span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">${escapeHtml(l)}</span>`).join('');
+          card.innerHTML = `
           <div class="flex items-start justify-between mb-3">
             <h4 class="font-bold text-sm group-hover:text-primary transition-colors line-clamp-1">${safeTitle}</h4>
             <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
@@ -2568,214 +3355,215 @@ if(org.ideas){
             <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">${escapeHtml(String(issue.comments || 0))} comments</span>
           </div>
         `;
-        container.appendChild(card);
-      });
-    } catch (e) {
-      console.error("GFI render failed:", e);
-      const container = document.querySelector('#issues .grid');
-      if (container) {
-        container.innerHTML = `
+          container.appendChild(card);
+        });
+      } catch (e) {
+        console.error("GFI render failed:", e);
+        const container = document.querySelector('#issues .grid');
+        if (container) {
+          container.innerHTML = `
           <div class="col-span-full bg-white rounded-xl p-8 border border-zinc-100 text-center">
             <p class="text-sm font-bold text-zinc-900 mb-2">Unable to load pre-fetched issues</p>
             <p class="text-sm text-zinc-600 max-w-xl mx-auto">Cached issue data could not be retrieved at this time. Please refresh the page or try again later.</p>
           </div>`;
-      }
-      const lastUpdatedEl = document.getElementById('issuesLastUpdated');
-      if (lastUpdatedEl) {
-        lastUpdatedEl.textContent = 'Last updated: unavailable';
+        }
+        const lastUpdatedEl = document.getElementById('issuesLastUpdated');
+        if (lastUpdatedEl) {
+          lastUpdatedEl.textContent = 'Last updated: unavailable';
+        }
       }
     }
-  }
 
-  // Live GitHub Stats Mock/Fetch
-  async function fetchStats() {
-    const btn = document.getElementById('mFetchBtn');
-    const orgName = document.querySelector('#mHeader h2').textContent;
-    const org = ORGS.find(o => o.name === orgName);
-    if (!org) return;
+    // Live GitHub Stats Mock/Fetch
+    async function fetchStats() {
+      const btn = document.getElementById('mFetchBtn');
+      const orgName = document.querySelector('#mHeader h2').textContent;
+      const org = ORGS.find(o => o.name === orgName);
+      if (!org) return;
 
-    btn.textContent = 'Fetching...';
-    btn.disabled = true;
+      btn.textContent = 'Fetching...';
+      btn.disabled = true;
 
-    try {
-      // Simulate real fetch delay
-      await new Promise(r => setTimeout(r, 1200));
-      
-      // Since no token, we simulate random but realistic growth
-      const stars = (Math.random() * 5000 + 1000).toFixed(0);
-      const forks = (stars * 0.2).toFixed(0);
-      const issues = (Math.random() * 50 + 10).toFixed(0);
-      
-      document.getElementById('mStars').textContent = `${(stars/1000).toFixed(1)}k`;
-      document.getElementById('mForks').textContent = forks;
-      document.getElementById('mIssues').textContent = issues;
-      document.getElementById('mActivity').textContent = 'High';
-      document.getElementById('mActivity').className = 'gh-stat-item text-green-400';
-      
-      btn.textContent = 'Stats Updated!';
-    } catch (e) {
-      btn.textContent = 'Error';
-    } finally {
-      setTimeout(() => {
-        btn.textContent = 'Fetch Live Stats';
-        btn.disabled = false;
-      }, 3000);
+      try {
+        // Simulate real fetch delay
+        await new Promise(r => setTimeout(r, 1200));
+
+        // Since no token, we simulate random but realistic growth
+        const stars = (Math.random() * 5000 + 1000).toFixed(0);
+        const forks = (stars * 0.2).toFixed(0);
+        const issues = (Math.random() * 50 + 10).toFixed(0);
+
+        document.getElementById('mStars').textContent = `${(stars / 1000).toFixed(1)}k`;
+        document.getElementById('mForks').textContent = forks;
+        document.getElementById('mIssues').textContent = issues;
+        document.getElementById('mActivity').textContent = 'High';
+        document.getElementById('mActivity').className = 'gh-stat-item text-green-400';
+
+        btn.textContent = 'Stats Updated!';
+      } catch (e) {
+        btn.textContent = 'Error';
+      } finally {
+        setTimeout(() => {
+          btn.textContent = 'Fetch Live Stats';
+          btn.disabled = false;
+        }, 3000);
+      }
     }
-  }
 
-  document.getElementById('mFetchBtn').addEventListener('click', fetchStats);
+    document.getElementById('mFetchBtn').addEventListener('click', fetchStats);
 
-  // Initialize
-  updateLanguageModeHint();
-  renderTimeline();        // populate #timeline-milestones on first load
-  updateCountdown();
-  setInterval(updateCountdown, 60000);
-  renderSelectedLanguages();
-  renderOrgs();
-  renderWatchlist();
-  loadMentorData();
-  renderGoodFirstIssues();
-  renderCompare();
-  const helpModal = document.getElementById('helpModal');
-const helpBtn = document.getElementById('helpBtn');
+    // Initialize
+    updateLanguageModeHint();
+    renderTimeline();        // populate #timeline-milestones on first load
+    updateCountdown();
+    setInterval(updateCountdown, 60000);
+    renderSelectedLanguages();
+    renderOrgs();
+    renderWatchlist();
+    loadMentorData();
+    renderGoodFirstIssues();
+    renderCompare();
+    const helpModal = document.getElementById('helpModal');
+    const helpBtn = document.getElementById('helpBtn');
 
-function openHelpModal() {
-  helpModal.classList.add('open');
-}
+    function openHelpModal() {
+      helpModal.classList.add('open');
+    }
 
-function closeHelpModal() {
-  helpModal.classList.remove('open');
-}
+    function closeHelpModal() {
+      helpModal.classList.remove('open');
+    }
 
-helpBtn.addEventListener('click', openHelpModal);
+    helpBtn.addEventListener('click', openHelpModal);
 
-document.addEventListener('keydown', (e) => {
+    document.addEventListener('keydown', (e) => {
 
-  if (e.key === '?') {
-    openHelpModal();
-  }
+      if (e.key === '?') {
+        openHelpModal();
+      }
 
-  if (e.key === 'Escape') {
-    closeHelpModal();
-  }
+      if (e.key === 'Escape') {
+        closeHelpModal();
+      }
 
-});
-  // Export helpers to global scope
-  globalThis.toggleCompare = toggleCompare;
-  globalThis.toggleBookmark = toggleBookmark;
-  globalThis.openModal = openModal;
-</script>
-
-<!-- Vercel Speed Insights -->
-<script type="module" src="agent/scripts/speed-insights.js"></script>
-<script>
-  if ('serviceWorker' in navigator) {
-    window.addEventListener('load', () => {
-      navigator.serviceWorker.register('sw.js').catch(err => console.log('SW error:', err));
     });
-  }
-</script>
+    // Export helpers to global scope
+    globalThis.toggleCompare = toggleCompare;
+    globalThis.toggleBookmark = toggleBookmark;
+    globalThis.openModal = openModal;
+  </script>
 
-<div class="modal-bg" id="helpModal">
-  <div class="modal">
-    
-    <button class="close-btn" onclick="closeHelpModal()">
-      <span class="material-symbols-outlined">close</span>
-    </button>
+  <!-- Vercel Speed Insights -->
+  <script type="module" src="agent/scripts/speed-insights.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js').catch(err => console.log('SW error:', err));
+      });
+    }
+  </script>
 
-    <div class="modal-header">
-      <h2>Keyboard Shortcuts</h2>
-      <p>Quick shortcuts for navigation</p>
-    </div>
+  <div class="modal-bg" id="helpModal">
+    <div class="modal">
 
-    <div class="modal-body">
-      <div class="section-title">Keyboard Shortcuts</div>
+      <button class="close-btn" onclick="closeHelpModal()">
+        <span class="material-symbols-outlined">close</span>
+      </button>
 
-<table class="w-full text-sm">
-  <thead>
-    <tr class="border-b text-left">
-      <th class="py-2">Key</th>
-      <th class="py-2">Action</th>
-    </tr>
-  </thead>
+      <div class="modal-header">
+        <h2>Keyboard Shortcuts</h2>
+        <p>Quick shortcuts for navigation</p>
+      </div>
 
-  <tbody>
-    <tr>
-      <td class="py-2">↑ ↓ ← →</td>
-      <td class="py-2">Move focus between cards</td>
-    </tr>
+      <div class="modal-body">
+        <div class="section-title">Keyboard Shortcuts</div>
 
-    <tr>
-      <td class="py-2">Enter</td>
-      <td class="py-2">Open focused card</td>
-    </tr>
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b text-left">
+              <th class="py-2">Key</th>
+              <th class="py-2">Action</th>
+            </tr>
+          </thead>
 
-    <tr>
-      <td class="py-2">C</td>
-      <td class="py-2">Toggle compare</td>
-    </tr>
+          <tbody>
+            <tr>
+              <td class="py-2">↑ ↓ ← →</td>
+              <td class="py-2">Move focus between cards</td>
+            </tr>
 
-    <tr>
-      <td class="py-2">Esc</td>
-      <td class="py-2">Close panel</td>
-    </tr>
+            <tr>
+              <td class="py-2">Enter</td>
+              <td class="py-2">Open focused card</td>
+            </tr>
 
-    <tr>
-      <td class="py-2">?</td>
-      <td class="py-2">Toggle help dialog</td>
-    </tr>
-  </tbody>
-</table>
+            <tr>
+              <td class="py-2">C</td>
+              <td class="py-2">Toggle compare</td>
+            </tr>
 
-       
+            <tr>
+              <td class="py-2">Esc</td>
+              <td class="py-2">Close panel</td>
+            </tr>
+
+            <tr>
+              <td class="py-2">?</td>
+              <td class="py-2">Toggle help dialog</td>
+            </tr>
+          </tbody>
+        </table>
+
+
 
       </div>
     </div>
 
   </div>
 
-<script>
-document.addEventListener('DOMContentLoaded', () => {
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
 
-  const helpModal = document.getElementById('helpModal');
-  const helpBtn = document.getElementById('helpBtn');
+      const helpModal = document.getElementById('helpModal');
+      const helpBtn = document.getElementById('helpBtn');
 
-  function openHelpModal() {
-    if (helpModal) {
-      helpModal.classList.add('open');
-    }
-  }
+      function openHelpModal() {
+        if (helpModal) {
+          helpModal.classList.add('open');
+        }
+      }
 
-  function closeHelpModal() {
-    if (helpModal) {
-      helpModal.classList.remove('open');
-    }
-  }
+      function closeHelpModal() {
+        if (helpModal) {
+          helpModal.classList.remove('open');
+        }
+      }
 
-  if (helpBtn) {
-    helpBtn.addEventListener('click', openHelpModal);
-  }
+      if (helpBtn) {
+        helpBtn.addEventListener('click', openHelpModal);
+      }
 
-  document.addEventListener('keydown', (e) => {
+      document.addEventListener('keydown', (e) => {
 
-    if (e.key === '?') {
-      openHelpModal();
-    }
+        if (e.key === '?') {
+          openHelpModal();
+        }
 
-    if (e.key === 'Escape') {
-      closeHelpModal();
-    }
+        if (e.key === 'Escape') {
+          closeHelpModal();
+        }
 
-  });
+      });
 
-  window.closeHelpModal = closeHelpModal;
+      window.closeHelpModal = closeHelpModal;
 
-});
-</script>
-<script src="src/js/githubAnalyzer.js"></script>
-<script src="src/js/skillExtractor.js"></script>
-<script src="src/js/recommender.js"></script>
-<script src="src/js/recommendation-ui.js"></script>
+    });
+  </script>
+  <script src="src/js/githubAnalyzer.js"></script>
+  <script src="src/js/skillExtractor.js"></script>
+  <script src="src/js/recommender.js"></script>
+  <script src="src/js/recommendation-ui.js"></script>
 
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -41,23 +41,13 @@
     }
   </script>
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-  <link
-    href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap"
-    rel="stylesheet" />
   <!--Fix: Preload material symbol before render-->
   <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=block"
     as="style" onload="this.rel='stylesheet'" />
   <noscript>
     <link rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap" />
-  </noscript>
-  <link rel="preload"
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=block"
-    as="style" onload="this.rel='stylesheet'" />
-  <noscript>
-    <link rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=block" />
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=block" />
   </noscript>
   <script>
     // Theme restoration - runs early to prevent FOUC

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4,7 +4,7 @@
 // ══════════════════════════════════════════════
 // THEME
 // ══════════════════════════════════════════════
-(function(){
+(function () {
   const saved = localStorage.getItem('theme') || 'light';
   document.documentElement.classList.toggle('dark', saved === 'dark');
   updateThemeIcon();
@@ -20,15 +20,15 @@ function escapeHtml(value) {
     .replaceAll("'", '&#39;');
 }
 
-globalThis.toggleTheme = function(){
+globalThis.toggleTheme = function () {
   const isDark = document.documentElement.classList.toggle('dark');
   localStorage.setItem('theme', isDark ? 'dark' : 'light');
   updateThemeIcon();
 };
 
-function updateThemeIcon(){
+function updateThemeIcon() {
   const icon = document.querySelector('#themeToggleBtn .material-symbols-outlined');
-  if(icon){
+  if (icon) {
     const isDark = document.documentElement.classList.contains('dark');
     icon.textContent = isDark ? 'light_mode' : 'dark_mode';
   }
@@ -37,77 +37,80 @@ function updateThemeIcon(){
 // ══════════════════════════════════════════════
 // COUNTDOWN
 // ══════════════════════════════════════════════
-const OPEN_DATE=new Date('2026-03-16T00:00:00Z');
-const CLOSE_DATE=new Date('2026-04-08T18:00:00Z');
-function updateCountdown(){
-  const now=Date.now();
-  const banner=document.getElementById('countdownBanner');
-  const sub=document.getElementById('countdownSub');
-  let target=OPEN_DATE.getTime();
-  let label='📅 GSoC 2026 Applications Open In';
-  let subText='Until March 16, 2026';
-  if(now>=OPEN_DATE.getTime()&&now<CLOSE_DATE.getTime()){
-    target=CLOSE_DATE.getTime();
-    label='🚀 Applications Are Open — Closes In';
-    subText='Until April 8, 2026';
-    banner.style.background='linear-gradient(135deg,rgba(0,135,90,.07),rgba(0,135,90,.12))';
-    banner.style.borderBottomColor='rgba(0,135,90,.3)';
-    banner.style.color='var(--green)';
-  } else if(now>=CLOSE_DATE.getTime()){
-    banner.innerHTML='<span>🎉 GSoC 2026 applications have closed. Stay tuned for accepted orgs!</span>';
-    clearInterval(cdTimer);return;
+const OPEN_DATE = new Date('2026-03-16T00:00:00Z');
+const CLOSE_DATE = new Date('2026-04-08T18:00:00Z');
+function updateCountdown() {
+  const now = Date.now();
+  const banner = document.getElementById('countdownBanner');
+  const sub = document.getElementById('countdownSub');
+  let target = OPEN_DATE.getTime();
+  let label = '📅 GSoC 2026 Applications Open In';
+  let subText = 'Until March 16, 2026';
+  if (now >= OPEN_DATE.getTime() && now < CLOSE_DATE.getTime()) {
+    target = CLOSE_DATE.getTime();
+    label = '🚀 Applications Are Open — Closes In';
+    subText = 'Until April 8, 2026';
+    banner.style.background = 'linear-gradient(135deg,rgba(0,135,90,.07),rgba(0,135,90,.12))';
+    banner.style.borderBottomColor = 'rgba(0,135,90,.3)';
+    banner.style.color = 'var(--green)';
+  } else if (now >= CLOSE_DATE.getTime()) {
+    banner.innerHTML = '<span>🎉 GSoC 2026 applications have closed. Stay tuned for accepted orgs!</span>';
+    clearInterval(cdTimer); return;
   }
-  const diff=Math.max(0,target-now);
-  const d=Math.floor(diff/86400000);
-  const h=Math.floor((diff%86400000)/3600000);
-  const m=Math.floor((diff%3600000)/60000);
-  const s=Math.floor((diff%60000)/1000);
-  document.getElementById('cdDays').textContent=String(d).padStart(2,'0');
-  document.getElementById('cdHours').textContent=String(h).padStart(2,'0');
-  document.getElementById('cdMins').textContent=String(m).padStart(2,'0');
-  document.getElementById('cdSecs').textContent=String(s).padStart(2,'0');
-  sub.textContent=subText;
-  banner.querySelector('.countdown-label').textContent=label;
+  const diff = Math.max(0, target - now);
+  const d = Math.floor(diff / 86400000);
+  const h = Math.floor((diff % 86400000) / 3600000);
+  const m = Math.floor((diff % 3600000) / 60000);
+  const s = Math.floor((diff % 60000) / 1000);
+  document.getElementById('cdDays').textContent = String(d).padStart(2, '0');
+  document.getElementById('cdHours').textContent = String(h).padStart(2, '0');
+  document.getElementById('cdMins').textContent = String(m).padStart(2, '0');
+  document.getElementById('cdSecs').textContent = String(s).padStart(2, '0');
+  sub.textContent = subText;
+  banner.querySelector('.countdown-label').textContent = label;
 }
 updateCountdown();
-const cdTimer=setInterval(updateCountdown,1000);
+const cdTimer = setInterval(updateCountdown, 1000);
 
 // ══════════════════════════════════════════════
 // ANALYTICS ENGINE
 // ══════════════════════════════════════════════
-const AN={
-  g(k,d){try{return JSON.parse(localStorage.getItem('gaf_'+k))??d;}catch{return d;}},
-  s(k,v){
-    try{
-      localStorage.setItem('gaf_'+k,JSON.stringify(v));
-    }catch(err){
-      console.warn('Analytics storage write failed for key:',k,err);
+const AN = {
+  g(k, d) { try { return JSON.parse(localStorage.getItem('gaf_' + k)) ?? d; } catch { return d; } },
+  s(k, v) {
+    try {
+      localStorage.setItem('gaf_' + k, JSON.stringify(v));
+    } catch (err) {
+      console.warn('Analytics storage write failed for key:', k, err);
     }
   },
-  inc(k){this.s(k,(this.g(k,0)+1));},
-  push(k,v,max=20){const a=this.g(k,[]);a.unshift(v);this.s(k,a.slice(0,max));},
-  today(){return new Date().toISOString().slice(0,10);},
-  trackVisit(){
+  inc(k) { this.s(k, (this.g(k, 0) + 1)); },
+  push(k, v, max = 20) { const a = this.g(k, []); a.unshift(v); this.s(k, a.slice(0, max)); },
+  today() { return new Date().toISOString().slice(0, 10); },
+  trackVisit() {
     this.inc('total');
-    const td=this.today(),daily=this.g('daily',{});
-    daily[td]=(daily[td]||0)+1;this.s('daily',daily);
-    if(!sessionStorage.getItem('gaf_s'))sessionStorage.setItem('gaf_s',Date.now());
+    const td = this.today(), daily = this.g('daily', {});
+    daily[td] = (daily[td] || 0) + 1; this.s('daily', daily);
+    if (!sessionStorage.getItem('gaf_s')) sessionStorage.setItem('gaf_s', Date.now());
   },
-  trackSearch(t){if(t.length>1){this.inc('searches');this.push('sterms',t.toLowerCase().trim());}},
-  trackCat(c){if(c){this.inc('filters');const cf=this.g('cats',{});cf[c]=(cf[c]||0)+1;this.s('cats',cf);}},
-  trackOrg(n){this.inc('views');const oc=this.g('orgs',{});oc[n]=(oc[n]||0)+1;this.s('orgs',oc);},
-  todayVisits(){return this.g('daily',{})[this.today()]||0;},
-  sessionTime(){
-    const s=sessionStorage.getItem('gaf_s');if(!s)return'—';
-    const sec=Math.floor((Date.now()-parseInt(s))/1000);
-    return sec<60?sec+'s':Math.floor(sec/60)+'m'+(sec%60)+'s';
+  trackSearch(t) { if (t.length > 1) { this.inc('searches'); this.push('sterms', t.toLowerCase().trim()); } },
+  trackCat(c) { if (c) { this.inc('filters'); const cf = this.g('cats', {}); cf[c] = (cf[c] || 0) + 1; this.s('cats', cf); } },
+  trackOrg(n) { this.inc('views'); const oc = this.g('orgs', {}); oc[n] = (oc[n] || 0) + 1; this.s('orgs', oc); },
+  todayVisits() { return this.g('daily', {})[this.today()] || 0; },
+  sessionTime() {
+    const s = sessionStorage.getItem('gaf_s'); if (!s) return '—';
+    const sec = Math.floor((Date.now() - parseInt(s)) / 1000);
+    return sec < 60 ? sec + 's' : Math.floor(sec / 60) + 'm' + (sec % 60) + 's';
   },
-  topCats(){return Object.entries(this.g('cats',{})).sort((a,b)=>b[1]-a[1]).slice(0,6);},
-  topOrgs(){return Object.entries(this.g('orgs',{})).sort((a,b)=>b[1]-a[1]).slice(0,5);},
-  topTerms(){const f={};this.g('sterms',[]).forEach(t=>{f[t]=(f[t]||0)+1;});return Object.entries(f).sort((a,b)=>b[1]-a[1]).slice(0,12);}
+  topCats() { return Object.entries(this.g('cats', {})).sort((a, b) => b[1] - a[1]).slice(0, 6); },
+  topOrgs() { return Object.entries(this.g('orgs', {})).sort((a, b) => b[1] - a[1]).slice(0, 5); },
+  topTerms() { const f = {}; this.g('sterms', []).forEach(t => { f[t] = (f[t] || 0) + 1; }); return Object.entries(f).sort((a, b) => b[1] - a[1]).slice(0, 12); }
 };
 AN.trackVisit();
-
+//Fix Add fonts loaded class once font is ready
+document.fonts.ready.then(() => {
+  document.documentElement.classList.add('fonts-loaded');
+});
 // ══════════════════════════════════════════════
 // URL VALIDATION & SANITIZATION
 // ══════════════════════════════════════════════
@@ -124,25 +127,25 @@ function validateIdeasUrl(ideasUrl) {
   if (!ideasUrl || !ideasUrl.trim()) {
     return null;
   }
-  
+
   try {
     let url = ideasUrl.trim();
-    
+
     // Prepend https:// only if no protocol scheme is present
     // This prevents converting malicious URLs like javascript:alert(1) to https://javascript:alert(1)
     if (!url.includes('://')) {
       url = 'https://' + url;
     }
-    
+
     // Parse and validate URL
     const urlObj = new URL(url);
-    
+
     // Security: Only allow http and https protocols
     // This prevents javascript:, data:, file:, and other potentially dangerous schemes
     if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
       return url;
     }
-    
+
     console.warn('Rejected non-HTTP(S) URL:', ideasUrl);
     return null;
   } catch (e) {
@@ -155,20 +158,20 @@ function validateIdeasUrl(ideasUrl) {
 // ══════════════════════════════════════════════
 // TRENDING
 // ══════════════════════════════════════════════
-function renderTrending(){
-  const top=AN.topOrgs();
-  const sec=document.getElementById('trendingSection');
-  const scroll=document.getElementById('trendingScroll');
-  if(!top.length){sec.style.display='none';return;}
-  sec.style.display='block';
-  scroll.innerHTML=top.map(([name,views],i)=>{
-    const o=ORGS.find(x=>x.name===name);
-    if(!o)return'';
-    return`<div class="trend-card" onclick="openModal(${ORGS.indexOf(o)})">
-      <div class="trend-rank">${escapeHtml(String(i+1))}</div>
+function renderTrending() {
+  const top = AN.topOrgs();
+  const sec = document.getElementById('trendingSection');
+  const scroll = document.getElementById('trendingScroll');
+  if (!top.length) { sec.style.display = 'none'; return; }
+  sec.style.display = 'block';
+  scroll.innerHTML = top.map(([name, views], i) => {
+    const o = ORGS.find(x => x.name === name);
+    if (!o) return '';
+    return `<div class="trend-card" onclick="openModal(${ORGS.indexOf(o)})">
+      <div class="trend-rank">${escapeHtml(String(i + 1))}</div>
       <div class="trend-info">
         <div class="trend-name">${escapeHtml(name)}</div>
-        <div class="trend-views">${escapeHtml(String(views))} view${views!==1?'s':''} · ${escapeHtml(catLabel(o.cat))}</div>
+        <div class="trend-views">${escapeHtml(String(views))} view${views !== 1 ? 's' : ''} · ${escapeHtml(catLabel(o.cat))}</div>
       </div>
     </div>`;
   }).join('');
@@ -177,164 +180,164 @@ function renderTrending(){
 // ══════════════════════════════════════════════
 // ANALYTICS PANEL
 // ══════════════════════════════════════════════
-function openAnalytics(){
-  document.getElementById('aTot').textContent=AN.g('total',0).toLocaleString();
-  document.getElementById('aToday').textContent=AN.todayVisits();
-  document.getElementById('aSearches').textContent=AN.g('searches',0);
-  document.getElementById('aViews').textContent=AN.g('views',0);
-  document.getElementById('aFilters').textContent=AN.g('filters',0);
-  document.getElementById('aTime').textContent=AN.sessionTime();
-  const tc=AN.topCats(),mx=tc[0]?.[1]||1;
-  document.getElementById('catChart').innerHTML=tc.length
-    ?tc.map(([c,n])=>`<div class="bar-row"><span class="bar-lbl">${escapeHtml(catLabel(c))}</span><div class="bar-track"><div class="bar-fill" style="width:${Math.round(n/mx*100)}%"></div></div><span class="bar-val">${escapeHtml(String(n))}</span></div>`).join('')
-    :'<span style="color:var(--muted);font-size:12px">Use category filters to track data</span>';
-  const to=AN.topOrgs(),mo=to[0]?.[1]||1;
-  document.getElementById('orgChart').innerHTML=to.length
-    ?to.map(([o,n])=>`<div class="bar-row"><span class="bar-lbl" style="font-size:10px">${escapeHtml(o.length>16?o.slice(0,16)+'…':o)}</span><div class="bar-track"><div class="bar-fill" style="width:${Math.round(n/mo*100)}%"></div></div><span class="bar-val">${escapeHtml(String(n))}</span></div>`).join('')
-    :'<span style="color:var(--muted);font-size:12px">Click org cards to track views</span>';
-  const tt=AN.topTerms();
-  document.getElementById('srchTerms').innerHTML=tt.length
-    ?tt.map(([t,c],i)=>`<span class="sch ${i<3?'hot':''}">${escapeHtml(t)} (${escapeHtml(String(c))})</span>`).join('')
-    :'<span style="color:var(--muted);font-size:12px">No searches yet</span>';
+function openAnalytics() {
+  document.getElementById('aTot').textContent = AN.g('total', 0).toLocaleString();
+  document.getElementById('aToday').textContent = AN.todayVisits();
+  document.getElementById('aSearches').textContent = AN.g('searches', 0);
+  document.getElementById('aViews').textContent = AN.g('views', 0);
+  document.getElementById('aFilters').textContent = AN.g('filters', 0);
+  document.getElementById('aTime').textContent = AN.sessionTime();
+  const tc = AN.topCats(), mx = tc[0]?.[1] || 1;
+  document.getElementById('catChart').innerHTML = tc.length
+    ? tc.map(([c, n]) => `<div class="bar-row"><span class="bar-lbl">${escapeHtml(catLabel(c))}</span><div class="bar-track"><div class="bar-fill" style="width:${Math.round(n / mx * 100)}%"></div></div><span class="bar-val">${escapeHtml(String(n))}</span></div>`).join('')
+    : '<span style="color:var(--muted);font-size:12px">Use category filters to track data</span>';
+  const to = AN.topOrgs(), mo = to[0]?.[1] || 1;
+  document.getElementById('orgChart').innerHTML = to.length
+    ? to.map(([o, n]) => `<div class="bar-row"><span class="bar-lbl" style="font-size:10px">${escapeHtml(o.length > 16 ? o.slice(0, 16) + '…' : o)}</span><div class="bar-track"><div class="bar-fill" style="width:${Math.round(n / mo * 100)}%"></div></div><span class="bar-val">${escapeHtml(String(n))}</span></div>`).join('')
+    : '<span style="color:var(--muted);font-size:12px">Click org cards to track views</span>';
+  const tt = AN.topTerms();
+  document.getElementById('srchTerms').innerHTML = tt.length
+    ? tt.map(([t, c], i) => `<span class="sch ${i < 3 ? 'hot' : ''}">${escapeHtml(t)} (${escapeHtml(String(c))})</span>`).join('')
+    : '<span style="color:var(--muted);font-size:12px">No searches yet</span>';
   document.getElementById('anBg').classList.add('open');
-  document.body.style.overflow='hidden';
+  document.body.style.overflow = 'hidden';
 }
-function closeAnEvent(e){if(e.target===document.getElementById('anBg'))closeAn();}
-function closeAn(){document.getElementById('anBg').classList.remove('open');document.body.style.overflow='';}
+function closeAnEvent(e) { if (e.target === document.getElementById('anBg')) closeAn(); }
+function closeAn() { document.getElementById('anBg').classList.remove('open'); document.body.style.overflow = ''; }
 
 // ══════════════════════════════════════════════
 // GITHUB API
 // ══════════════════════════════════════════════
-const API='/api/github';
-const cache=JSON.parse(localStorage.getItem('gaf_ghc')||'{}');
-let modalIdx=-1,fetching=false,lastSearch='';
-const pills=new Set();
-const chips=new Set();
-let matchAllLanguages=false; // false = OR (any), true = AND (all)
+const API = '/api/github';
+const cache = JSON.parse(localStorage.getItem('gaf_ghc') || '{}');
+let modalIdx = -1, fetching = false, lastSearch = '';
+const pills = new Set();
+const chips = new Set();
+let matchAllLanguages = false; // false = OR (any), true = AND (all)
 
 // Expose to global scope for HTML onclick handlers and debugging
 globalThis.pills = pills;
 globalThis.matchAllLanguages = matchAllLanguages;
-let filteredOrgs=[]; // for keyboard nav
-let focusedIdx=-1;
+let filteredOrgs = []; // for keyboard nav
+let focusedIdx = -1;
 
-async function checkAPI(){
-  try{
-    const r=await fetch(`${API}?repo=django/django`);
-    const banner=document.getElementById('apiBanner');
-    if(r.ok){
-      banner.className='api-banner api-ok';
-      document.getElementById('apiStrong').textContent='✓ GitHub API Connected';
-      document.getElementById('apiText').textContent='Live stats (stars, forks, good first issues) available for all visitors.';
-      document.getElementById('fetchBtn').style.display='flex';
-    }else{
-      banner.className='api-banner api-warn';
-      document.getElementById('apiStrong').textContent='⚠ API Error';
-      document.getElementById('apiText').textContent='Add GITHUB_TOKEN in Vercel dashboard and redeploy.';
+async function checkAPI() {
+  try {
+    const r = await fetch(`${API}?repo=django/django`);
+    const banner = document.getElementById('apiBanner');
+    if (r.ok) {
+      banner.className = 'api-banner api-ok';
+      document.getElementById('apiStrong').textContent = '✓ GitHub API Connected';
+      document.getElementById('apiText').textContent = 'Live stats (stars, forks, good first issues) available for all visitors.';
+      document.getElementById('fetchBtn').style.display = 'flex';
+    } else {
+      banner.className = 'api-banner api-warn';
+      document.getElementById('apiStrong').textContent = '⚠ API Error';
+      document.getElementById('apiText').textContent = 'Add GITHUB_TOKEN in Vercel dashboard and redeploy.';
     }
-  }catch{
-    document.getElementById('apiStrong').textContent='○ Running Locally';
-    document.getElementById('apiText').textContent='Deploy to Vercel for live GitHub stats.';
+  } catch {
+    document.getElementById('apiStrong').textContent = '○ Running Locally';
+    document.getElementById('apiText').textContent = 'Deploy to Vercel for live GitHub stats.';
   }
 }
 
-async function fetchGH(repo){
-  if(!repo)return null;
-  if(cache[repo]&&Date.now()-cache[repo].ts<3600000)return cache[repo];
-  try{
-    const r=await fetch(`${API}?repo=${encodeURIComponent(repo)}`);
-    if(!r.ok)return null;
-    const d=await r.json();
-    if(d.error)return null;
-    cache[repo]=d;localStorage.setItem('gaf_ghc',JSON.stringify(cache));return d;
-  }catch{return null;}
+async function fetchGH(repo) {
+  if (!repo) return null;
+  if (cache[repo] && Date.now() - cache[repo].ts < 3600000) return cache[repo];
+  try {
+    const r = await fetch(`${API}?repo=${encodeURIComponent(repo)}`);
+    if (!r.ok) return null;
+    const d = await r.json();
+    if (d.error) return null;
+    cache[repo] = d; localStorage.setItem('gaf_ghc', JSON.stringify(cache)); return d;
+  } catch { return null; }
 }
 
-async function fetchGFI(repo){
-  if(!repo)return null;
-  const cacheKey=repo+'__gfi';
-  const hit=cache[cacheKey];
-  if(hit&&Date.now()-hit.ts<3600000&&hit.count!==null&&hit.count!==undefined)return hit.count;
-  try{
-    const r=await fetch(`${API}?repo=${encodeURIComponent(repo)}&gfi=1`);
-    if(!r.ok)return null;
-    const d=await r.json();
-    if(d.gfi===null||d.gfi===undefined)return null;
-    cache[cacheKey]={count:d.gfi,ts:Date.now()};
-    localStorage.setItem('gaf_ghc',JSON.stringify(cache));
+async function fetchGFI(repo) {
+  if (!repo) return null;
+  const cacheKey = repo + '__gfi';
+  const hit = cache[cacheKey];
+  if (hit && Date.now() - hit.ts < 3600000 && hit.count !== null && hit.count !== undefined) return hit.count;
+  try {
+    const r = await fetch(`${API}?repo=${encodeURIComponent(repo)}&gfi=1`);
+    if (!r.ok) return null;
+    const d = await r.json();
+    if (d.gfi === null || d.gfi === undefined) return null;
+    cache[cacheKey] = { count: d.gfi, ts: Date.now() };
+    localStorage.setItem('gaf_ghc', JSON.stringify(cache));
     return d.gfi;
-  }catch{return null;}
+  } catch { return null; }
 }
 
-async function fetchAll(){
-  if(fetching)return; fetching=true;
-  const spin=document.getElementById('fetchSpin'),txt=document.getElementById('fetchTxt'),btn=document.getElementById('fetchBtn');
-  spin.style.display='block';btn.disabled=true;
-  let done=0;
-  for(const o of ORGS){
-    if(o.github){
-      txt.textContent=`${++done}/${ORGS.length}…`;
-      const d=await fetchGH(o.github);if(d)o._gh=d;
-      await new Promise(r=>setTimeout(r,85));
+async function fetchAll() {
+  if (fetching) return; fetching = true;
+  const spin = document.getElementById('fetchSpin'), txt = document.getElementById('fetchTxt'), btn = document.getElementById('fetchBtn');
+  spin.style.display = 'block'; btn.disabled = true;
+  let done = 0;
+  for (const o of ORGS) {
+    if (o.github) {
+      txt.textContent = `${++done}/${ORGS.length}…`;
+      const d = await fetchGH(o.github); if (d) o._gh = d;
+      await new Promise(r => setTimeout(r, 85));
     }
   }
-  spin.style.display='none';btn.disabled=false;txt.textContent='✓ Done';fetching=false;
-  applyFilters();updateStats();
+  spin.style.display = 'none'; btn.disabled = false; txt.textContent = '✓ Done'; fetching = false;
+  applyFilters(); updateStats();
 }
 
-async function fetchModalGH(){
-  const o=ORGS[modalIdx];if(!o?.github)return;
-  document.getElementById('mFetchBtn').textContent='Loading…';
+async function fetchModalGH() {
+  const o = ORGS[modalIdx]; if (!o?.github) return;
+  document.getElementById('mFetchBtn').textContent = 'Loading…';
   delete cache[o.github];
-  delete cache[o.github+'__gfi'];
-  const d=await fetchGH(o.github);
-  if(d){
-    o._gh=d;
-    document.getElementById('ghStars').textContent=fmt(d.stars);
-    document.getElementById('ghForks').textContent=fmt(d.forks);
-    document.getElementById('ghIssues').textContent=fmt(d.issues);
-    document.getElementById('ghCommit').textContent=d.lastCommit;
-    document.getElementById('mFetchBtn').textContent='↻ Refresh';
-    document.getElementById('ghGFI').textContent='…';
-    const gfi=await fetchGFI(o.github);
-    const gfiTxt=gfi!==null?fmt(gfi):'—';
-    document.getElementById('ghGFI').textContent=gfiTxt;
-    if(gfi!==null){
-      o._gh.gfi=gfi;
-      const cells=document.getElementById('mMetrics')?.querySelectorAll('.mv');
-      if(cells&&cells[3])cells[3].textContent=gfiTxt;
+  delete cache[o.github + '__gfi'];
+  const d = await fetchGH(o.github);
+  if (d) {
+    o._gh = d;
+    document.getElementById('ghStars').textContent = fmt(d.stars);
+    document.getElementById('ghForks').textContent = fmt(d.forks);
+    document.getElementById('ghIssues').textContent = fmt(d.issues);
+    document.getElementById('ghCommit').textContent = d.lastCommit;
+    document.getElementById('mFetchBtn').textContent = '↻ Refresh';
+    document.getElementById('ghGFI').textContent = '…';
+    const gfi = await fetchGFI(o.github);
+    const gfiTxt = gfi !== null ? fmt(gfi) : '—';
+    document.getElementById('ghGFI').textContent = gfiTxt;
+    if (gfi !== null) {
+      o._gh.gfi = gfi;
+      const cells = document.getElementById('mMetrics')?.querySelectorAll('.mv');
+      if (cells && cells[3]) cells[3].textContent = gfiTxt;
     }
     applyFilters();
     renderCompareTable();
-  }else document.getElementById('mFetchBtn').textContent='✗ Failed';
+  } else document.getElementById('mFetchBtn').textContent = '✗ Failed';
 }
 
-function fmt(n){return(!n&&n!==0)?'—':n>=1000?(n/1000).toFixed(1)+'k':String(n);}
+function fmt(n) { return (!n && n !== 0) ? '—' : n >= 1000 ? (n / 1000).toFixed(1) + 'k' : String(n); }
 
 // ══════════════════════════════════════════════
 // HELPERS
 // ══════════════════════════════════════════════
-function yCls(y){return y>=8?'veteran':y>=4?'experienced':'newcomer';}
-function yLbl(y){return y>=8?'🏆 Veteran':y>=4?'⭐ Experienced':'🌱 Newcomer';}
-function yBdg(y){return y>=8?'bv':y>=4?'be':'bn';}
-function cLbl(c){return c==='hot'?'🔥 High':c==='moderate'?'🟡 Moderate':'😎 Low';}
-function cBdg(c){return c==='hot'?'bh':c==='moderate'?'bm':'bc';}
-function aLbl(a){return a==='active'?'⚡ Active':a==='moderate'?'📊 Moderate':a==='low'?'💤 Low':'○ —';}
-function aBdg(a){return a==='active'?'bac':a==='moderate'?'bam':a==='low'?'bal':'bna';}
-function catLabel(c){return{science:'Science',programming:'Programming',data:'Data',web:'Web',os:'OS',security:'Security',media:'Media',infra:'Infra',ai:'AI',dev:'Dev Tools',other:'Other'}[c]||c;}
-function catBdg(c){return'cb-'+(c||'other');}
+function yCls(y) { return y >= 8 ? 'veteran' : y >= 4 ? 'experienced' : 'newcomer'; }
+function yLbl(y) { return y >= 8 ? '🏆 Veteran' : y >= 4 ? '⭐ Experienced' : '🌱 Newcomer'; }
+function yBdg(y) { return y >= 8 ? 'bv' : y >= 4 ? 'be' : 'bn'; }
+function cLbl(c) { return c === 'hot' ? '🔥 High' : c === 'moderate' ? '🟡 Moderate' : '😎 Low'; }
+function cBdg(c) { return c === 'hot' ? 'bh' : c === 'moderate' ? 'bm' : 'bc'; }
+function aLbl(a) { return a === 'active' ? '⚡ Active' : a === 'moderate' ? '📊 Moderate' : a === 'low' ? '💤 Low' : '○ —'; }
+function aBdg(a) { return a === 'active' ? 'bac' : a === 'moderate' ? 'bam' : a === 'low' ? 'bal' : 'bna'; }
+function catLabel(c) { return { science: 'Science', programming: 'Programming', data: 'Data', web: 'Web', os: 'OS', security: 'Security', media: 'Media', infra: 'Infra', ai: 'AI', dev: 'Dev Tools', other: 'Other' }[c] || c; }
+function catBdg(c) { return 'cb-' + (c || 'other'); }
 
 // ══════════════════════════════════════════════
 // COMPARE
 // ══════════════════════════════════════════════
-const compareSet=new Set(); // stores ORGS indices
+const compareSet = new Set(); // stores ORGS indices
 
-function toggleCompare(idx,e){
-  if(e){e.stopPropagation();}
-  if(compareSet.has(idx)){
+function toggleCompare(idx, e) {
+  if (e) { e.stopPropagation(); }
+  if (compareSet.has(idx)) {
     compareSet.delete(idx);
   } else {
-    if(compareSet.size>=3){showCompareToast('Max 3 orgs for comparison');return;}
+    if (compareSet.size >= 3) { showCompareToast('Max 3 orgs for comparison'); return; }
     compareSet.add(idx);
   }
   updateCompareBadge();
@@ -342,113 +345,113 @@ function toggleCompare(idx,e){
   renderCompareTable();
 }
 
-function toggleCompareFromModal(){
-  if(modalIdx<0)return;
-  toggleCompare(modalIdx,null);
+function toggleCompareFromModal() {
+  if (modalIdx < 0) return;
+  toggleCompare(modalIdx, null);
   updateModalCompareBtn();
 }
 
-function updateModalCompareBtn(){
-  const btn=document.getElementById('mCompareBtn');
-  if(!btn)return;
-  const inSet=compareSet.has(modalIdx);
-  btn.classList.toggle('active',inSet);
-  btn.title=inSet?'Remove from compare':'Add to compare';
-  btn.textContent=inSet?'✓⚖':'⚖️';
+function updateModalCompareBtn() {
+  const btn = document.getElementById('mCompareBtn');
+  if (!btn) return;
+  const inSet = compareSet.has(modalIdx);
+  btn.classList.toggle('active', inSet);
+  btn.title = inSet ? 'Remove from compare' : 'Add to compare';
+  btn.textContent = inSet ? '✓⚖' : '⚖️';
 }
 
-function updateCompareBadge(){
-  const badge=document.getElementById('compareBadge');
-  badge.textContent=compareSet.size;
-  badge.classList.toggle('show',compareSet.size>0);
+function updateCompareBadge() {
+  const badge = document.getElementById('compareBadge');
+  badge.textContent = compareSet.size;
+  badge.classList.toggle('show', compareSet.size > 0);
 }
 
-function openCompare(){
+function openCompare() {
   renderCompareSlots();
   renderCompareTable();
   document.getElementById('compareBg').classList.add('open');
-  document.body.style.overflow='hidden';
+  document.body.style.overflow = 'hidden';
 }
-function closeCompare(){document.getElementById('compareBg').classList.remove('open');document.body.style.overflow='';}
-function closeCompareEv(e){if(e.target===document.getElementById('compareBg'))closeCompare();}
+function closeCompare() { document.getElementById('compareBg').classList.remove('open'); document.body.style.overflow = ''; }
+function closeCompareEv(e) { if (e.target === document.getElementById('compareBg')) closeCompare(); }
 
-function renderCompareSlots(){
-  const arr=[...compareSet].map(i=>ORGS[i]);
-  const slots=document.getElementById('compareSlots');
-  let html='';
-  for(let i=0;i<3;i++){
-    const o=arr[i];
-    if(o){
-      const idx=ORGS.indexOf(o);
-      html+=`<div class="compare-slot filled">
+function renderCompareSlots() {
+  const arr = [...compareSet].map(i => ORGS[i]);
+  const slots = document.getElementById('compareSlots');
+  let html = '';
+  for (let i = 0; i < 3; i++) {
+    const o = arr[i];
+    if (o) {
+      const idx = ORGS.indexOf(o);
+      html += `<div class="compare-slot filled">
         <span class="slot-cat ${catBdg(o.cat)}">${escapeHtml(catLabel(o.cat))}</span>
         <span class="slot-name">${escapeHtml(o.name)}</span>
         <button class="slot-remove" onclick="toggleCompare(${idx},null);renderCompareSlots();renderCompareTable();">✕ Remove</button>
       </div>`;
     } else {
-      html+=`<div class="compare-slot"><span class="slot-empty">+ Add org</span><span style="font-size:10px;color:var(--muted)">Click ⚖️ on any card</span></div>`;
+      html += `<div class="compare-slot"><span class="slot-empty">+ Add org</span><span style="font-size:10px;color:var(--muted)">Click ⚖️ on any card</span></div>`;
     }
   }
-  slots.innerHTML=html;
+  slots.innerHTML = html;
 }
 
-function renderCompareTable(){
+function renderCompareTable() {
   renderCompareSlots();
-  const arr=[...compareSet].map(i=>ORGS[i]);
-  const wrap=document.getElementById('compareTableWrap');
-  if(arr.length<2){
-    wrap.innerHTML=`<div class="compare-hint">Select at least 2 organizations using the ⚖️ button on cards to compare them here.</div>`;
+  const arr = [...compareSet].map(i => ORGS[i]);
+  const wrap = document.getElementById('compareTableWrap');
+  if (arr.length < 2) {
+    wrap.innerHTML = `<div class="compare-hint">Select at least 2 organizations using the ⚖️ button on cards to compare them here.</div>`;
     return;
   }
 
-  const compScore={hot:3,moderate:2,chill:1};
-  const rows=[
-    {label:'Category',    vals:arr.map(o=>catLabel(o.cat)), type:'text'},
-    {label:'GSoC Years',  vals:arr.map(o=>o.years), type:'bar', max:11, best:'high'},
-    {label:'Since',       vals:arr.map(o=>o.firstYear), type:'text'},
-    {label:'Competition', vals:arr.map(o=>cLbl(o.competition)), scores:arr.map(o=>compScore[o.competition]), type:'scored', best:'low'},
-    {label:'Stars ⭐',     vals:arr.map(o=>o._gh?fmt(o._gh.stars):'—'), scores:arr.map(o=>o._gh?.stars||0), type:'scored', best:'high'},
-    {label:'Forks',       vals:arr.map(o=>o._gh?fmt(o._gh.forks):'—'), scores:arr.map(o=>o._gh?.forks||0), type:'scored', best:'high'},
-    {label:'Open Issues', vals:arr.map(o=>o._gh?fmt(o._gh.issues):'—'), scores:arr.map(o=>o._gh?.issues||0), type:'scored', best:'low'},
-    {label:'Last Commit', vals:arr.map(o=>o._gh?o._gh.lastCommit:'—'), type:'text'},
-    {label:'Good 1st Issues', vals:arr.map(o=>o._gh?.gfi!==null&&o._gh?.gfi!==undefined?fmt(o._gh.gfi):'—'), scores:arr.map(o=>o._gh?.gfi||0), type:'scored', best:'high'},
-    {label:'Languages',   vals:arr.map(o=>o.tags.slice(0,3).join(', ')), type:'text'},
+  const compScore = { hot: 3, moderate: 2, chill: 1 };
+  const rows = [
+    { label: 'Category', vals: arr.map(o => catLabel(o.cat)), type: 'text' },
+    { label: 'GSoC Years', vals: arr.map(o => o.years), type: 'bar', max: 11, best: 'high' },
+    { label: 'Since', vals: arr.map(o => o.firstYear), type: 'text' },
+    { label: 'Competition', vals: arr.map(o => cLbl(o.competition)), scores: arr.map(o => compScore[o.competition]), type: 'scored', best: 'low' },
+    { label: 'Stars ⭐', vals: arr.map(o => o._gh ? fmt(o._gh.stars) : '—'), scores: arr.map(o => o._gh?.stars || 0), type: 'scored', best: 'high' },
+    { label: 'Forks', vals: arr.map(o => o._gh ? fmt(o._gh.forks) : '—'), scores: arr.map(o => o._gh?.forks || 0), type: 'scored', best: 'high' },
+    { label: 'Open Issues', vals: arr.map(o => o._gh ? fmt(o._gh.issues) : '—'), scores: arr.map(o => o._gh?.issues || 0), type: 'scored', best: 'low' },
+    { label: 'Last Commit', vals: arr.map(o => o._gh ? o._gh.lastCommit : '—'), type: 'text' },
+    { label: 'Good 1st Issues', vals: arr.map(o => o._gh?.gfi !== null && o._gh?.gfi !== undefined ? fmt(o._gh.gfi) : '—'), scores: arr.map(o => o._gh?.gfi || 0), type: 'scored', best: 'high' },
+    { label: 'Languages', vals: arr.map(o => o.tags.slice(0, 3).join(', ')), type: 'text' },
   ];
 
-  const thead=`<tr><th>Metric</th>${arr.map(o=>`<th>${escapeHtml(o.name.length>22?o.name.slice(0,22)+'…':o.name)}</th>`).join('')}</tr>`;
-  let tbody='';
-  for(const row of rows){
-    let cells='';
-    if(row.type==='bar'){
-      const mx=Math.max(...row.vals);
-      cells=row.vals.map((v)=>{
-        const pct=mx>0?Math.round(v/mx*100):0;
-        return`<td><div class="cmp-bar-wrap"><div class="cmp-bar-track"><div class="cmp-bar-fill" style="width:${pct}%"></div></div><span class="cmp-val">${escapeHtml(String(v))}y</span></div></td>`;
+  const thead = `<tr><th>Metric</th>${arr.map(o => `<th>${escapeHtml(o.name.length > 22 ? o.name.slice(0, 22) + '…' : o.name)}</th>`).join('')}</tr>`;
+  let tbody = '';
+  for (const row of rows) {
+    let cells = '';
+    if (row.type === 'bar') {
+      const mx = Math.max(...row.vals);
+      cells = row.vals.map((v) => {
+        const pct = mx > 0 ? Math.round(v / mx * 100) : 0;
+        return `<td><div class="cmp-bar-wrap"><div class="cmp-bar-track"><div class="cmp-bar-fill" style="width:${pct}%"></div></div><span class="cmp-val">${escapeHtml(String(v))}y</span></div></td>`;
       }).join('');
-    } else if(row.type==='scored'&&row.scores&&row.scores.some(s=>s>0)){
-      const mx=Math.max(...row.scores),mn=Math.min(...row.scores.filter(s=>s>0)||[0]);
-      cells=row.vals.map((v,i)=>{
-        const s=row.scores[i];
-        let cls='cmp-val';
-        if(s>0){
-          cls=row.best==='high'?(s===mx?'cmp-best':s===mn?'cmp-worst':'cmp-val'):(s===mn?'cmp-best':s===mx?'cmp-worst':'cmp-val');
+    } else if (row.type === 'scored' && row.scores && row.scores.some(s => s > 0)) {
+      const mx = Math.max(...row.scores), mn = Math.min(...row.scores.filter(s => s > 0) || [0]);
+      cells = row.vals.map((v, i) => {
+        const s = row.scores[i];
+        let cls = 'cmp-val';
+        if (s > 0) {
+          cls = row.best === 'high' ? (s === mx ? 'cmp-best' : s === mn ? 'cmp-worst' : 'cmp-val') : (s === mn ? 'cmp-best' : s === mx ? 'cmp-worst' : 'cmp-val');
         }
-        return`<td class="${cls}">${escapeHtml(String(v))}</td>`;
+        return `<td class="${cls}">${escapeHtml(String(v))}</td>`;
       }).join('');
     } else {
-      cells=row.vals.map(v=>`<td class="cmp-val">${escapeHtml(String(v))}</td>`).join('');
+      cells = row.vals.map(v => `<td class="cmp-val">${escapeHtml(String(v))}</td>`).join('');
     }
-    tbody+=`<tr><td class="row-label">${escapeHtml(row.label)}</td>${cells}</tr>`;
+    tbody += `<tr><td class="row-label">${escapeHtml(row.label)}</td>${cells}</tr>`;
   }
-  wrap.innerHTML=`<table class="compare-table"><thead>${thead}</thead><tbody>${tbody}</tbody></table>
+  wrap.innerHTML = `<table class="compare-table"><thead>${thead}</thead><tbody>${tbody}</tbody></table>
     <p style="font-size:10px;color:var(--muted);margin-top:10px;text-align:right">🟢 Best value &nbsp; 🔴 Lowest value &nbsp; (requires GitHub stats to be fetched)</p>`;
 }
 
-function showCompareToast(msg){
-  let t=document.getElementById('compareToast');
-  if(!t){t=document.createElement('div');t.id='compareToast';t.style.cssText='position:fixed;bottom:24px;left:50%;transform:translateX(-50%);background:var(--ink);color:var(--bg);padding:10px 18px;border-radius:8px;font-size:12px;font-weight:700;z-index:999;transition:opacity .3s;white-space:nowrap';document.body.appendChild(t);}
-  t.textContent=msg;t.style.opacity='1';
-  setTimeout(()=>t.style.opacity='0',2200);
+function showCompareToast(msg) {
+  let t = document.getElementById('compareToast');
+  if (!t) { t = document.createElement('div'); t.id = 'compareToast'; t.style.cssText = 'position:fixed;bottom:24px;left:50%;transform:translateX(-50%);background:var(--ink);color:var(--bg);padding:10px 18px;border-radius:8px;font-size:12px;font-weight:700;z-index:999;transition:opacity .3s;white-space:nowrap'; document.body.appendChild(t); }
+  t.textContent = msg; t.style.opacity = '1';
+  setTimeout(() => t.style.opacity = '0', 2200);
 }
 
 function showSkeletons(count = 12) {
@@ -517,7 +520,7 @@ function orgMatchesLanguages(org, selectedLanguages) {
   }
 }
 
-function applyFilters(){
+function applyFilters() {
   const search = (document.getElementById('searchInput')?.value || '').trim().toLowerCase();
   const categoryValue = document.getElementById('categoryFilter')?.value || '';
   const cat = categoryValue === 'all' ? '' : categoryValue;
@@ -525,65 +528,65 @@ function applyFilters(){
   const compF = document.getElementById('complexityFilter')?.value || '';
   const sort = document.getElementById('sortSelect')?.value || 'alpha';
 
-  if(search!==lastSearch&&search.length>1){AN.trackSearch(search);lastSearch=search;}
-  if(cat)AN.trackCat(cat);
+  if (search !== lastSearch && search.length > 1) { AN.trackSearch(search); lastSearch = search; }
+  if (cat) AN.trackCat(cat);
 
-  const res=ORGS.filter(o=>{
+  const res = ORGS.filter(o => {
     // Search only organization names
-    const orgName=o.name.toLowerCase();
-    
+    const orgName = o.name.toLowerCase();
+
     // Category Filter
-    if(cat && o.cat !== cat) return false;
+    if (cat && o.cat !== cat) return false;
 
     // Complexity Filter (if it exists in data, otherwise skip)
     // Note: Complexity is currently a display-only field in the card UI 
     // based on competition/years, but the filter select exists in HTML.
-    if(compF && compF !== 'all') {
-       if(o.codebase !== compF) return false;
+    if (compF && compF !== 'all') {
+      if (o.codebase !== compF) return false;
     }
 
     // Language Filter
-    if(lang){
-      const langLabel=Object.keys(LANGUAGE_MAP).find(label=>label.toLowerCase()===lang)||lang;
-      if(!orgMatchesLanguages(o,new Set([langLabel])))return false;
+    if (lang) {
+      const langLabel = Object.keys(LANGUAGE_MAP).find(label => label.toLowerCase() === lang) || lang;
+      if (!orgMatchesLanguages(o, new Set([langLabel]))) return false;
     }
 
     // Search input (synchronized from hero-search)
-    if(search && !orgName.includes(search)) return false;
+    if (search && !orgName.includes(search)) return false;
 
     // Language pills (multi-select)
-    if(pills.size > 0 && !orgMatchesLanguages(o, pills)) return false;
- 
+    if (pills.size > 0 && !orgMatchesLanguages(o, pills)) return false;
+
     // Filter chips
-    if(chips.has('veteran') && yCls(o.years) !== 'veteran') return false;
-    if(chips.has('newcomer') && yCls(o.years) !== 'newcomer') return false;
-    if(chips.has('hot') && o.competition !== 'hot') return false;
-    if(chips.has('chill') && o.competition !== 'chill') return false;
-    if(chips.has('active') && (!o._gh || o._gh.activity !== 'active')) return false;
-    if(chips.has('bookmarked') && !isBookmarked(o.name)) return false;
-    
+    if (chips.has('veteran') && yCls(o.years) !== 'veteran') return false;
+    if (chips.has('newcomer') && yCls(o.years) !== 'newcomer') return false;
+    if (chips.has('hot') && o.competition !== 'hot') return false;
+    if (chips.has('chill') && o.competition !== 'chill') return false;
+    if (chips.has('active') && (!o._gh || o._gh.activity !== 'active')) return false;
+    if (chips.has('bookmarked') && !isBookmarked(o.name)) return false;
+
     return true;
   });
 
   // Improved search ranking: exact matches first, then startsWith, then partial
-  if(search){
-    res.sort((a,b)=>{
-      const nameA=a.name.toLowerCase();
-      const nameB=b.name.toLowerCase();
-      
+  if (search) {
+    res.sort((a, b) => {
+      const nameA = a.name.toLowerCase();
+      const nameB = b.name.toLowerCase();
+
       // Exact match gets highest priority
-      if(nameA===search && nameB!==search) return -1;
-      if(nameB===search && nameA!==search) return 1;
-      
+      if (nameA === search && nameB !== search) return -1;
+      if (nameB === search && nameA !== search) return 1;
+
       // Starts with gets second priority  
-      if(nameA.startsWith(search) && !nameB.startsWith(search)) return -1;
-      if(nameB.startsWith(search) && !nameA.startsWith(search)) return 1;
-      
+      if (nameA.startsWith(search) && !nameB.startsWith(search)) return -1;
+      if (nameB.startsWith(search) && !nameA.startsWith(search)) return 1;
+
       // Both start with search, sort by selected sort option or alphabetically
-      if(nameA.startsWith(search) && nameB.startsWith(search)) {
+      if (nameA.startsWith(search) && nameB.startsWith(search)) {
         return applySecondarySort(a, b, sort);
       }
-      
+
       // Neither starts with, sort by selected sort option or alphabetically
       return applySecondarySort(a, b, sort);
     });
@@ -592,78 +595,78 @@ function applyFilters(){
 
 
   // Apply other sorting if no search
-  if(!search){
-    res.sort((a,b) => applySecondarySort(a, b, sort));
+  if (!search) {
+    res.sort((a, b) => applySecondarySort(a, b, sort));
   }
 
-  filteredOrgs=res;
-  focusedIdx=-1;
+  filteredOrgs = res;
+  focusedIdx = -1;
   renderGrid(res);
   document.getElementById('orgCount').textContent = res.length;
 
   // Sync filter state to URL
   const params = new URLSearchParams();
-  if (search)    params.set('q',search);
-  if (cat)    params.set('cat',cat);
+  if (search) params.set('q', search);
+  if (cat) params.set('cat', cat);
   const selectedLangs = pills.size ? [...pills] : (lang ? [lang] : []);
-  if (selectedLangs.length)    params.set('lang', selectedLangs.join(','));
-  if (sort && sort !== 'alpha')    params.set('sort',sort);
-  history.replaceState(null,'',params.toString()?'?'+params.toString():location.pathname);
+  if (selectedLangs.length) params.set('lang', selectedLangs.join(','));
+  if (sort && sort !== 'alpha') params.set('sort', sort);
+  history.replaceState(null, '', params.toString() ? '?' + params.toString() : location.pathname);
 }
 
 function applySecondarySort(a, b, sortType) {
-  if(sortType==='years-desc') return b.years - a.years;
-  if(sortType==='years-asc') return a.years - b.years;
-  if(sortType==='comp-low') return ['chill','moderate','hot'].indexOf(a.competition) - ['chill','moderate','hot'].indexOf(b.competition);
-  if(sortType==='stars') return (b._gh?.stars||0) - (a._gh?.stars||0);
-  if(sortType==='gfi') return (b._gh?.gfi||0) - (a._gh?.gfi||0);
+  if (sortType === 'years-desc') return b.years - a.years;
+  if (sortType === 'years-asc') return a.years - b.years;
+  if (sortType === 'comp-low') return ['chill', 'moderate', 'hot'].indexOf(a.competition) - ['chill', 'moderate', 'hot'].indexOf(b.competition);
+  if (sortType === 'stars') return (b._gh?.stars || 0) - (a._gh?.stars || 0);
+  if (sortType === 'gfi') return (b._gh?.gfi || 0) - (a._gh?.gfi || 0);
   return a.name.localeCompare(b.name);
 }
 
 // Umbrella orgs: link goes to org page, not a single example repo
 // Single-project orgs: link goes to that specific repo
-const UMBRELLA_ORGS=new Set([
-  'Apache Software Foundation','CNCF','Eclipse Foundation','FOSSASIA','GNOME Foundation',
-  'GNU Project','Jenkins','KDE Community','NumFOCUS','OpenMRS','openSUSE Project',
-  'OWASP Foundation','The Linux Foundation','Wikimedia Foundation','AOSSIE','CERN-HSF',
-  'CCExtractor Development','Blender Foundation','Open Robotics','JBoss Community',
-  'The Honeynet Project','MetaBrainz Foundation Inc','OSGeo (Open Source Geospatial Foundation)',
-  'SW360','DBpedia','LibreOffice','Oppia Foundation','Sugar Labs','Internet Archive',
-  'VideoLAN','JdeRobot','Kubeflow','INCF','OpenAstronomy','Machine Learning for Science (ML4SCI)',
-  'SageMath','National Resource for Network Biology (NRNB)','FOSSology','JabRef e.V.',
-  'FOSSASIA','LabLua','Liquid Galaxy project','Free and Open Source Silicon Foundation',
+const UMBRELLA_ORGS = new Set([
+  'Apache Software Foundation', 'CNCF', 'Eclipse Foundation', 'FOSSASIA', 'GNOME Foundation',
+  'GNU Project', 'Jenkins', 'KDE Community', 'NumFOCUS', 'OpenMRS', 'openSUSE Project',
+  'OWASP Foundation', 'The Linux Foundation', 'Wikimedia Foundation', 'AOSSIE', 'CERN-HSF',
+  'CCExtractor Development', 'Blender Foundation', 'Open Robotics', 'JBoss Community',
+  'The Honeynet Project', 'MetaBrainz Foundation Inc', 'OSGeo (Open Source Geospatial Foundation)',
+  'SW360', 'DBpedia', 'LibreOffice', 'Oppia Foundation', 'Sugar Labs', 'Internet Archive',
+  'VideoLAN', 'JdeRobot', 'Kubeflow', 'INCF', 'OpenAstronomy', 'Machine Learning for Science (ML4SCI)',
+  'SageMath', 'National Resource for Network Biology (NRNB)', 'FOSSology', 'JabRef e.V.',
+  'FOSSASIA', 'LabLua', 'Liquid Galaxy project', 'Free and Open Source Silicon Foundation',
 ]);
 
-function orgLogoOwner(o){
-  if(!o.github)return'';
-  return o.github.includes('/')?o.github.split('/')[0]:o.github;
+function orgLogoOwner(o) {
+  if (!o.github) return '';
+  return o.github.includes('/') ? o.github.split('/')[0] : o.github;
 }
-function imgErr(img){
-  img.onerror=null;
-  const p=document.createElement('div');
-  p.className='org-logo-placeholder';
-  p.textContent=(img.alt||'?')[0].toUpperCase();
-  img.parentNode.replaceChild(p,img);
+function imgErr(img) {
+  img.onerror = null;
+  const p = document.createElement('div');
+  p.className = 'org-logo-placeholder';
+  p.textContent = (img.alt || '?')[0].toUpperCase();
+  img.parentNode.replaceChild(p, img);
 }
-function orgLogo(o){
-  const owner=orgLogoOwner(o);
-  if(!owner)return'';
+function orgLogo(o) {
+  const owner = orgLogoOwner(o);
+  if (!owner) return '';
   // Use avatars.githubusercontent.com — no redirect, works cross-origin
-  return`https://github.com/${owner}.png?size=64`;
+  return `https://github.com/${owner}.png?size=64`;
 }
-function repoUrl(o){
-  if(!o.github)return'';
-  const owner=o.github.includes('/')?o.github.split('/')[0]:o.github;
+function repoUrl(o) {
+  if (!o.github) return '';
+  const owner = o.github.includes('/') ? o.github.split('/')[0] : o.github;
   // Umbrella orgs → link to their org page; single-project orgs → their specific repo
-  if(UMBRELLA_ORGS.has(o.name)||!o.github.includes('/'))
-    return`https://github.com/${owner}`;
-  return`https://github.com/${o.github}`;
+  if (UMBRELLA_ORGS.has(o.name) || !o.github.includes('/'))
+    return `https://github.com/${owner}`;
+  return `https://github.com/${o.github}`;
 }
-function repoLinkLabel(o){
-  if(!o.github)return'';
-  const owner=o.github.includes('/')?o.github.split('/')[0]:o.github;
-  if(UMBRELLA_ORGS.has(o.name)||!o.github.includes('/'))
-    return owner+' (org)';
+function repoLinkLabel(o) {
+  if (!o.github) return '';
+  const owner = o.github.includes('/') ? o.github.split('/')[0] : o.github;
+  if (UMBRELLA_ORGS.has(o.name) || !o.github.includes('/'))
+    return owner + ' (org)';
   return o.github;
 }
 
@@ -695,14 +698,14 @@ function isBookmarked(orgName) {
   return saved.includes(orgName);
 }
 
-function renderGfiBadge(gh){
-  if(gh?.gfi===null||gh?.gfi===undefined)return '';
+function renderGfiBadge(gh) {
+  if (gh?.gfi === null || gh?.gfi === undefined) return '';
   return `<span class="gh-s">🟢 <b>${escapeHtml(fmt(gh.gfi))} GFI</b></span>`;
 }
-function renderGrid(orgs){
-  const g=document.getElementById('orgGrid');
-  if(!orgs.length){
-    g.innerHTML=`
+function renderGrid(orgs) {
+  const g = document.getElementById('orgGrid');
+  if (!orgs.length) {
+    g.innerHTML = `
       <div class="empty">
         <div class="empty-icon">🔍</div>
         <h3>No organizations match your current filters.</h3>
@@ -711,54 +714,54 @@ function renderGrid(orgs){
       </div>`;
     return;
   }
-  g.innerHTML=orgs.map((o,i)=>{
-    const act=o._gh?.activity||null;
-    const tags=o.tags.slice(0,5).map(t=>`<span class="tag">${escapeHtml(t)}</span>`).join('');
-    const ghm=o._gh?`<div class="gh-mini">
+  g.innerHTML = orgs.map((o, i) => {
+    const act = o._gh?.activity || null;
+    const tags = o.tags.slice(0, 5).map(t => `<span class="tag">${escapeHtml(t)}</span>`).join('');
+    const ghm = o._gh ? `<div class="gh-mini">
       <span class="gh-s">⭐ <b>${fmt(o._gh.stars)}</b></span>
       <span class="gh-s">🍴 <b>${fmt(o._gh.forks)}</b></span>
       ${renderGfiBadge(o._gh)}
       <span class="gh-s">🕐 <b>${escapeHtml(String(o._gh.lastCommit))}</b></span>
-    </div>`:'';
-    const globalIdx=ORGS.indexOf(o);
-    const inCompare=compareSet.has(globalIdx);
-    const isFocused=focusedIdx===i;
-    const logo=orgLogo(o);
-    const repoHref=repoUrl(o);
+    </div>`: '';
+    const globalIdx = ORGS.indexOf(o);
+    const inCompare = compareSet.has(globalIdx);
+    const isFocused = focusedIdx === i;
+    const logo = orgLogo(o);
+    const repoHref = repoUrl(o);
     // shortRepo now handled by repoLinkLabel()
-    return`<div class="org-card${inCompare?' in-compare':''}${isFocused?' focused':''}"
+    return `<div class="org-card${inCompare ? ' in-compare' : ''}${isFocused ? ' focused' : ''}"
       role="article"
       aria-label="Organization: ${escapeHtml(o.name)}"
       onclick="openModal(${globalIdx})"
       data-filtered-idx="${i}"
       tabindex="0">
       <div class="card-header-row">
-        ${logo?`<img class="org-logo" src="${escapeHtml(logo)}" alt="${escapeHtml((o.name||'')[0]||'') }" loading="lazy" onerror="imgErr(this)">`:``}
+        ${logo ? `<img class="org-logo" src="${escapeHtml(logo)}" alt="${escapeHtml((o.name || '')[0] || '')}" loading="lazy" onerror="imgErr(this)">` : ``}
         <div class="org-logo-info">
           <div class="card-top-line">
             <div class="org-name">${escapeHtml(o.name)}</div>
             <div class="card-actions">
-              <button class="btn-card-compare${inCompare?' active':''}" onclick="toggleCompare(${globalIdx},event)" title="${inCompare?'Remove from compare':'Add to compare'}">⚖</button>
+              <button class="btn-card-compare${inCompare ? ' active' : ''}" onclick="toggleCompare(${globalIdx},event)" title="${inCompare ? 'Remove from compare' : 'Add to compare'}">⚖</button>
               <span class="cat-pill ${catBdg(o.cat)}">${catLabel(o.cat)}</span>
               <button type="button" onclick="toggleBookmark(event, ${globalIdx})" class="bookmark-btn" title="${isBookmarked(o.name) ? 'Remove bookmark' : 'Add bookmark'}" aria-label="${isBookmarked(o.name) ? 'Remove bookmark from ' : 'Add bookmark to '}${escapeHtml(o.name)}">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-label="star" role="img">
                   <path
                     d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
                     ${isBookmarked(o.name)
-                      ? 'fill="#FFC107" stroke="#FFC107" stroke-width="1.5" stroke-linejoin="round"'
-                      : 'fill="none" stroke="#6B7280" stroke-width="1.5" stroke-linejoin="round"'
-                    }
+        ? 'fill="#FFC107" stroke="#FFC107" stroke-width="1.5" stroke-linejoin="round"'
+        : 'fill="none" stroke="#6B7280" stroke-width="1.5" stroke-linejoin="round"'
+      }
                   />
                 </svg>
               </button>
             </div>
           </div>
-          ${repoHref?`<a class="card-repo-link" href="${escapeHtml(repoHref)}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" title="${escapeHtml(repoHref)}">
-            ${UMBRELLA_ORGS.has(o.name)||!o.github.includes('/')?
-              '<svg viewBox="0 0 24 24" fill="currentColor" width="10" height="10"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg>':
-              '<svg viewBox="0 0 24 24" fill="currentColor" width="10" height="10"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.031 1.531 1.031.892 1.529 2.341 1.087 2.912.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>'}
+          ${repoHref ? `<a class="card-repo-link" href="${escapeHtml(repoHref)}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" title="${escapeHtml(repoHref)}">
+            ${UMBRELLA_ORGS.has(o.name) || !o.github.includes('/') ?
+          '<svg viewBox="0 0 24 24" fill="currentColor" width="10" height="10"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg>' :
+          '<svg viewBox="0 0 24 24" fill="currentColor" width="10" height="10"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.031 1.531 1.031.892 1.529 2.341 1.087 2.912.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>'}
             ${repoLinkLabel(o)}
-          </a>`:''}
+          </a>`: ''}
         </div>
       </div>
       <div class="org-desc">${o.desc}</div>
@@ -766,7 +769,7 @@ function renderGrid(orgs){
         <span class="b ${yBdg(o.years)}">${yLbl(o.years)} · ${o.years}y</span>
         <span class="b ${cBdg(o.competition)}">${cLbl(o.competition)}</span>
         <span class="b ${aBdg(act)}">${aLbl(act)}</span>
-        ${o._gh?.gfi>0?`<span class="b bgfi">🟢 ${o._gh.gfi} GFI</span>`:''}
+        ${o._gh?.gfi > 0 ? `<span class="b bgfi">🟢 ${o._gh.gfi} GFI</span>` : ''}
       </div>
       <div class="tags">${tags}</div>
       ${ghm}
@@ -774,87 +777,87 @@ function renderGrid(orgs){
   }).join('');
 }
 
-function updateStats(){
-  document.getElementById('totalStat').textContent=ORGS.length;
-  document.getElementById('veteranStat').textContent=ORGS.filter(o=>o.years>=8).length;
-  document.getElementById('newcomerStat').textContent=ORGS.filter(o=>o.years<=3).length;
-  document.getElementById('visitorStat').textContent=AN.todayVisits();
+function updateStats() {
+  document.getElementById('totalStat').textContent = ORGS.length;
+  document.getElementById('veteranStat').textContent = ORGS.filter(o => o.years >= 8).length;
+  document.getElementById('newcomerStat').textContent = ORGS.filter(o => o.years <= 3).length;
+  document.getElementById('visitorStat').textContent = AN.todayVisits();
 }
 
 // ══════════════════════════════════════════════
 // KEYBOARD NAVIGATION
 // ══════════════════════════════════════════════
-const GRID_COLS=()=>{
-  const g=document.getElementById('orgGrid');
-  if(!g||!g.children.length)return 3;
-  const firstRect=g.children[0].getBoundingClientRect();
-  let cols=1;
-  for(let i=1;i<g.children.length;i++){
-    if(Math.abs(g.children[i].getBoundingClientRect().top-firstRect.top)<5)cols++;
+const GRID_COLS = () => {
+  const g = document.getElementById('orgGrid');
+  if (!g || !g.children.length) return 3;
+  const firstRect = g.children[0].getBoundingClientRect();
+  let cols = 1;
+  for (let i = 1; i < g.children.length; i++) {
+    if (Math.abs(g.children[i].getBoundingClientRect().top - firstRect.top) < 5) cols++;
     else break;
   }
   return cols;
 };
 
-document.addEventListener('keydown',e=>{
+document.addEventListener('keydown', e => {
   // Close modals first
-  if(e.key==='Escape'){
-    if(document.getElementById('modalBg').classList.contains('open')){closeModal();return;}
-    if(document.getElementById('compareBg').classList.contains('open')){closeCompare();return;}
-    if(document.getElementById('anBg').classList.contains('open')){closeAn();return;}
+  if (e.key === 'Escape') {
+    if (document.getElementById('modalBg').classList.contains('open')) { closeModal(); return; }
+    if (document.getElementById('compareBg').classList.contains('open')) { closeCompare(); return; }
+    if (document.getElementById('anBg').classList.contains('open')) { closeAn(); return; }
   }
   // Don't hijack when typing in inputs
-  if(document.activeElement&&['INPUT','SELECT','TEXTAREA'].includes(document.activeElement.tagName))return;
-  const n=filteredOrgs.length;
-  if(!n)return;
-  const cols=GRID_COLS();
-  if(e.key==='ArrowRight'){
+  if (document.activeElement && ['INPUT', 'SELECT', 'TEXTAREA'].includes(document.activeElement.tagName)) return;
+  const n = filteredOrgs.length;
+  if (!n) return;
+  const cols = GRID_COLS();
+  if (e.key === 'ArrowRight') {
     e.preventDefault();
-    focusedIdx=Math.min(focusedIdx+1,n-1);
-    if(focusedIdx<0)focusedIdx=0;
-    scrollToFocused();renderGrid(filteredOrgs);
-  } else if(e.key==='ArrowLeft'){
+    focusedIdx = Math.min(focusedIdx + 1, n - 1);
+    if (focusedIdx < 0) focusedIdx = 0;
+    scrollToFocused(); renderGrid(filteredOrgs);
+  } else if (e.key === 'ArrowLeft') {
     e.preventDefault();
-    focusedIdx=Math.max(focusedIdx-1,0);
-    if(focusedIdx<0)focusedIdx=0;
-    scrollToFocused();renderGrid(filteredOrgs);
-  } else if(e.key==='ArrowDown'){
+    focusedIdx = Math.max(focusedIdx - 1, 0);
+    if (focusedIdx < 0) focusedIdx = 0;
+    scrollToFocused(); renderGrid(filteredOrgs);
+  } else if (e.key === 'ArrowDown') {
     e.preventDefault();
-    if(focusedIdx<0)focusedIdx=0;
-    else focusedIdx=Math.min(focusedIdx+cols,n-1);
-    scrollToFocused();renderGrid(filteredOrgs);
-  } else if(e.key==='ArrowUp'){
+    if (focusedIdx < 0) focusedIdx = 0;
+    else focusedIdx = Math.min(focusedIdx + cols, n - 1);
+    scrollToFocused(); renderGrid(filteredOrgs);
+  } else if (e.key === 'ArrowUp') {
     e.preventDefault();
-    if(focusedIdx<0)focusedIdx=0;
-    else focusedIdx=Math.max(focusedIdx-cols,0);
-    scrollToFocused();renderGrid(filteredOrgs);
-  } else if(e.key==='Enter'&&focusedIdx>=0&&focusedIdx<n){
+    if (focusedIdx < 0) focusedIdx = 0;
+    else focusedIdx = Math.max(focusedIdx - cols, 0);
+    scrollToFocused(); renderGrid(filteredOrgs);
+  } else if (e.key === 'Enter' && focusedIdx >= 0 && focusedIdx < n) {
     openModal(ORGS.indexOf(filteredOrgs[focusedIdx]));
-  } else if((e.key==='c'||e.key==='C')&&focusedIdx>=0&&focusedIdx<n){
+  } else if ((e.key === 'c' || e.key === 'C') && focusedIdx >= 0 && focusedIdx < n) {
     e.preventDefault();
-    toggleCompare(ORGS.indexOf(filteredOrgs[focusedIdx]),null);
+    toggleCompare(ORGS.indexOf(filteredOrgs[focusedIdx]), null);
   } else if (e.key === '/' && !['INPUT', 'SELECT', 'TEXTAREA'].includes(document.activeElement?.tagName)) {
     e.preventDefault();
     document.getElementById('searchInput').focus();
   }
 });
 
-function scrollToFocused(){
-  setTimeout(()=>{
-    const g=document.getElementById('orgGrid');
-    const card=g?.querySelector(`[data-filtered-idx="${focusedIdx}"]`);
-    if(card)card.scrollIntoView({block:'nearest',behavior:'smooth'});
-  },30);
+function scrollToFocused() {
+  setTimeout(() => {
+    const g = document.getElementById('orgGrid');
+    const card = g?.querySelector(`[data-filtered-idx="${focusedIdx}"]`);
+    if (card) card.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, 30);
 }
 
 // ══════════════════════════════════════════════
 // PILLS & CHIPS
 // ══════════════════════════════════════════════
-function togglePill(el){
-  const l=el.dataset.lang;
+function togglePill(el) {
+  const l = el.dataset.lang;
   const isActive = el.classList.toggle('active');
   el.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-  if(isActive)pills.add(l);else pills.delete(l);
+  if (isActive) pills.add(l); else pills.delete(l);
   renderSelectedLanguages();
   applyFilters();
 }
@@ -866,34 +869,34 @@ function togglePill(el){
 globalThis.togglePill = togglePill;
 
 globalThis.renderSelectedLanguages = renderSelectedLanguages;
-function renderSelectedLanguages(){
-  const container=document.getElementById('selectedLangsStrip');
-  if(!container)return;
+function renderSelectedLanguages() {
+  const container = document.getElementById('selectedLangsStrip');
+  if (!container) return;
 
-  if(pills.size===0){
-    container.innerHTML='<span class="empty-state">No languages selected</span>';
+  if (pills.size === 0) {
+    container.innerHTML = '<span class="empty-state">No languages selected</span>';
     return;
   }
 
-  const badges=[...pills].map(lang=>{
-    return`<span class="selected-lang-badge" data-lang="${lang}">
+  const badges = [...pills].map(lang => {
+    return `<span class="selected-lang-badge" data-lang="${lang}">
       ${lang}
       <button class="unselect-lang-btn" onclick="unselectLanguage('${lang}')" aria-label="Remove ${lang}">×</button>
     </span>`;
   }).join('');
 
-  const clearAll=`<button class="clear-all-langs-btn" onclick="clearAllLanguages()">Clear all</button>`;
+  const clearAll = `<button class="clear-all-langs-btn" onclick="clearAllLanguages()">Clear all</button>`;
 
-  container.innerHTML=badges+clearAll;
+  container.innerHTML = badges + clearAll;
 }
 
-function unselectLanguage(lang){
+function unselectLanguage(lang) {
   pills.delete(lang);
 
-  const pillBtn=document.querySelector(`.pill[data-lang="${lang}"]`);
-  if(pillBtn){
+  const pillBtn = document.querySelector(`.pill[data-lang="${lang}"]`);
+  if (pillBtn) {
     pillBtn.classList.remove('active');
-    pillBtn.setAttribute('aria-pressed','false');
+    pillBtn.setAttribute('aria-pressed', 'false');
   }
 
   renderSelectedLanguages();
@@ -901,12 +904,12 @@ function unselectLanguage(lang){
 }
 globalThis.unselectLanguage = unselectLanguage;
 
-function clearAllLanguages(){
+function clearAllLanguages() {
   pills.clear();
 
-  document.querySelectorAll('.pill.active').forEach(p=>{
+  document.querySelectorAll('.pill.active').forEach(p => {
     p.classList.remove('active');
-    p.setAttribute('aria-pressed','false');
+    p.setAttribute('aria-pressed', 'false');
   });
 
   renderSelectedLanguages();
@@ -914,13 +917,13 @@ function clearAllLanguages(){
 }
 globalThis.clearAllLanguages = clearAllLanguages;
 
-const chipCls={veteran:'cv',newcomer:'cn',hot:'ch',chill:'cc',active:'ca', bookmarked:'cb'};
-function toggleChip(k){
-  const el=document.getElementById('chip-'+k);
-  if(!el) return;
-  
+const chipCls = { veteran: 'cv', newcomer: 'cn', hot: 'ch', chill: 'cc', active: 'ca', bookmarked: 'cb' };
+function toggleChip(k) {
+  const el = document.getElementById('chip-' + k);
+  if (!el) return;
+
   const isActive = !chips.has(k);
-  if(isActive){
+  if (isActive) {
     chips.add(k);
     el.classList.add('bg-orange-600', 'text-white');
     el.classList.remove('bg-surface-container-highest');
@@ -931,110 +934,111 @@ function toggleChip(k){
   }
   applyFilters();
 }
-function resetFilters(){
+function resetFilters() {
   ['searchInput', 'hero-search', 'categoryFilter', 'complexityFilter', 'langFilter'].forEach(id => {
     const e = document.getElementById(id);
     if (e) e.value = (id === 'categoryFilter' || id === 'complexityFilter') ? 'all' : '';
   });
-  document.getElementById('sortSelect').value='alpha';
-  pills.clear();chips.clear();
+  document.getElementById('sortSelect').value = 'alpha';
+  pills.clear(); chips.clear();
 
-  document.querySelectorAll('.pill.active').forEach(p=>p.classList.remove('active'));
-  Object.keys(chipCls).forEach(k=>{const e=document.getElementById('chip-'+k);if(e)e.className='chip';});
+  document.querySelectorAll('.pill.active').forEach(p => p.classList.remove('active'));
+  Object.keys(chipCls).forEach(k => { const e = document.getElementById('chip-' + k); if (e) e.className = 'chip'; });
 
-  document.querySelectorAll('.pill.active').forEach(p=>{p.classList.remove('active');p.setAttribute('aria-pressed','false');});
-  Object.keys(chipCls).forEach(k=>{
-    const e=document.getElementById('chip-'+k);
-    if(e) {
+  document.querySelectorAll('.pill.active').forEach(p => { p.classList.remove('active'); p.setAttribute('aria-pressed', 'false'); });
+  Object.keys(chipCls).forEach(k => {
+    const e = document.getElementById('chip-' + k);
+    if (e) {
       e.classList.remove('bg-orange-600', 'text-white');
       e.classList.add('bg-surface-container-highest');
     }
   });
   renderSelectedLanguages();
- 
+
   applyFilters();
 }
 
 // ══════════════════════════════════════════════
 // MODAL
 // ══════════════════════════════════════════════
-function openModal(idx){
-  const o=ORGS[idx];modalIdx=idx;AN.trackOrg(o.name);
-  document.getElementById('mCat').innerHTML=`<span class="cat-pill ${catBdg(o.cat)}">${escapeHtml(catLabel(o.cat))}</span>`;
-  document.getElementById('mName').textContent=o.name;
-  document.getElementById('mDesc').textContent=o.desc;
-  const cc={hot:'var(--red)',moderate:'#92600A',chill:'var(--green)'};
-  document.getElementById('mMetrics').innerHTML=`
-    <div class="mc"><div class="mv" style="color:${o.years>=8?'#C2410C':o.years>=4?'var(--blue)':'var(--purple)'}">${escapeHtml(String(o.years))}</div>
-    <div class="ml">GSoC Years</div><div class="prog"><div class="prog-fill" style="width:${Math.min(o.years/11*100,100)}%;background:${o.years>=8?'#C2410C':o.years>=4?'var(--blue)':'var(--purple)'}"></div></div></div>
-    <div class="mc"><div class="mv" style="color:${cc[o.competition]}">${escapeHtml(o.competition==='hot'?'🔥':o.competition==='moderate'?'🟡':'😎')}</div><div class="ml">${escapeHtml(String(cLbl(o.competition)))}</div></div>
+function openModal(idx) {
+  const o = ORGS[idx]; modalIdx = idx; AN.trackOrg(o.name);
+  document.getElementById('mCat').innerHTML = `<span class="cat-pill ${catBdg(o.cat)}">${escapeHtml(catLabel(o.cat))}</span>`;
+  document.getElementById('mName').textContent = o.name;
+  document.getElementById('mDesc').textContent = o.desc;
+  const cc = { hot: 'var(--red)', moderate: '#92600A', chill: 'var(--green)' };
+  document.getElementById('mMetrics').innerHTML = `
+    <div class="mc"><div class="mv" style="color:${o.years >= 8 ? '#C2410C' : o.years >= 4 ? 'var(--blue)' : 'var(--purple)'}">${escapeHtml(String(o.years))}</div>
+    <div class="ml">GSoC Years</div><div class="prog"><div class="prog-fill" style="width:${Math.min(o.years / 11 * 100, 100)}%;background:${o.years >= 8 ? '#C2410C' : o.years >= 4 ? 'var(--blue)' : 'var(--purple)'}"></div></div></div>
+    <div class="mc"><div class="mv" style="color:${cc[o.competition]}">${escapeHtml(o.competition === 'hot' ? '🔥' : o.competition === 'moderate' ? '🟡' : '😎')}</div><div class="ml">${escapeHtml(String(cLbl(o.competition)))}</div></div>
     <div class="mc"><div class="mv" style="color:var(--orange)">${escapeHtml(String(o.firstYear))}</div><div class="ml">First Year</div></div>
-    <div class="mc"><div class="mv" style="color:var(--green)">${escapeHtml(o._gh?.gfi!==null&&o._gh?.gfi!==undefined?fmt(o._gh.gfi):'—')}</div><div class="ml">Good 1st Issues</div></div>`;
-  const gh=o._gh;
-  document.getElementById('ghStars').textContent=gh?fmt(gh.stars):'—';
-  document.getElementById('ghForks').textContent=gh?fmt(gh.forks):'—';
-  document.getElementById('ghIssues').textContent=gh?fmt(gh.issues):'—';
-  document.getElementById('ghCommit').textContent=gh?gh.lastCommit:'—';
-  document.getElementById('ghGFI').textContent=gh?.gfi!==null&&gh?.gfi!==undefined?fmt(gh.gfi):'—';
-  document.getElementById('mFetchBtn').textContent=gh?'↻ Refresh':'Fetch Live Data';
-  document.getElementById('mTags').innerHTML=o.tags.map(t=>`<span class="m-tag">${escapeHtml(t)}</span>`).join('');
-  document.getElementById('mFit').innerHTML=o.fit.map(f=>`<span class="m-tag">${escapeHtml(f)}</span>`).join('');
-  let tl='';
-  for(let y=o.firstYear;y<=2026;y++){
-    const cur=y===2026;
-    tl+=`<span style="margin-right:10px;color:${cur?'var(--orange)':'var(--ink3)'};font-weight:${cur?700:400}">${escapeHtml(cur?'⭐':'✓')} ${escapeHtml(String(y))}</span>`;}
-  document.getElementById('mTimeline').innerHTML=tl;
-  // Smart link: umbrella orgs → org page, single-project → specific repo
-  const mLinkEl=document.getElementById('mLink');
-  if(mLinkEl&&o.github){
-    const owner=o.github.includes('/')?o.github.split('/')[0]:o.github;
-    const isUmbrella=UMBRELLA_ORGS.has(o.name)||!o.github.includes('/');
-    mLinkEl.href=isUmbrella?`https://github.com/${owner}`:`https://github.com/${o.github}`;
-    mLinkEl.textContent=isUmbrella?'View GitHub Org →':'View Repository →';
+    <div class="mc"><div class="mv" style="color:var(--green)">${escapeHtml(o._gh?.gfi !== null && o._gh?.gfi !== undefined ? fmt(o._gh.gfi) : '—')}</div><div class="ml">Good 1st Issues</div></div>`;
+  const gh = o._gh;
+  document.getElementById('ghStars').textContent = gh ? fmt(gh.stars) : '—';
+  document.getElementById('ghForks').textContent = gh ? fmt(gh.forks) : '—';
+  document.getElementById('ghIssues').textContent = gh ? fmt(gh.issues) : '—';
+  document.getElementById('ghCommit').textContent = gh ? gh.lastCommit : '—';
+  document.getElementById('ghGFI').textContent = gh?.gfi !== null && gh?.gfi !== undefined ? fmt(gh.gfi) : '—';
+  document.getElementById('mFetchBtn').textContent = gh ? '↻ Refresh' : 'Fetch Live Data';
+  document.getElementById('mTags').innerHTML = o.tags.map(t => `<span class="m-tag">${escapeHtml(t)}</span>`).join('');
+  document.getElementById('mFit').innerHTML = o.fit.map(f => `<span class="m-tag">${escapeHtml(f)}</span>`).join('');
+  let tl = '';
+  for (let y = o.firstYear; y <= 2026; y++) {
+    const cur = y === 2026;
+    tl += `<span style="margin-right:10px;color:${cur ? 'var(--orange)' : 'var(--ink3)'};font-weight:${cur ? 700 : 400}">${escapeHtml(cur ? '⭐' : '✓')} ${escapeHtml(String(y))}</span>`;
   }
-  
+  document.getElementById('mTimeline').innerHTML = tl;
+  // Smart link: umbrella orgs → org page, single-project → specific repo
+  const mLinkEl = document.getElementById('mLink');
+  if (mLinkEl && o.github) {
+    const owner = o.github.includes('/') ? o.github.split('/')[0] : o.github;
+    const isUmbrella = UMBRELLA_ORGS.has(o.name) || !o.github.includes('/');
+    mLinkEl.href = isUmbrella ? `https://github.com/${owner}` : `https://github.com/${o.github}`;
+    mLinkEl.textContent = isUmbrella ? 'View GitHub Org →' : 'View Repository →';
+  }
+
   // Validate and display Ideas page link if available
   // Uses security-hardened validation that ensures only http/https protocols
   // Displays fallback message when no valid link exists
-  const mIdeasEl=document.getElementById('mIdeasLink');
-  const mIdeasText=document.getElementById('mIdeasText');
-  const validatedUrl=validateIdeasUrl(o.ideas);
-  
-  if(mIdeasEl){
-    mIdeasEl.style.display=validatedUrl?'inline-flex':'none';
-    if(validatedUrl){
-      mIdeasEl.href=validatedUrl;
-      mIdeasEl.textContent='View Ideas List →';
+  const mIdeasEl = document.getElementById('mIdeasLink');
+  const mIdeasText = document.getElementById('mIdeasText');
+  const validatedUrl = validateIdeasUrl(o.ideas);
+
+  if (mIdeasEl) {
+    mIdeasEl.style.display = validatedUrl ? 'inline-flex' : 'none';
+    if (validatedUrl) {
+      mIdeasEl.href = validatedUrl;
+      mIdeasEl.textContent = 'View Ideas List →';
     }
   }
-  
-  if(mIdeasText){
-    mIdeasText.style.display=validatedUrl?'none':'block';
+
+  if (mIdeasText) {
+    mIdeasText.style.display = validatedUrl ? 'none' : 'block';
   }
-  
+
   updateModalCompareBtn();
   document.getElementById('modalBg').classList.add('open');
-  document.body.style.overflow='hidden';
+  document.body.style.overflow = 'hidden';
   // Fetch GFI lazily on modal open
-  if(o.github&&(o._gh?.gfi===null||o._gh?.gfi===undefined)){
-    document.getElementById('ghGFI').textContent='…';
-    fetchGFI(o.github).then(gfi=>{
-      if(gfi!==null){
-        if(!o._gh)o._gh={};
-        o._gh.gfi=gfi;
-        document.getElementById('ghGFI').textContent=fmt(gfi);
-        const cells=document.getElementById('mMetrics')?.querySelectorAll('.mv');
-        if(cells&&cells[3])cells[3].textContent=fmt(gfi);
+  if (o.github && (o._gh?.gfi === null || o._gh?.gfi === undefined)) {
+    document.getElementById('ghGFI').textContent = '…';
+    fetchGFI(o.github).then(gfi => {
+      if (gfi !== null) {
+        if (!o._gh) o._gh = {};
+        o._gh.gfi = gfi;
+        document.getElementById('ghGFI').textContent = fmt(gfi);
+        const cells = document.getElementById('mMetrics')?.querySelectorAll('.mv');
+        if (cells && cells[3]) cells[3].textContent = fmt(gfi);
         renderGrid(filteredOrgs);
         renderCompareTable();
-      }else{
-        document.getElementById('ghGFI').textContent='—';
+      } else {
+        document.getElementById('ghGFI').textContent = '—';
       }
     });
   }
 }
-function closeModalEv(e){if(e.target===document.getElementById('modalBg'))closeModal();}
-function closeModal(){document.getElementById('modalBg').classList.remove('open');document.body.style.overflow='';modalIdx=-1;}
+function closeModalEv(e) { if (e.target === document.getElementById('modalBg')) closeModal(); }
+function closeModal() { document.getElementById('modalBg').classList.remove('open'); document.body.style.overflow = ''; modalIdx = -1; }
 
 // ══════════════════════════════════════════════
 // INIT
@@ -1043,37 +1047,37 @@ function closeModal(){document.getElementById('modalBg').classList.remove('open'
 // ══════════════════════════════════════════════
 // ISSUES PAGE
 // ══════════════════════════════════════════════
-let allIssues=[];        // flat list of {title,url,org,orgCat,orgTags,logo,repo,created_at}
-let filteredIssues=[];
-let shownIssues=0;
-const ISSUES_PAGE_SIZE=40;
-let issuesFetching=false;
+let allIssues = [];        // flat list of {title,url,org,orgCat,orgTags,logo,repo,created_at}
+let filteredIssues = [];
+let shownIssues = 0;
+const ISSUES_PAGE_SIZE = 40;
+let issuesFetching = false;
 
-function openIssuesPage(){
+function openIssuesPage() {
   document.getElementById('issuesPage').classList.add('open');
-  document.body.style.overflow='hidden';
+  document.body.style.overflow = 'hidden';
   loadCachedIssues();
 }
 
-function closeIssuesPage(){
+function closeIssuesPage() {
   document.getElementById('issuesPage').classList.remove('open');
-  document.body.style.overflow='';
+  document.body.style.overflow = '';
 }
 
-async function fetchAllIssues(){
-  if(issuesFetching)return;
-  issuesFetching=true;
-  const btn=document.getElementById('fetchIssuesBtn');
-  const spin=document.getElementById('fetchIssuesSpin');
-  const txt=document.getElementById('fetchIssuesTxt');
-  btn.disabled=true; spin.style.display='inline-block';
+async function fetchAllIssues() {
+  if (issuesFetching) return;
+  issuesFetching = true;
+  const btn = document.getElementById('fetchIssuesBtn');
+  const spin = document.getElementById('fetchIssuesSpin');
+  const txt = document.getElementById('fetchIssuesTxt');
+  btn.disabled = true; spin.style.display = 'inline-block';
 
-  allIssues=[];
-  const orgsWithGithub=ORGS.filter(o=>o.github);
-  let done=0;
-  let found=0;
+  allIssues = [];
+  const orgsWithGithub = ORGS.filter(o => o.github);
+  let done = 0;
+  let found = 0;
 
-  document.getElementById('issuesContainer').innerHTML=`
+  document.getElementById('issuesContainer').innerHTML = `
     <div class="fetch-progress">
       <div style="font-size:14px;font-weight:600;color:var(--ink)">Fetching Good First Issues…</div>
       <div style="font-size:12px;color:var(--muted);margin-top:4px" id="fpStatus">Checking 0 / ${orgsWithGithub.length} orgs</div>
@@ -1082,173 +1086,173 @@ async function fetchAllIssues(){
     </div>`;
 
   // Batch in groups of 5 to avoid hammering the proxy
-  const BATCH=5;
-  for(let i=0;i<orgsWithGithub.length;i+=BATCH){
-    const batch=orgsWithGithub.slice(i,i+BATCH);
-    await Promise.all(batch.map(async o=>{
-      try{
-        const r=await fetch(`${API}?repo=${encodeURIComponent(o.github)}&gfi=1&issues=1`);
-        if(!r.ok)return;
-        const data=await r.json();
-        if(data.items?.length){
-          const owner=o.github.split('/')[0];
-          const logo=`https://github.com/${owner}.png?size=64`;
-          data.items.forEach(issue=>{
-            const labelNames=(issue.labels||[]).map(l=>typeof l==='string'?l:(l.name||''));
+  const BATCH = 5;
+  for (let i = 0; i < orgsWithGithub.length; i += BATCH) {
+    const batch = orgsWithGithub.slice(i, i + BATCH);
+    await Promise.all(batch.map(async o => {
+      try {
+        const r = await fetch(`${API}?repo=${encodeURIComponent(o.github)}&gfi=1&issues=1`);
+        if (!r.ok) return;
+        const data = await r.json();
+        if (data.items?.length) {
+          const owner = o.github.split('/')[0];
+          const logo = `https://github.com/${owner}.png?size=64`;
+          data.items.forEach(issue => {
+            const labelNames = (issue.labels || []).map(l => typeof l === 'string' ? l : (l.name || ''));
             allIssues.push({
-              title:issue.title,
-              url:issue.html_url,
-              org:o.name,
-              orgCat:o.cat,
-              orgTags:o.tags,
+              title: issue.title,
+              url: issue.html_url,
+              org: o.name,
+              orgCat: o.cat,
+              orgTags: o.tags,
               logo,
-              repo:o.github,
-              created_at:issue.created_at,
-              labels:labelNames,
-              comments:issue.comments||0,
+              repo: o.github,
+              created_at: issue.created_at,
+              labels: labelNames,
+              comments: issue.comments || 0,
             });
           });
-          found+=data.items.length;
+          found += data.items.length;
         }
-        const gfiCount=data.total??data.gfi;
-        if(gfiCount!==null&&gfiCount!==undefined){
-          if(!o._gh)o._gh={};
-          o._gh.gfi=gfiCount;
+        const gfiCount = data.total ?? data.gfi;
+        if (gfiCount !== null && gfiCount !== undefined) {
+          if (!o._gh) o._gh = {};
+          o._gh.gfi = gfiCount;
         }
-      }catch(err){
-        console.warn('Failed fetching GFI issues for org:',o.github,err);
+      } catch (err) {
+        console.warn('Failed fetching GFI issues for org:', o.github, err);
       }
       done++;
     }));
     // Update progress UI
-    const pct=Math.round(done/orgsWithGithub.length*100);
-    const fpStatus=document.getElementById('fpStatus');
-    const fpBar=document.getElementById('fpBar');
-    const fpFound=document.getElementById('fpFound');
-    if(fpStatus)fpStatus.textContent=`Checking ${done} / ${orgsWithGithub.length} orgs`;
-    if(fpBar)fpBar.style.width=pct+'%';
-    if(fpFound)fpFound.textContent=`${found} issues found so far`;
-    txt.textContent=`${done}/${orgsWithGithub.length}…`;
-    await new Promise(r=>setTimeout(r,60));
+    const pct = Math.round(done / orgsWithGithub.length * 100);
+    const fpStatus = document.getElementById('fpStatus');
+    const fpBar = document.getElementById('fpBar');
+    const fpFound = document.getElementById('fpFound');
+    if (fpStatus) fpStatus.textContent = `Checking ${done} / ${orgsWithGithub.length} orgs`;
+    if (fpBar) fpBar.style.width = pct + '%';
+    if (fpFound) fpFound.textContent = `${found} issues found so far`;
+    txt.textContent = `${done}/${orgsWithGithub.length}…`;
+    await new Promise(r => setTimeout(r, 60));
   }
 
   // Sort: newest first
-  allIssues.sort((a,b)=>new Date(b.created_at)-new Date(a.created_at));
+  allIssues.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
-  issuesFetching=false;
-  btn.disabled=false; spin.style.display='none'; txt.textContent='↻ Refresh';
+  issuesFetching = false;
+  btn.disabled = false; spin.style.display = 'none'; txt.textContent = '↻ Refresh';
 
   filterIssues();
   renderGrid(filteredOrgs);
   updateStats();
 }
 
-async function loadCachedIssues(){
-  if(allIssues.length||issuesFetching) return;
-  try{
-    const res=await fetch('/data/issues.json');
-    if(!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data=await res.json();
-    if(!Array.isArray(data.issues)) return;
+async function loadCachedIssues() {
+  if (allIssues.length || issuesFetching) return;
+  try {
+    const res = await fetch('/data/issues.json');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (!Array.isArray(data.issues)) return;
 
-    const orgByGithub=new Map(ORGS.map(o=>[o.github?.toLowerCase(),o]));
-    const orgByName=new Map(ORGS.map(o=>[o.name?.toLowerCase(),o]));
+    const orgByGithub = new Map(ORGS.map(o => [o.github?.toLowerCase(), o]));
+    const orgByName = new Map(ORGS.map(o => [o.name?.toLowerCase(), o]));
 
-    allIssues=data.issues.map(issue=>{
-      const key=issue.github?.toLowerCase()||issue.repo?.toLowerCase()||issue.org?.toLowerCase();
-      const orgMeta=orgByGithub.get(key)||orgByName.get(issue.org?.toLowerCase());
-      const owner=(issue.github||issue.repo||'').split('/')[0]||'';
-      return{
-        title:issue.title||'',
-        url:issue.url||'',
-        org:issue.org||'',
-        orgCat:orgMeta?.cat||'',
-        orgTags:orgMeta?.tags||[],
-        logo:owner?`https://github.com/${owner}.png?size=64`:'',
-        repo:issue.repo||issue.github||'',
-        created_at:issue.created_at||'',
-        labels:Array.isArray(issue.labels)?issue.labels.map(l=>typeof l==='string'?l:(l.name||'')):[],
-        comments:typeof issue.comments==='number'?issue.comments:Number(issue.comments||0),
+    allIssues = data.issues.map(issue => {
+      const key = issue.github?.toLowerCase() || issue.repo?.toLowerCase() || issue.org?.toLowerCase();
+      const orgMeta = orgByGithub.get(key) || orgByName.get(issue.org?.toLowerCase());
+      const owner = (issue.github || issue.repo || '').split('/')[0] || '';
+      return {
+        title: issue.title || '',
+        url: issue.url || '',
+        org: issue.org || '',
+        orgCat: orgMeta?.cat || '',
+        orgTags: orgMeta?.tags || [],
+        logo: owner ? `https://github.com/${owner}.png?size=64` : '',
+        repo: issue.repo || issue.github || '',
+        created_at: issue.created_at || '',
+        labels: Array.isArray(issue.labels) ? issue.labels.map(l => typeof l === 'string' ? l : (l.name || '')) : [],
+        comments: typeof issue.comments === 'number' ? issue.comments : Number(issue.comments || 0),
       };
     });
 
-    allIssues.sort((a,b)=>new Date(b.created_at)-new Date(a.created_at));
+    allIssues.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
     filterIssues();
-  }catch(err){
-    console.warn('Failed to load cached issues:',err);
+  } catch (err) {
+    console.warn('Failed to load cached issues:', err);
   }
 }
 
-function filterIssues(){
-  const search=(document.getElementById('issueSearch')?.value||'').toLowerCase().trim();
-  const cat=document.getElementById('issueCatFilter')?.value||'';
-  const lang=document.getElementById('issueLangFilter')?.value||'';
-  
-  filteredIssues=allIssues.filter(iss=>{
-    if(cat&&iss.orgCat!==cat)return false;
-    if(lang&&!iss.orgTags.some(t=>t.includes(lang)))return false;
-    if(search&&!iss.title.toLowerCase().includes(search)&&!iss.org.toLowerCase().includes(search))return false;
+function filterIssues() {
+  const search = (document.getElementById('issueSearch')?.value || '').toLowerCase().trim();
+  const cat = document.getElementById('issueCatFilter')?.value || '';
+  const lang = document.getElementById('issueLangFilter')?.value || '';
+
+  filteredIssues = allIssues.filter(iss => {
+    if (cat && iss.orgCat !== cat) return false;
+    if (lang && !iss.orgTags.some(t => t.includes(lang))) return false;
+    if (search && !iss.title.toLowerCase().includes(search) && !iss.org.toLowerCase().includes(search)) return false;
     return true;
   });
-  
-  shownIssues=0;
+
+  shownIssues = 0;
   renderIssues();
 }
 
-function relativeTime(dateStr){
-  const diff=Date.now()-new Date(dateStr).getTime();
-  const d=Math.floor(diff/86400000);
-  if(d===0)return'Today';
-  if(d===1)return'Yesterday';
-  if(d<30)return d+'d ago';
-  if(d<365)return Math.floor(d/30)+'mo ago';
-  return Math.floor(d/365)+'y ago';
+function relativeTime(dateStr) {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const d = Math.floor(diff / 86400000);
+  if (d === 0) return 'Today';
+  if (d === 1) return 'Yesterday';
+  if (d < 30) return d + 'd ago';
+  if (d < 365) return Math.floor(d / 30) + 'mo ago';
+  return Math.floor(d / 365) + 'y ago';
 }
 
-function renderIssues(){
-  const container=document.getElementById('issuesContainer');
-  const statsDiv=document.getElementById('issuesStats');
-  const loadMore=document.getElementById('loadMoreWrap');
+function renderIssues() {
+  const container = document.getElementById('issuesContainer');
+  const statsDiv = document.getElementById('issuesStats');
+  const loadMore = document.getElementById('loadMoreWrap');
 
-  if(!allIssues.length){
-    container.innerHTML=`<div class="issue-empty"><div class="ei">🟢</div><h3>Ready to find your first issue?</h3><p>Click "Load Issues" to fetch Good First Issues from all GSoC orgs.</p></div>`;
-    statsDiv.style.display='none';loadMore.style.display='none';return;
+  if (!allIssues.length) {
+    container.innerHTML = `<div class="issue-empty"><div class="ei">🟢</div><h3>Ready to find your first issue?</h3><p>Click "Load Issues" to fetch Good First Issues from all GSoC orgs.</p></div>`;
+    statsDiv.style.display = 'none'; loadMore.style.display = 'none'; return;
   }
 
-  if(!filteredIssues.length){
-    container.innerHTML=`<div class="issue-empty"><div class="ei">🔍</div><h3>No issues match your filters</h3><p>Try adjusting the search or category.</p></div>`;
-    statsDiv.style.display='flex';loadMore.style.display='none';
+  if (!filteredIssues.length) {
+    container.innerHTML = `<div class="issue-empty"><div class="ei">🔍</div><h3>No issues match your filters</h3><p>Try adjusting the search or category.</p></div>`;
+    statsDiv.style.display = 'flex'; loadMore.style.display = 'none';
   } else {
-    shownIssues=Math.min(shownIssues+ISSUES_PAGE_SIZE,filteredIssues.length);
-    const visible=filteredIssues.slice(0,shownIssues);
-    container.innerHTML=`<div class="issues-grid">${visible.map(renderIssueCard).join('')}</div>`;
-    loadMore.style.display=shownIssues<filteredIssues.length?'flex':'none';
+    shownIssues = Math.min(shownIssues + ISSUES_PAGE_SIZE, filteredIssues.length);
+    const visible = filteredIssues.slice(0, shownIssues);
+    container.innerHTML = `<div class="issues-grid">${visible.map(renderIssueCard).join('')}</div>`;
+    loadMore.style.display = shownIssues < filteredIssues.length ? 'flex' : 'none';
   }
 
   // Update stats
-  const orgsWithIssues=new Set(allIssues.map(i=>i.org)).size;
-  document.getElementById('issTotal').textContent=allIssues.length.toLocaleString();
-  document.getElementById('issOrgs').textContent=orgsWithIssues;
-  document.getElementById('issShown').textContent=Math.min(shownIssues,filteredIssues.length);
-  statsDiv.style.display='flex';
+  const orgsWithIssues = new Set(allIssues.map(i => i.org)).size;
+  document.getElementById('issTotal').textContent = allIssues.length.toLocaleString();
+  document.getElementById('issOrgs').textContent = orgsWithIssues;
+  document.getElementById('issShown').textContent = Math.min(shownIssues, filteredIssues.length);
+  statsDiv.style.display = 'flex';
 }
 
-function renderIssueCard(iss){
-  const langTags=iss.orgTags.slice(0,2).map(t=>`<span class="issue-label lang">${escapeHtml(t)}</span>`).join('');
-  const gfiNames=['good first issue','good-first-issue'];
-  const otherLabels=iss.labels.filter(l=>!gfiNames.includes(String(l).toLowerCase())).slice(0,2)
-    .map(l=>`<span class="issue-label" style="background:rgba(107,33,168,.06);color:var(--purple);border:1px solid rgba(107,33,168,.2)">${escapeHtml(l)}</span>`).join('');
+function renderIssueCard(iss) {
+  const langTags = iss.orgTags.slice(0, 2).map(t => `<span class="issue-label lang">${escapeHtml(t)}</span>`).join('');
+  const gfiNames = ['good first issue', 'good-first-issue'];
+  const otherLabels = iss.labels.filter(l => !gfiNames.includes(String(l).toLowerCase())).slice(0, 2)
+    .map(l => `<span class="issue-label" style="background:rgba(107,33,168,.06);color:var(--purple);border:1px solid rgba(107,33,168,.2)">${escapeHtml(l)}</span>`).join('');
   const safeHref = validateIdeasUrl(iss.url);
   const imgSrc = validateIdeasUrl(iss.logo);
   const hrefStart = safeHref ? `<a class="issue-card" href="${escapeHtml(safeHref)}" target="_blank" rel="noopener noreferrer">` : `<div class="issue-card">`;
   const hrefEnd = safeHref ? '</a>' : '</div>';
   return `${hrefStart}
-    ${imgSrc?`<img class="issue-logo" src="${escapeHtml(imgSrc)}" alt="${escapeHtml(iss.org)}" loading="lazy" onerror="this.style.display='none'">`:``}
+    ${imgSrc ? `<img class="issue-logo" src="${escapeHtml(imgSrc)}" alt="${escapeHtml(iss.org)}" loading="lazy" onerror="this.style.display='none'">` : ``}
     <div class="issue-body">
       <div class="issue-top">
         <span class="issue-org">${escapeHtml(iss.org)}</span>
         <span class="issue-label gfi">✓ Good First Issue</span>
-        ${iss.comments>0?`<span style="font-size:10px;color:var(--muted)">💬 ${escapeHtml(String(iss.comments))}</span>`:''}
+        ${iss.comments > 0 ? `<span style="font-size:10px;color:var(--muted)">💬 ${escapeHtml(String(iss.comments))}</span>` : ''}
       </div>
       <div class="issue-title">${escapeHtml(iss.title)}</div>
       <div class="issue-meta">
@@ -1259,16 +1263,16 @@ function renderIssueCard(iss){
   ${hrefEnd}`;
 }
 
-function showMoreIssues(){
-  const container=document.getElementById('issuesContainer');
-  const next=filteredIssues.slice(shownIssues,shownIssues+ISSUES_PAGE_SIZE);
-  shownIssues+=next.length;
-  container.querySelector('.issues-grid').insertAdjacentHTML('beforeend',next.map(renderIssueCard).join(''));
-  document.getElementById('loadMoreWrap').style.display=shownIssues<filteredIssues.length?'flex':'none';
-  document.getElementById('issShown').textContent=shownIssues;
+function showMoreIssues() {
+  const container = document.getElementById('issuesContainer');
+  const next = filteredIssues.slice(shownIssues, shownIssues + ISSUES_PAGE_SIZE);
+  shownIssues += next.length;
+  container.querySelector('.issues-grid').insertAdjacentHTML('beforeend', next.map(renderIssueCard).join(''));
+  document.getElementById('loadMoreWrap').style.display = shownIssues < filteredIssues.length ? 'flex' : 'none';
+  document.getElementById('issShown').textContent = shownIssues;
 }
 
-ORGS.forEach(o=>{if(o.github&&cache[o.github])o._gh=cache[o.github];});
+ORGS.forEach(o => { if (o.github && cache[o.github]) o._gh = cache[o.github]; });
 showSkeletons();
 updateStats();
 renderSelectedLanguages();
@@ -1279,10 +1283,10 @@ document.getElementById('matchAllLanguagesToggle')?.addEventListener('change', (
   applyFilters();
 });
 
-requestAnimationFrame(()=>{
+requestAnimationFrame(() => {
   const params = new URLSearchParams(location.search);
-  if (params.get('q'))    document.getElementById('searchInput').value = params.get('q');
-  if (params.get('cat'))    document.getElementById('categoryFilter').value = params.get('cat');
+  if (params.get('q')) document.getElementById('searchInput').value = params.get('q');
+  if (params.get('cat')) document.getElementById('categoryFilter').value = params.get('cat');
   const langParam = params.get('lang');
   if (langParam) {
     const langs = langParam.split(',').map(s => s.trim()).filter(Boolean);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -69,8 +69,9 @@ function updateCountdown() {
   sub.textContent = subText;
   banner.querySelector('.countdown-label').textContent = label;
 }
+let cdTimer;
 updateCountdown();
-const cdTimer = setInterval(updateCountdown, 1000);
+cdTimer = setInterval(updateCountdown, 1000);
 
 // ══════════════════════════════════════════════
 // ANALYTICS ENGINE

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,426 +1,2718 @@
-*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root,[data-theme="light"]{
-  --bg:#FAFAFA;--white:#FFFFFF;
-  --orange:#F46B0E;--orange-deep:#D45800;--orange-pale:#FFF4EC;--orange-mid:#FFE0C8;--orange-border:#FECBA0;
-  --ink:#1C1008;--ink2:#3A2010;--ink3:#7A5030;--muted:#B07850;
-  --border:#EAD8C8;--border2:#F2E5D8;
-  --green:#00875A;--red:#C53030;--blue:#1A56DB;--purple:#6B21A8;
-  --shadow:0 1px 4px rgba(28,16,8,.07),0 6px 20px rgba(28,16,8,.05);
-  --shadow-lg:0 12px 40px rgba(28,16,8,.13);
-  --card-bg:#FFFFFF;--nav-bg:rgba(250,250,250,.93);--toggle-bg:#EAD8C8;--toggle-knob:#FFFFFF;
-  --input-bg:#FAFAFA;--tag-bg:#FAFAFA;--modal-bg:#FFFFFF;--an-bg:#FAFAFA;
-  --skeleton-base:#e8e8e8;--skeleton-shine:#f4f4f4;
+/* Fix: hide material symbols until font loads */
+.material-symbols-outlined {
+  opacity: 0;
+  transition: opacity 0.15s ease;
 }
-[data-theme="dark"]{
-  --bg:#0F0A05;--white:#1A1108;
-  --orange:#F97316;--orange-deep:#FB923C;--orange-pale:#1C0F05;--orange-mid:#2A1508;--orange-border:#7C3A0A;
-  --ink:#F5E6D3;--ink2:#E0C9A8;--ink3:#C4A07A;--muted:#8A6A45;
-  --border:#2E1E0A;--border2:#241608;
-  --green:#34D399;--red:#FC8181;--blue:#60A5FA;--purple:#C084FC;
-  --shadow:0 1px 4px rgba(0,0,0,.4),0 6px 20px rgba(0,0,0,.3);
-  --shadow-lg:0 12px 40px rgba(0,0,0,.5);
-  --card-bg:#1A1108;--nav-bg:rgba(15,10,5,.93);--toggle-bg:#2E1E0A;--toggle-knob:#F97316;
-  --input-bg:#1A1108;--tag-bg:#0F0A05;--modal-bg:#1A1108;--an-bg:#0F0A05;
-  --skeleton-base:#2a2a3a;--skeleton-shine:#33334a;
+
+.fonts-loaded .material-symbols-outlined {
+  opacity: 1;
 }
-html{scroll-behavior:smooth}
-body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-serif;min-height:100vh;overflow-x:hidden;transition:background .3s,color .3s}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0
+}
+
+:root,
+[data-theme="light"] {
+  --bg: #FAFAFA;
+  --white: #FFFFFF;
+  --orange: #F46B0E;
+  --orange-deep: #D45800;
+  --orange-pale: #FFF4EC;
+  --orange-mid: #FFE0C8;
+  --orange-border: #FECBA0;
+  --ink: #1C1008;
+  --ink2: #3A2010;
+  --ink3: #7A5030;
+  --muted: #B07850;
+  --border: #EAD8C8;
+  --border2: #F2E5D8;
+  --green: #00875A;
+  --red: #C53030;
+  --blue: #1A56DB;
+  --purple: #6B21A8;
+  --shadow: 0 1px 4px rgba(28, 16, 8, .07), 0 6px 20px rgba(28, 16, 8, .05);
+  --shadow-lg: 0 12px 40px rgba(28, 16, 8, .13);
+  --card-bg: #FFFFFF;
+  --nav-bg: rgba(250, 250, 250, .93);
+  --toggle-bg: #EAD8C8;
+  --toggle-knob: #FFFFFF;
+  --input-bg: #FAFAFA;
+  --tag-bg: #FAFAFA;
+  --modal-bg: #FFFFFF;
+  --an-bg: #FAFAFA;
+  --skeleton-base: #e8e8e8;
+  --skeleton-shine: #f4f4f4;
+}
+
+[data-theme="dark"] {
+  --bg: #0F0A05;
+  --white: #1A1108;
+  --orange: #F97316;
+  --orange-deep: #FB923C;
+  --orange-pale: #1C0F05;
+  --orange-mid: #2A1508;
+  --orange-border: #7C3A0A;
+  --ink: #F5E6D3;
+  --ink2: #E0C9A8;
+  --ink3: #C4A07A;
+  --muted: #8A6A45;
+  --border: #2E1E0A;
+  --border2: #241608;
+  --green: #34D399;
+  --red: #FC8181;
+  --blue: #60A5FA;
+  --purple: #C084FC;
+  --shadow: 0 1px 4px rgba(0, 0, 0, .4), 0 6px 20px rgba(0, 0, 0, .3);
+  --shadow-lg: 0 12px 40px rgba(0, 0, 0, .5);
+  --card-bg: #1A1108;
+  --nav-bg: rgba(15, 10, 5, .93);
+  --toggle-bg: #2E1E0A;
+  --toggle-knob: #F97316;
+  --input-bg: #1A1108;
+  --tag-bg: #0F0A05;
+  --modal-bg: #1A1108;
+  --an-bg: #0F0A05;
+  --skeleton-base: #2a2a3a;
+  --skeleton-shine: #33334a;
+}
+
+html {
+  scroll-behavior: smooth
+}
+
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  min-height: 100vh;
+  overflow-x: hidden;
+  transition: background .3s, color .3s
+}
 
 /* ── NAV ── */
-.nav{position:sticky;top:0;z-index:60;background:var(--nav-bg);backdrop-filter:blur(14px);border-bottom:1px solid var(--border);transition:background .3s,border-color .3s}
-.nav-inner{max-width:1340px;margin:0 auto;height:58px;display:flex;align-items:center;justify-content:space-between;padding:0 24px;gap:8px}
-.nav-brand{display:flex;align-items:center;gap:10px;text-decoration:none;flex-shrink:0}
-.gsoc-logo{width:34px;height:34px;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,#FBBC04,var(--orange));border-radius:8px;font-family:'Playfair Display',serif;font-size:18px;font-weight:900;color:white;letter-spacing:-0.04em;box-shadow:0 2px 8px rgba(244,107,14,.3)}
-.nav-title{font-family:'Playfair Display',serif;font-size:16px;font-weight:700;color:var(--ink);letter-spacing:-.02em;transition:color .3s}
-.nav-title em{font-style:italic;color:var(--orange)}
-.nav-right{display:flex;align-items:center;gap:6px;flex-wrap:nowrap}
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  background: var(--nav-bg);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border);
+  transition: background .3s, border-color .3s
+}
+
+.nav-inner {
+  max-width: 1340px;
+  margin: 0 auto;
+  height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  gap: 8px
+}
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  flex-shrink: 0
+}
+
+.gsoc-logo {
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #FBBC04, var(--orange));
+  border-radius: 8px;
+  font-family: 'Playfair Display', serif;
+  font-size: 18px;
+  font-weight: 900;
+  color: white;
+  letter-spacing: -0.04em;
+  box-shadow: 0 2px 8px rgba(244, 107, 14, .3)
+}
+
+.nav-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: -.02em;
+  transition: color .3s
+}
+
+.nav-title em {
+  font-style: italic;
+  color: var(--orange)
+}
+
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: nowrap
+}
 
 /* ── COUNTDOWN BANNER ── */
-.countdown-banner{background:linear-gradient(135deg,var(--orange-pale),var(--orange-mid));border-bottom:1px solid var(--orange-border);padding:8px 24px;text-align:center;font-size:12px;font-weight:600;color:var(--orange-deep);display:flex;align-items:center;justify-content:center;gap:12px;flex-wrap:wrap}
-.countdown-units{display:inline-flex;gap:8px}
-.cu{display:inline-flex;flex-direction:column;align-items:center;background:var(--orange);color:white;border-radius:6px;padding:2px 8px;min-width:36px}
-.cu-n{font-family:'Playfair Display',serif;font-size:15px;font-weight:900;line-height:1}
-.cu-l{font-size:8px;letter-spacing:.07em;text-transform:uppercase;opacity:.85}
-.countdown-label{font-size:11px;opacity:.8}
+.countdown-banner {
+  background: linear-gradient(135deg, var(--orange-pale), var(--orange-mid));
+  border-bottom: 1px solid var(--orange-border);
+  padding: 8px 24px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--orange-deep);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap
+}
+
+.countdown-units {
+  display: inline-flex;
+  gap: 8px
+}
+
+.cu {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--orange);
+  color: white;
+  border-radius: 6px;
+  padding: 2px 8px;
+  min-width: 36px
+}
+
+.cu-n {
+  font-family: 'Playfair Display', serif;
+  font-size: 15px;
+  font-weight: 900;
+  line-height: 1
+}
+
+.cu-l {
+  font-size: 8px;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+  opacity: .85
+}
+
+.countdown-label {
+  font-size: 11px;
+  opacity: .8
+}
 
 /* ── THEME TOGGLE ── */
-.theme-toggle{display:inline-flex;align-items:center;gap:6px;padding:5px 9px;border-radius:8px;border:1.5px solid var(--border);background:transparent;cursor:pointer;font-family:'Plus Jakarta Sans',sans-serif;transition:all .18s;flex-shrink:0}
-.theme-toggle:hover{border-color:var(--orange);background:var(--orange-pale)}
-.toggle-track{width:32px;height:18px;border-radius:100px;background:var(--toggle-bg);position:relative;transition:background .3s;border:1.5px solid var(--border);flex-shrink:0}
-.toggle-knob{width:12px;height:12px;border-radius:50%;background:var(--toggle-knob);position:absolute;top:1px;left:1px;transition:transform .3s;box-shadow:0 1px 3px rgba(0,0,0,.2)}
-[data-theme="dark"] .toggle-knob{transform:translateX(14px)}
-.toggle-label{font-size:11px;font-weight:700;color:var(--ink3);white-space:nowrap}
-.sun-icon,.moon-icon{font-size:12px;line-height:1}
-[data-theme="light"] .moon-icon{display:none}
-[data-theme="dark"] .sun-icon{display:none}
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 9px;
+  border-radius: 8px;
+  border: 1.5px solid var(--border);
+  background: transparent;
+  cursor: pointer;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  transition: all .18s;
+  flex-shrink: 0
+}
 
-.btn-analytics,.btn-compare-nav{display:inline-flex;align-items:center;gap:5px;padding:6px 11px;border-radius:8px;border:1.5px solid var(--border);background:transparent;color:var(--ink3);font-size:11px;font-weight:600;cursor:pointer;font-family:'Plus Jakarta Sans',sans-serif;transition:all .18s;white-space:nowrap}
-.btn-analytics:hover,.btn-compare-nav:hover{border-color:var(--orange);color:var(--orange);background:var(--orange-pale)}
-.btn-compare-nav{position:relative}
-.compare-badge{position:absolute;top:-5px;right:-5px;background:var(--orange);color:white;border-radius:50%;width:16px;height:16px;font-size:9px;font-weight:900;align-items:center;justify-content:center;display:none}
-.compare-badge.show{display:flex}
-.btn-contribute{display:inline-flex;align-items:center;gap:5px;padding:7px 13px;border-radius:8px;border:none;background:var(--ink);color:var(--bg);font-size:11px;font-weight:700;cursor:pointer;font-family:'Plus Jakarta Sans',sans-serif;text-decoration:none;transition:all .18s;white-space:nowrap}
-.btn-contribute:hover{background:var(--orange);color:white;transform:translateY(-1px)}
-.btn-contribute svg{width:13px;height:13px;flex-shrink:0}
-.pulse{width:7px;height:7px;border-radius:50%;background:var(--orange);animation:pulse 2s ease-in-out infinite;flex-shrink:0}
-@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.75)}}
+.theme-toggle:hover {
+  border-color: var(--orange);
+  background: var(--orange-pale)
+}
+
+.toggle-track {
+  width: 32px;
+  height: 18px;
+  border-radius: 100px;
+  background: var(--toggle-bg);
+  position: relative;
+  transition: background .3s;
+  border: 1.5px solid var(--border);
+  flex-shrink: 0
+}
+
+.toggle-knob {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--toggle-knob);
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  transition: transform .3s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, .2)
+}
+
+[data-theme="dark"] .toggle-knob {
+  transform: translateX(14px)
+}
+
+.toggle-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--ink3);
+  white-space: nowrap
+}
+
+.sun-icon,
+.moon-icon {
+  font-size: 12px;
+  line-height: 1
+}
+
+[data-theme="light"] .moon-icon {
+  display: none
+}
+
+[data-theme="dark"] .sun-icon {
+  display: none
+}
+
+.btn-analytics,
+.btn-compare-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 11px;
+  border-radius: 8px;
+  border: 1.5px solid var(--border);
+  background: transparent;
+  color: var(--ink3);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  transition: all .18s;
+  white-space: nowrap
+}
+
+.btn-analytics:hover,
+.btn-compare-nav:hover {
+  border-color: var(--orange);
+  color: var(--orange);
+  background: var(--orange-pale)
+}
+
+.btn-compare-nav {
+  position: relative
+}
+
+.compare-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  background: var(--orange);
+  color: white;
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  font-size: 9px;
+  font-weight: 900;
+  align-items: center;
+  justify-content: center;
+  display: none
+}
+
+.compare-badge.show {
+  display: flex
+}
+
+.btn-contribute {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 13px;
+  border-radius: 8px;
+  border: none;
+  background: var(--ink);
+  color: var(--bg);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  text-decoration: none;
+  transition: all .18s;
+  white-space: nowrap
+}
+
+.btn-contribute:hover {
+  background: var(--orange);
+  color: white;
+  transform: translateY(-1px)
+}
+
+.btn-contribute svg {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0
+}
+
+.pulse {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--orange);
+  animation: pulse 2s ease-in-out infinite;
+  flex-shrink: 0
+}
+
+@keyframes pulse {
+
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1)
+  }
+
+  50% {
+    opacity: .5;
+    transform: scale(.75)
+  }
+}
 
 /* ── HERO ── */
-.hero{padding:48px 24px 36px;text-align:center;position:relative;overflow:hidden}
-.hero::before{content:'';position:absolute;inset:0;background:radial-gradient(ellipse 70% 60% at 50% 0%,rgba(244,107,14,.07),transparent);pointer-events:none}
-.hero-pill{display:inline-flex;align-items:center;gap:8px;background:var(--orange-pale);border:1.5px solid var(--orange-border);border-radius:100px;padding:5px 14px;font-size:11px;font-weight:700;color:var(--orange-deep);letter-spacing:.05em;text-transform:uppercase;margin-bottom:18px}
-.hero h1{font-family:'Playfair Display',serif;font-size:clamp(36px,5.5vw,68px);font-weight:900;color:var(--ink);line-height:1.02;letter-spacing:-.03em;margin-bottom:12px;transition:color .3s}
-.hero h1 em{font-style:italic;color:var(--orange)}
-.hero-sub{font-size:14px;color:var(--ink3);line-height:1.7;max-width:480px;margin:0 auto 30px;font-weight:400}
+.hero {
+  padding: 48px 24px 36px;
+  text-align: center;
+  position: relative;
+  overflow: hidden
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse 70% 60% at 50% 0%, rgba(244, 107, 14, .07), transparent);
+  pointer-events: none
+}
+
+.hero-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--orange-pale);
+  border: 1.5px solid var(--orange-border);
+  border-radius: 100px;
+  padding: 5px 14px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--orange-deep);
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  margin-bottom: 18px
+}
+
+.hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(36px, 5.5vw, 68px);
+  font-weight: 900;
+  color: var(--ink);
+  line-height: 1.02;
+  letter-spacing: -.03em;
+  margin-bottom: 12px;
+  transition: color .3s
+}
+
+.hero h1 em {
+  font-style: italic;
+  color: var(--orange)
+}
+
+.hero-sub {
+  font-size: 14px;
+  color: var(--ink3);
+  line-height: 1.7;
+  max-width: 480px;
+  margin: 0 auto 30px;
+  font-weight: 400
+}
 
 /* ── TRENDING SECTION ── */
-.trending-section{max-width:1340px;margin:0 auto;padding:0 24px 20px}
-.trending-header{display:flex;align-items:center;gap:8px;margin-bottom:12px}
-.trending-title{font-size:11px;font-weight:700;color:var(--muted);letter-spacing:.1em;text-transform:uppercase}
-.trending-scroll{display:flex;gap:8px;overflow-x:auto;padding-bottom:4px;scrollbar-width:none}
-.trending-scroll::-webkit-scrollbar{display:none}
-.trend-card{flex-shrink:0;background:var(--white);border:1.5px solid var(--border);border-radius:10px;padding:10px 14px;cursor:pointer;transition:all .15s;display:flex;align-items:center;gap:8px;min-width:180px;max-width:220px}
-.trend-card:hover{border-color:var(--orange);transform:translateY(-1px);box-shadow:0 4px 12px rgba(244,107,14,.1)}
-.trend-rank{font-family:'Playfair Display',serif;font-size:18px;font-weight:900;color:var(--orange);opacity:.4;flex-shrink:0;width:20px}
-.trend-info{overflow:hidden}
-.trend-name{font-size:11px;font-weight:700;color:var(--ink);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.trend-views{font-size:10px;color:var(--muted);margin-top:1px}
+.trending-section {
+  max-width: 1340px;
+  margin: 0 auto;
+  padding: 0 24px 20px
+}
+
+.trending-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px
+}
+
+.trending-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--muted);
+  letter-spacing: .1em;
+  text-transform: uppercase
+}
+
+.trending-scroll {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  scrollbar-width: none
+}
+
+.trending-scroll::-webkit-scrollbar {
+  display: none
+}
+
+.trend-card {
+  flex-shrink: 0;
+  background: var(--white);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 14px;
+  cursor: pointer;
+  transition: all .15s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 180px;
+  max-width: 220px
+}
+
+.trend-card:hover {
+  border-color: var(--orange);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(244, 107, 14, .1)
+}
+
+.trend-rank {
+  font-family: 'Playfair Display', serif;
+  font-size: 18px;
+  font-weight: 900;
+  color: var(--orange);
+  opacity: .4;
+  flex-shrink: 0;
+  width: 20px
+}
+
+.trend-info {
+  overflow: hidden
+}
+
+.trend-name {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis
+}
+
+.trend-views {
+  font-size: 10px;
+  color: var(--muted);
+  margin-top: 1px
+}
 
 /* ── STATS BAR ── */
-.stats-bar{display:flex;justify-content:center;margin-bottom:44px}
-.stats-inner{display:inline-flex;border:1.5px solid var(--border);border-radius:14px;overflow:hidden;background:var(--white);box-shadow:var(--shadow);transition:background .3s,border-color .3s}
-.sbox{padding:12px 22px;border-right:1.5px solid var(--border);text-align:center;transition:border-color .3s}
-.sbox:last-child{border-right:none}
-.sn{font-family:'Playfair Display',serif;font-size:24px;font-weight:900;line-height:1;margin-bottom:2px}
-.sl{font-size:10px;color:var(--muted);letter-spacing:.08em;text-transform:uppercase;font-weight:600}
-.sn.orange{color:var(--orange)}.sn.green{color:var(--green)}.sn.purple{color:var(--purple)}.sn.red{color:var(--red)}
+.stats-bar {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 44px
+}
+
+.stats-inner {
+  display: inline-flex;
+  border: 1.5px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--white);
+  box-shadow: var(--shadow);
+  transition: background .3s, border-color .3s
+}
+
+.sbox {
+  padding: 12px 22px;
+  border-right: 1.5px solid var(--border);
+  text-align: center;
+  transition: border-color .3s
+}
+
+.sbox:last-child {
+  border-right: none
+}
+
+.sn {
+  font-family: 'Playfair Display', serif;
+  font-size: 24px;
+  font-weight: 900;
+  line-height: 1;
+  margin-bottom: 2px
+}
+
+.sl {
+  font-size: 10px;
+  color: var(--muted);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  font-weight: 600
+}
+
+.sn.orange {
+  color: var(--orange)
+}
+
+.sn.green {
+  color: var(--green)
+}
+
+.sn.purple {
+  color: var(--purple)
+}
+
+.sn.red {
+  color: var(--red)
+}
 
 /* ── FILTERS ── */
-.wrap{max-width:1340px;margin:0 auto;padding:0 24px}
-.filter-card{background:var(--white);border:1.5px solid var(--border);border-radius:16px;padding:20px;box-shadow:var(--shadow);margin-bottom:18px;transition:background .3s,border-color .3s}
-.filter-label{font-size:10px;font-weight:700;color:var(--muted);letter-spacing:.1em;text-transform:uppercase;margin-bottom:12px}
-.filters-row{display:flex;flex-wrap:wrap;gap:10px;align-items:flex-end;margin-bottom:16px}
-.fg{display:flex;flex-direction:column;gap:5px}
-.fg label{font-size:10px;font-weight:700;color:var(--muted);letter-spacing:.07em;text-transform:uppercase}
-.fg select,.search-input{background:var(--input-bg);border:1.5px solid var(--border);border-radius:10px;padding:9px 13px;color:var(--ink);font-family:'Plus Jakarta Sans',sans-serif;font-size:13px;font-weight:500;outline:none;cursor:pointer;transition:border-color .18s,background .3s,color .3s;min-width:148px}
-.fg select{appearance:none;padding-right:28px;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' fill='%23B07850' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 9px center}
-.fg select:focus,.search-input:focus{border-color:var(--orange)}
-.search-box{position:relative;display:flex;flex-direction:column;gap:5px}
-.search-box label{font-size:10px;font-weight:700;color:var(--muted);letter-spacing:.07em;text-transform:uppercase}
-.search-input{padding-left:34px;min-width:200px}
-.search-ico{position:absolute;bottom:10px;left:12px;font-size:14px;color:var(--muted);pointer-events:none}
-.btn-reset{background:transparent;border:1.5px solid var(--border);border-radius:10px;padding:9px 15px;color:var(--muted);font-family:'Plus Jakarta Sans',sans-serif;font-size:12px;font-weight:700;cursor:pointer;transition:all .18s;align-self:flex-end}
-.btn-reset:hover{border-color:var(--orange);color:var(--orange);background:var(--orange-pale)}
-.chips{display:flex;flex-wrap:wrap;gap:7px;padding-top:13px;border-top:1px solid var(--border2)}
-.chip{display:inline-flex;align-items:center;gap:4px;padding:5px 11px;border-radius:100px;border:1.5px solid var(--border);background:var(--bg);font-size:11px;color:var(--ink3);cursor:pointer;transition:all .15s;user-select:none;font-weight:600}
-.chip:hover{border-color:var(--orange);color:var(--orange);background:var(--orange-pale)}
-.chip.cv{border-color:#C2410C;background:rgba(194,65,12,.06);color:#C2410C}
-.chip.cn{border-color:var(--purple);background:rgba(107,33,168,.06);color:var(--purple)}
-.chip.ch{border-color:var(--red);background:rgba(197,48,48,.06);color:var(--red)}
-.chip.cc{border-color:var(--green);background:rgba(0,135,90,.06);color:var(--green)}
-.chip.ca{border-color:var(--orange);background:var(--orange-pale);color:var(--orange)}
-.chip.cb{border-color:#0891B2;background:rgba(8,145,178,.06);color:#0891B2}
-.pills{display:flex;flex-wrap:wrap;gap:5px;margin-top:11px}
-.pill{padding:4px 11px;border-radius:100px;border:1.5px solid var(--border);background:var(--bg);font-size:11px;color:var(--muted);cursor:pointer;transition:all .15s;user-select:none;font-weight:600}
-.pill:hover{border-color:var(--orange);color:var(--orange)}
-.pill.active{border-color:var(--orange);background:var(--orange-pale);color:var(--orange-deep)}
+.wrap {
+  max-width: 1340px;
+  margin: 0 auto;
+  padding: 0 24px
+}
+
+.filter-card {
+  background: var(--white);
+  border: 1.5px solid var(--border);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: var(--shadow);
+  margin-bottom: 18px;
+  transition: background .3s, border-color .3s
+}
+
+.filter-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--muted);
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  margin-bottom: 12px
+}
+
+.filters-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-end;
+  margin-bottom: 16px
+}
+
+.fg {
+  display: flex;
+  flex-direction: column;
+  gap: 5px
+}
+
+.fg label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--muted);
+  letter-spacing: .07em;
+  text-transform: uppercase
+}
+
+.fg select,
+.search-input {
+  background: var(--input-bg);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 9px 13px;
+  color: var(--ink);
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  outline: none;
+  cursor: pointer;
+  transition: border-color .18s, background .3s, color .3s;
+  min-width: 148px
+}
+
+.fg select {
+  appearance: none;
+  padding-right: 28px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' fill='%23B07850' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 9px center
+}
+
+.fg select:focus,
+.search-input:focus {
+  border-color: var(--orange)
+}
+
+.search-box {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 5px
+}
+
+.search-box label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--muted);
+  letter-spacing: .07em;
+  text-transform: uppercase
+}
+
+.search-input {
+  padding-left: 34px;
+  min-width: 200px
+}
+
+.search-ico {
+  position: absolute;
+  bottom: 10px;
+  left: 12px;
+  font-size: 14px;
+  color: var(--muted);
+  pointer-events: none
+}
+
+.btn-reset {
+  background: transparent;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 9px 15px;
+  color: var(--muted);
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all .18s;
+  align-self: flex-end
+}
+
+.btn-reset:hover {
+  border-color: var(--orange);
+  color: var(--orange);
+  background: var(--orange-pale)
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  padding-top: 13px;
+  border-top: 1px solid var(--border2)
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 11px;
+  border-radius: 100px;
+  border: 1.5px solid var(--border);
+  background: var(--bg);
+  font-size: 11px;
+  color: var(--ink3);
+  cursor: pointer;
+  transition: all .15s;
+  user-select: none;
+  font-weight: 600
+}
+
+.chip:hover {
+  border-color: var(--orange);
+  color: var(--orange);
+  background: var(--orange-pale)
+}
+
+.chip.cv {
+  border-color: #C2410C;
+  background: rgba(194, 65, 12, .06);
+  color: #C2410C
+}
+
+.chip.cn {
+  border-color: var(--purple);
+  background: rgba(107, 33, 168, .06);
+  color: var(--purple)
+}
+
+.chip.ch {
+  border-color: var(--red);
+  background: rgba(197, 48, 48, .06);
+  color: var(--red)
+}
+
+.chip.cc {
+  border-color: var(--green);
+  background: rgba(0, 135, 90, .06);
+  color: var(--green)
+}
+
+.chip.ca {
+  border-color: var(--orange);
+  background: var(--orange-pale);
+  color: var(--orange)
+}
+
+.chip.cb {
+  border-color: #0891B2;
+  background: rgba(8, 145, 178, .06);
+  color: #0891B2
+}
+
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 11px
+}
+
+.pill {
+  padding: 4px 11px;
+  border-radius: 100px;
+  border: 1.5px solid var(--border);
+  background: var(--bg);
+  font-size: 11px;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all .15s;
+  user-select: none;
+  font-weight: 600
+}
+
+.pill:hover {
+  border-color: var(--orange);
+  color: var(--orange)
+}
+
+.pill.active {
+  border-color: var(--orange);
+  background: var(--orange-pale);
+  color: var(--orange-deep)
+}
 
 /* ── KEYBOARD HINT ── */
-.kbd-hint{display:flex;align-items:center;gap:6px;font-size:10px;color:var(--muted);margin-bottom:10px;flex-wrap:wrap}
-.kbd{display:inline-flex;align-items:center;justify-content:center;background:var(--white);border:1px solid var(--border);border-radius:4px;padding:1px 5px;font-family:'Fira Code',monospace;font-size:10px;color:var(--ink3);box-shadow:0 1px 2px rgba(0,0,0,.08)}
+.kbd-hint {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  color: var(--muted);
+  margin-bottom: 10px;
+  flex-wrap: wrap
+}
+
+.kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-family: 'Fira Code', monospace;
+  font-size: 10px;
+  color: var(--ink3);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .08)
+}
 
 /* ── API BANNER ── */
-.api-banner{display:flex;align-items:center;gap:12px;padding:10px 16px;border-radius:12px;border:1.5px solid var(--border);background:var(--white);font-size:12px;margin-bottom:16px;flex-wrap:wrap;transition:background .3s,border-color .3s}
-.api-ok{border-color:rgba(0,135,90,.3);background:rgba(0,135,90,.04)}
-.api-ok .api-strong{color:var(--green)}
-.api-warn{border-color:rgba(244,107,14,.3);background:var(--orange-pale)}
-.api-warn .api-strong{color:var(--orange-deep)}
-.api-strong{font-weight:700;color:var(--ink)}
-.api-text{color:var(--muted)}
-.fetch-btn{display:inline-flex;align-items:center;gap:5px;background:var(--ink);color:var(--bg);border:none;border-radius:8px;padding:7px 13px;font-size:11px;font-weight:700;cursor:pointer;font-family:'Plus Jakarta Sans',sans-serif;transition:background .18s;white-space:nowrap;margin-left:auto}
-.fetch-btn:hover{background:var(--orange);color:white}
-.fetch-btn:disabled{opacity:.5;cursor:not-allowed}
-.spin{width:10px;height:10px;border:2px solid rgba(255,255,255,.3);border-top-color:#fff;border-radius:50%;animation:spin .7s linear infinite}
-@keyframes spin{to{transform:rotate(360deg)}}
+.api-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1.5px solid var(--border);
+  background: var(--white);
+  font-size: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+  transition: background .3s, border-color .3s
+}
+
+.api-ok {
+  border-color: rgba(0, 135, 90, .3);
+  background: rgba(0, 135, 90, .04)
+}
+
+.api-ok .api-strong {
+  color: var(--green)
+}
+
+.api-warn {
+  border-color: rgba(244, 107, 14, .3);
+  background: var(--orange-pale)
+}
+
+.api-warn .api-strong {
+  color: var(--orange-deep)
+}
+
+.api-strong {
+  font-weight: 700;
+  color: var(--ink)
+}
+
+.api-text {
+  color: var(--muted)
+}
+
+.fetch-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--ink);
+  color: var(--bg);
+  border: none;
+  border-radius: 8px;
+  padding: 7px 13px;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  transition: background .18s;
+  white-space: nowrap;
+  margin-left: auto
+}
+
+.fetch-btn:hover {
+  background: var(--orange);
+  color: white
+}
+
+.fetch-btn:disabled {
+  opacity: .5;
+  cursor: not-allowed
+}
+
+.spin {
+  width: 10px;
+  height: 10px;
+  border: 2px solid rgba(255, 255, 255, .3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin .7s linear infinite
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg)
+  }
+}
 
 /* ── RESULTS ── */
-.results-bar{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px;flex-wrap:wrap;gap:8px}
-.result-count{font-size:13px;color:var(--muted);font-weight:500}
-.result-count strong{color:var(--ink);font-weight:700}
-.sort-row{display:flex;align-items:center;gap:7px;font-size:12px;color:var(--muted)}
-.sort-row select{background:var(--white);border:1.5px solid var(--border);border-radius:8px;padding:6px 26px 6px 9px;color:var(--ink);font-family:'Plus Jakarta Sans',sans-serif;font-size:12px;font-weight:600;outline:none;cursor:pointer;appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%23B07850' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 7px center;transition:background-color .3s,border-color .3s,color .3s}
+.results-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+  gap: 8px
+}
+
+.result-count {
+  font-size: 13px;
+  color: var(--muted);
+  font-weight: 500
+}
+
+.result-count strong {
+  color: var(--ink);
+  font-weight: 700
+}
+
+.sort-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--muted)
+}
+
+.sort-row select {
+  background: var(--white);
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 26px 6px 9px;
+  color: var(--ink);
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  outline: none;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%23B07850' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 7px center;
+  transition: background-color .3s, border-color .3s, color .3s
+}
 
 /* ── GRID ── */
-.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(310px,1fr));gap:12px;margin-bottom:60px}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(310px, 1fr));
+  gap: 12px;
+  margin-bottom: 60px
+}
 
 /* ── CARD ── */
-.org-card{background:var(--card-bg);border:1.5px solid var(--border);border-radius:14px;padding:18px;cursor:pointer;position:relative;overflow:hidden;animation:fadeUp .25s ease forwards;transition:border-color .18s,box-shadow .18s,transform .15s,background .3s}
-.org-card::after{content:'';position:absolute;top:0;left:0;right:0;height:2.5px;background:linear-gradient(90deg,var(--orange),#FBBC04);opacity:0;transition:opacity .2s}
-.org-card:hover,.org-card.focused{border-color:var(--orange-border);box-shadow:0 4px 20px rgba(244,107,14,.1);transform:translateY(-2px)}
-.org-card:hover::after,.org-card.focused::after{opacity:1}
-.org-card.focused{outline:2px solid var(--orange);outline-offset:2px}
-.org-card.in-compare{border-color:var(--blue);background:rgba(26,86,219,.03)}
-.org-card.in-compare::after{opacity:1;background:linear-gradient(90deg,var(--blue),var(--purple))}
-@keyframes fadeUp{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:translateY(0)}}
-@media(prefers-reduced-motion:reduce){.org-card{animation:none;opacity:1}}
-.card-head{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin-bottom:7px}
-.card-header-row{display:flex;align-items:flex-start;gap:10px;margin-bottom:8px}
-.card-top-line{display:flex;align-items:flex-start;justify-content:space-between;gap:6px;margin-bottom:3px}
-.org-name{font-family:'Playfair Display',serif;font-size:14px;font-weight:700;color:var(--ink);line-height:1.3;flex:1;min-width:0;transition:color .3s}
-.card-actions{display:flex;gap:4px;flex-shrink:0;align-items:flex-start}
-.org-logo-info{flex:1;min-width:0}
-.cat-pill{font-size:9px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:3px 8px;border-radius:5px;white-space:nowrap}
-.org-desc{font-size:12px;color:var(--muted);line-height:1.6;margin-bottom:10px}
-.badges{display:flex;gap:4px;flex-wrap:wrap;margin-bottom:8px}
-.b{display:inline-flex;align-items:center;gap:3px;padding:3px 8px;border-radius:5px;font-size:10px;font-weight:700;border:1px solid transparent}
-.bv{background:rgba(194,65,12,.07);color:#C2410C;border-color:rgba(194,65,12,.2)}
-.be{background:rgba(26,86,219,.07);color:var(--blue);border-color:rgba(26,86,219,.2)}
-.bn{background:rgba(107,33,168,.07);color:var(--purple);border-color:rgba(107,33,168,.2)}
-.bh{background:rgba(197,48,48,.07);color:var(--red);border-color:rgba(197,48,48,.2)}
-.bm{background:#FFFAED;color:#92600A;border-color:rgba(251,191,36,.3)}
-[data-theme="dark"] .bm,[data-theme="dark"] .bam{background:rgba(251,191,36,.12);color:#FBBC04;border-color:rgba(251,191,36,.35)}
-.bc{background:rgba(0,135,90,.07);color:var(--green);border-color:rgba(0,135,90,.2)}
-.bac{background:var(--orange-pale);color:var(--orange-deep);border-color:var(--orange-border)}
-.bam{background:#FFFAED;color:#92600A;border-color:rgba(251,191,36,.2)}
-.bal{background:var(--border2);color:var(--muted);border-color:var(--border)}
-.bna{background:var(--bg);color:var(--muted);border-color:var(--border2)}
-.bgfi{background:rgba(26,86,219,.07);color:var(--blue);border-color:rgba(26,86,219,.2);cursor:default}
-.tags{display:flex;flex-wrap:wrap;gap:4px}
-.tag{font-size:10px;padding:2px 7px;border-radius:4px;border:1px solid var(--border2);color:var(--muted);background:var(--tag-bg);font-family:'Fira Code',monospace;transition:background .3s,border-color .3s,color .3s}
-.org-logo{width:48px;height:48px;border-radius:10px;object-fit:cover;border:1.5px solid var(--border2);background:#fff;flex-shrink:0;transition:border-color .18s}
-[data-theme="dark"] .org-logo{border-color:rgba(255,255,255,.12)}
-.issue-logo{background:#fff!important}
-.org-logo-placeholder{width:48px;height:48px;border-radius:10px;background:var(--orange-pale);color:var(--orange);font-family:'Playfair Display',serif;font-size:20px;font-weight:900;display:flex;align-items:center;justify-content:center;flex-shrink:0;border:1.5px solid var(--orange-border)}
-
-.card-repo-link{display:inline-flex;align-items:center;gap:4px;font-size:10px;color:var(--muted);text-decoration:none;font-family:'Fira Code',monospace;padding:2px 6px;border-radius:4px;border:1px solid var(--border2);background:var(--tag-bg);transition:all .15s;margin-top:4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
-.card-repo-link:hover{border-color:var(--orange);color:var(--orange);background:var(--orange-pale)}
-.card-repo-link svg{width:10px;height:10px;flex-shrink:0}
-.gh-mini{display:flex;gap:10px;margin-top:8px;padding-top:8px;border-top:1px solid var(--border2);flex-wrap:wrap}
-.bookmark-btn{
-  background:none;
-  border:none;
-  cursor:pointer;
-  padding:4px;            /* larger tap target */
-  border-radius:6px;
+.org-card {
+  background: var(--card-bg);
+  border: 1.5px solid var(--border);
+  border-radius: 14px;
+  padding: 18px;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  animation: fadeUp .25s ease forwards;
+  transition: border-color .18s, box-shadow .18s, transform .15s, background .3s
 }
-.bookmark-btn:focus-visible{
-  outline:2px solid var(--orange);
-  outline-offset:2px;
+
+.org-card::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2.5px;
+  background: linear-gradient(90deg, var(--orange), #FBBC04);
+  opacity: 0;
+  transition: opacity .2s
+}
+
+.org-card:hover,
+.org-card.focused {
+  border-color: var(--orange-border);
+  box-shadow: 0 4px 20px rgba(244, 107, 14, .1);
+  transform: translateY(-2px)
+}
+
+.org-card:hover::after,
+.org-card.focused::after {
+  opacity: 1
+}
+
+.org-card.focused {
+  outline: 2px solid var(--orange);
+  outline-offset: 2px
+}
+
+.org-card.in-compare {
+  border-color: var(--blue);
+  background: rgba(26, 86, 219, .03)
+}
+
+.org-card.in-compare::after {
+  opacity: 1;
+  background: linear-gradient(90deg, var(--blue), var(--purple))
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(10px)
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)
+  }
+}
+
+@media(prefers-reduced-motion:reduce) {
+  .org-card {
+    animation: none;
+    opacity: 1
+  }
+}
+
+.card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 7px
+}
+
+.card-header-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 8px
+}
+
+.card-top-line {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 6px;
+  margin-bottom: 3px
+}
+
+.org-name {
+  font-family: 'Playfair Display', serif;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1.3;
+  flex: 1;
+  min-width: 0;
+  transition: color .3s
+}
+
+.card-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+  align-items: flex-start
+}
+
+.org-logo-info {
+  flex: 1;
+  min-width: 0
+}
+
+.cat-pill {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 5px;
+  white-space: nowrap
+}
+
+.org-desc {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.6;
+  margin-bottom: 10px
+}
+
+.badges {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-bottom: 8px
+}
+
+.b {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 8px;
+  border-radius: 5px;
+  font-size: 10px;
+  font-weight: 700;
+  border: 1px solid transparent
+}
+
+.bv {
+  background: rgba(194, 65, 12, .07);
+  color: #C2410C;
+  border-color: rgba(194, 65, 12, .2)
+}
+
+.be {
+  background: rgba(26, 86, 219, .07);
+  color: var(--blue);
+  border-color: rgba(26, 86, 219, .2)
+}
+
+.bn {
+  background: rgba(107, 33, 168, .07);
+  color: var(--purple);
+  border-color: rgba(107, 33, 168, .2)
+}
+
+.bh {
+  background: rgba(197, 48, 48, .07);
+  color: var(--red);
+  border-color: rgba(197, 48, 48, .2)
+}
+
+.bm {
+  background: #FFFAED;
+  color: #92600A;
+  border-color: rgba(251, 191, 36, .3)
+}
+
+[data-theme="dark"] .bm,
+[data-theme="dark"] .bam {
+  background: rgba(251, 191, 36, .12);
+  color: #FBBC04;
+  border-color: rgba(251, 191, 36, .35)
+}
+
+.bc {
+  background: rgba(0, 135, 90, .07);
+  color: var(--green);
+  border-color: rgba(0, 135, 90, .2)
+}
+
+.bac {
+  background: var(--orange-pale);
+  color: var(--orange-deep);
+  border-color: var(--orange-border)
+}
+
+.bam {
+  background: #FFFAED;
+  color: #92600A;
+  border-color: rgba(251, 191, 36, .2)
+}
+
+.bal {
+  background: var(--border2);
+  color: var(--muted);
+  border-color: var(--border)
+}
+
+.bna {
+  background: var(--bg);
+  color: var(--muted);
+  border-color: var(--border2)
+}
+
+.bgfi {
+  background: rgba(26, 86, 219, .07);
+  color: var(--blue);
+  border-color: rgba(26, 86, 219, .2);
+  cursor: default
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px
+}
+
+.tag {
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 4px;
+  border: 1px solid var(--border2);
+  color: var(--muted);
+  background: var(--tag-bg);
+  font-family: 'Fira Code', monospace;
+  transition: background .3s, border-color .3s, color .3s
+}
+
+.org-logo {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  object-fit: cover;
+  border: 1.5px solid var(--border2);
+  background: #fff;
+  flex-shrink: 0;
+  transition: border-color .18s
+}
+
+[data-theme="dark"] .org-logo {
+  border-color: rgba(255, 255, 255, .12)
+}
+
+.issue-logo {
+  background: #fff !important
+}
+
+.org-logo-placeholder {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  background: var(--orange-pale);
+  color: var(--orange);
+  font-family: 'Playfair Display', serif;
+  font-size: 20px;
+  font-weight: 900;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border: 1.5px solid var(--orange-border)
+}
+
+.card-repo-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  color: var(--muted);
+  text-decoration: none;
+  font-family: 'Fira Code', monospace;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border2);
+  background: var(--tag-bg);
+  transition: all .15s;
+  margin-top: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%
+}
+
+.card-repo-link:hover {
+  border-color: var(--orange);
+  color: var(--orange);
+  background: var(--orange-pale)
+}
+
+.card-repo-link svg {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0
+}
+
+.gh-mini {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border2);
+  flex-wrap: wrap
+}
+
+.bookmark-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  /* larger tap target */
+  border-radius: 6px;
+}
+
+.bookmark-btn:focus-visible {
+  outline: 2px solid var(--orange);
+  outline-offset: 2px;
 }
 
 /* ── ISSUES PAGE ── */
-.page{display:none;position:fixed;inset:0;z-index:80;background:var(--bg);overflow-y:auto;transition:background .3s}
-.page.open{display:block}
-.page-nav{position:sticky;top:0;z-index:10;background:var(--nav-bg);backdrop-filter:blur(14px);border-bottom:1px solid var(--border);padding:0 24px;height:56px;display:flex;align-items:center;gap:12px}
-.page-back{display:inline-flex;align-items:center;gap:6px;background:transparent;border:1.5px solid var(--border);border-radius:8px;padding:6px 12px;color:var(--ink3);font-size:12px;font-weight:700;cursor:pointer;font-family:'Plus Jakarta Sans',sans-serif;transition:all .18s}
-.page-back:hover{border-color:var(--orange);color:var(--orange);background:var(--orange-pale)}
-.page-title{font-family:'Playfair Display',serif;font-size:17px;font-weight:900;color:var(--ink);flex:1}
-.page-title em{color:var(--orange);font-style:italic}
-.page-body{max-width:1100px;margin:0 auto;padding:32px 24px 60px}
-.issues-hero{text-align:center;margin-bottom:36px}
-.issues-hero h2{font-family:'Playfair Display',serif;font-size:clamp(28px,4vw,48px);font-weight:900;color:var(--ink);margin-bottom:8px}
-.issues-hero p{font-size:14px;color:var(--ink3);max-width:500px;margin:0 auto 20px}
-.issues-controls{display:flex;gap:10px;flex-wrap:wrap;align-items:center;justify-content:center;margin-bottom:12px}
-.issues-controls select,.issues-search{background:var(--input-bg);border:1.5px solid var(--border);border-radius:10px;padding:8px 12px;color:var(--ink);font-family:'Plus Jakarta Sans',sans-serif;font-size:12px;font-weight:500;outline:none;cursor:pointer;transition:border-color .18s,background .3s}
-.issues-controls select{appearance:none;padding-right:24px;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%23B07850' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 7px center}
-.issues-controls select:focus,.issues-search:focus{border-color:var(--orange)}
-.issues-search{min-width:220px}
-.btn-fetch-issues{display:inline-flex;align-items:center;gap:6px;background:var(--ink);color:var(--bg);border:none;border-radius:10px;padding:9px 18px;font-size:12px;font-weight:700;cursor:pointer;font-family:'Plus Jakarta Sans',sans-serif;transition:background .18s}
-.btn-fetch-issues:hover{background:var(--orange);color:white}
-.btn-fetch-issues:disabled{opacity:.5;cursor:not-allowed}
-.issues-stats{display:flex;gap:12px;justify-content:center;margin-bottom:28px;flex-wrap:wrap}
-.istat{background:var(--white);border:1.5px solid var(--border);border-radius:10px;padding:10px 18px;text-align:center;min-width:80px}
-.istat .iv{font-family:'Playfair Display',serif;font-size:20px;font-weight:900;color:var(--orange)}
-.istat .il{font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em;margin-top:2px}
-.issues-grid{display:flex;flex-direction:column;gap:10px}
-.issue-card{background:var(--white);border:1.5px solid var(--border);border-radius:12px;padding:16px 18px;display:flex;gap:14px;align-items:flex-start;transition:border-color .18s,box-shadow .18s,background .3s;text-decoration:none}
-.issue-card:hover{border-color:var(--orange-border);box-shadow:0 3px 14px rgba(244,107,14,.09)}
-.issue-logo{width:36px;height:36px;border-radius:8px;border:1.5px solid var(--border2);object-fit:cover;flex-shrink:0;background:var(--border2)}
-.issue-body{flex:1;min-width:0}
-.issue-top{display:flex;align-items:center;gap:8px;margin-bottom:4px;flex-wrap:wrap}
-.issue-org{font-size:10px;font-weight:700;color:var(--muted);flex-shrink:0}
-.issue-title{font-size:13px;font-weight:700;color:var(--ink);line-height:1.4;margin-bottom:6px;transition:color .3s}
-.issue-card:hover .issue-title{color:var(--orange)}
-.issue-meta{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
-.issue-label{font-size:10px;padding:2px 8px;border-radius:100px;font-weight:600}
-.issue-label.gfi{background:rgba(0,135,90,.08);color:var(--green);border:1px solid rgba(0,135,90,.2)}
-.issue-label.lang{background:var(--tag-bg);color:var(--muted);border:1px solid var(--border2);font-family:'Fira Code',monospace}
-.issue-label.cat{background:var(--orange-pale);color:var(--orange-deep);border:1px solid var(--orange-border)}
-.issue-date{font-size:10px;color:var(--muted);margin-left:auto;white-space:nowrap}
-.issue-empty{text-align:center;padding:60px 20px;color:var(--muted)}
-.issue-empty .ei{font-size:40px;margin-bottom:12px}
-.issue-empty h3{font-family:'Playfair Display',serif;font-size:20px;color:var(--ink);margin-bottom:6px}
-.load-more{display:flex;justify-content:center;margin-top:20px}
-.btn-load-more{background:var(--white);border:1.5px solid var(--border);border-radius:10px;padding:10px 24px;font-size:12px;font-weight:700;color:var(--ink3);cursor:pointer;font-family:'Plus Jakarta Sans',sans-serif;transition:all .18s}
-.btn-load-more:hover{border-color:var(--orange);color:var(--orange);background:var(--orange-pale)}
-.fetch-progress{text-align:center;padding:40px 20px;color:var(--muted)}
-.fetch-progress .fp-bar-wrap{max-width:300px;margin:14px auto 0;background:var(--border2);border-radius:100px;height:6px;overflow:hidden}
-.fetch-progress .fp-bar{height:100%;background:linear-gradient(90deg,var(--orange),#FBBC04);border-radius:100px;transition:width .4s}
-.gh-s{display:flex;align-items:center;gap:3px;font-size:10px;color:var(--muted);font-family:'Fira Code',monospace}
-.gh-s b{color:var(--ink);font-weight:600;transition:color .3s}
+.page {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  background: var(--bg);
+  overflow-y: auto;
+  transition: background .3s
+}
+
+.page.open {
+  display: block
+}
+
+.page-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--nav-bg);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border);
+  padding: 0 24px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  gap: 12px
+}
+
+.page-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 12px;
+  color: var(--ink3);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  transition: all .18s
+}
+
+.page-back:hover {
+  border-color: var(--orange);
+  color: var(--orange);
+  background: var(--orange-pale)
+}
+
+.page-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 17px;
+  font-weight: 900;
+  color: var(--ink);
+  flex: 1
+}
+
+.page-title em {
+  color: var(--orange);
+  font-style: italic
+}
+
+.page-body {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 24px 60px
+}
+
+.issues-hero {
+  text-align: center;
+  margin-bottom: 36px
+}
+
+.issues-hero h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(28px, 4vw, 48px);
+  font-weight: 900;
+  color: var(--ink);
+  margin-bottom: 8px
+}
+
+.issues-hero p {
+  font-size: 14px;
+  color: var(--ink3);
+  max-width: 500px;
+  margin: 0 auto 20px
+}
+
+.issues-controls {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 12px
+}
+
+.issues-controls select,
+.issues-search {
+  background: var(--input-bg);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 12px;
+  color: var(--ink);
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  outline: none;
+  cursor: pointer;
+  transition: border-color .18s, background .3s
+}
+
+.issues-controls select {
+  appearance: none;
+  padding-right: 24px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%23B07850' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 7px center
+}
+
+.issues-controls select:focus,
+.issues-search:focus {
+  border-color: var(--orange)
+}
+
+.issues-search {
+  min-width: 220px
+}
+
+.btn-fetch-issues {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--ink);
+  color: var(--bg);
+  border: none;
+  border-radius: 10px;
+  padding: 9px 18px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  transition: background .18s
+}
+
+.btn-fetch-issues:hover {
+  background: var(--orange);
+  color: white
+}
+
+.btn-fetch-issues:disabled {
+  opacity: .5;
+  cursor: not-allowed
+}
+
+.issues-stats {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-bottom: 28px;
+  flex-wrap: wrap
+}
+
+.istat {
+  background: var(--white);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 18px;
+  text-align: center;
+  min-width: 80px
+}
+
+.istat .iv {
+  font-family: 'Playfair Display', serif;
+  font-size: 20px;
+  font-weight: 900;
+  color: var(--orange)
+}
+
+.istat .il {
+  font-size: 10px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: .07em;
+  margin-top: 2px
+}
+
+.issues-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px
+}
+
+.issue-card {
+  background: var(--white);
+  border: 1.5px solid var(--border);
+  border-radius: 12px;
+  padding: 16px 18px;
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  transition: border-color .18s, box-shadow .18s, background .3s;
+  text-decoration: none
+}
+
+.issue-card:hover {
+  border-color: var(--orange-border);
+  box-shadow: 0 3px 14px rgba(244, 107, 14, .09)
+}
+
+.issue-logo {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1.5px solid var(--border2);
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--border2)
+}
+
+.issue-body {
+  flex: 1;
+  min-width: 0
+}
+
+.issue-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  flex-wrap: wrap
+}
+
+.issue-org {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--muted);
+  flex-shrink: 0
+}
+
+.issue-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1.4;
+  margin-bottom: 6px;
+  transition: color .3s
+}
+
+.issue-card:hover .issue-title {
+  color: var(--orange)
+}
+
+.issue-meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center
+}
+
+.issue-label {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 100px;
+  font-weight: 600
+}
+
+.issue-label.gfi {
+  background: rgba(0, 135, 90, .08);
+  color: var(--green);
+  border: 1px solid rgba(0, 135, 90, .2)
+}
+
+.issue-label.lang {
+  background: var(--tag-bg);
+  color: var(--muted);
+  border: 1px solid var(--border2);
+  font-family: 'Fira Code', monospace
+}
+
+.issue-label.cat {
+  background: var(--orange-pale);
+  color: var(--orange-deep);
+  border: 1px solid var(--orange-border)
+}
+
+.issue-date {
+  font-size: 10px;
+  color: var(--muted);
+  margin-left: auto;
+  white-space: nowrap
+}
+
+.issue-empty {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--muted)
+}
+
+.issue-empty .ei {
+  font-size: 40px;
+  margin-bottom: 12px
+}
+
+.issue-empty h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 20px;
+  color: var(--ink);
+  margin-bottom: 6px
+}
+
+.load-more {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px
+}
+
+.btn-load-more {
+  background: var(--white);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 24px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--ink3);
+  cursor: pointer;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  transition: all .18s
+}
+
+.btn-load-more:hover {
+  border-color: var(--orange);
+  color: var(--orange);
+  background: var(--orange-pale)
+}
+
+.fetch-progress {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--muted)
+}
+
+.fetch-progress .fp-bar-wrap {
+  max-width: 300px;
+  margin: 14px auto 0;
+  background: var(--border2);
+  border-radius: 100px;
+  height: 6px;
+  overflow: hidden
+}
+
+.fetch-progress .fp-bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--orange), #FBBC04);
+  border-radius: 100px;
+  transition: width .4s
+}
+
+.gh-s {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  color: var(--muted);
+  font-family: 'Fira Code', monospace
+}
+
+.gh-s b {
+  color: var(--ink);
+  font-weight: 600;
+  transition: color .3s
+}
 
 /* compare btn on card */
-.btn-card-compare{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;border-radius:5px;border:1.5px solid var(--border);background:transparent;color:var(--muted);cursor:pointer;font-size:11px;transition:all .15s;flex-shrink:0}
-.btn-card-compare:hover{border-color:var(--blue);color:var(--blue);background:rgba(26,86,219,.06)}
-.btn-card-compare.active{border-color:var(--blue);color:var(--blue);background:rgba(26,86,219,.08)}
+.btn-card-compare {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  border: 1.5px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 11px;
+  transition: all .15s;
+  flex-shrink: 0
+}
+
+.btn-card-compare:hover {
+  border-color: var(--blue);
+  color: var(--blue);
+  background: rgba(26, 86, 219, .06)
+}
+
+.btn-card-compare.active {
+  border-color: var(--blue);
+  color: var(--blue);
+  background: rgba(26, 86, 219, .08)
+}
 
 /* ── CAT COLORS ── */
-.cb-science{background:rgba(26,86,219,.07);color:#1E40AF}
-.cb-programming{background:rgba(107,33,168,.07);color:#6B21A8}
-.cb-data{background:rgba(0,135,90,.07);color:#065F46}
-.cb-web{background:rgba(244,107,14,.08);color:var(--orange-deep)}
-.cb-os{background:rgba(100,116,139,.08);color:#374151}
-.cb-security{background:rgba(197,48,48,.07);color:#991B1B}
-.cb-media{background:rgba(219,39,119,.07);color:#9D174D}
-.cb-infra{background:rgba(14,165,233,.07);color:#075985}
-.cb-ai{background:rgba(99,102,241,.08);color:#3730A3}
-.cb-dev{background:rgba(245,158,11,.08);color:#78350F}
-.cb-other{background:var(--border2);color:var(--muted)}
-[data-theme="dark"] .cb-os{background:rgba(100,116,139,.15);color:#9CA3AF}
-[data-theme="dark"] .cb-other{background:rgba(255,255,255,.05);color:var(--muted)}
+.cb-science {
+  background: rgba(26, 86, 219, .07);
+  color: #1E40AF
+}
+
+.cb-programming {
+  background: rgba(107, 33, 168, .07);
+  color: #6B21A8
+}
+
+.cb-data {
+  background: rgba(0, 135, 90, .07);
+  color: #065F46
+}
+
+.cb-web {
+  background: rgba(244, 107, 14, .08);
+  color: var(--orange-deep)
+}
+
+.cb-os {
+  background: rgba(100, 116, 139, .08);
+  color: #374151
+}
+
+.cb-security {
+  background: rgba(197, 48, 48, .07);
+  color: #991B1B
+}
+
+.cb-media {
+  background: rgba(219, 39, 119, .07);
+  color: #9D174D
+}
+
+.cb-infra {
+  background: rgba(14, 165, 233, .07);
+  color: #075985
+}
+
+.cb-ai {
+  background: rgba(99, 102, 241, .08);
+  color: #3730A3
+}
+
+.cb-dev {
+  background: rgba(245, 158, 11, .08);
+  color: #78350F
+}
+
+.cb-other {
+  background: var(--border2);
+  color: var(--muted)
+}
+
+[data-theme="dark"] .cb-os {
+  background: rgba(100, 116, 139, .15);
+  color: #9CA3AF
+}
+
+[data-theme="dark"] .cb-other {
+  background: rgba(255, 255, 255, .05);
+  color: var(--muted)
+}
 
 /* ── EMPTY ── */
-.empty{grid-column:1/-1;text-align:center;padding:70px 20px;color:var(--muted)}
-.empty-icon{font-size:44px;margin-bottom:14px}
-.empty h3{font-family:'Playfair Display',serif;font-size:21px;color:var(--ink);margin-bottom:8px}
-.empty p{font-size:14px;margin-bottom:24px}
-.btn-clear-filters{display:inline-flex;align-items:center;gap:8px;padding:10px 22px;background:var(--ink);color:var(--bg);border:none;border-radius:10px;font-size:13px;font-weight:700;cursor:pointer;transition:all .18s;font-family:'Plus Jakarta Sans',sans-serif}
-.btn-clear-filters:hover{background:var(--orange);color:white;transform:translateY(-1px);box-shadow:0 4px 12px rgb(244 107 14 / 0.2)}
+.empty {
+  grid-column: 1/-1;
+  text-align: center;
+  padding: 70px 20px;
+  color: var(--muted)
+}
+
+.empty-icon {
+  font-size: 44px;
+  margin-bottom: 14px
+}
+
+.empty h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 21px;
+  color: var(--ink);
+  margin-bottom: 8px
+}
+
+.empty p {
+  font-size: 14px;
+  margin-bottom: 24px
+}
+
+.btn-clear-filters {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 22px;
+  background: var(--ink);
+  color: var(--bg);
+  border: none;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all .18s;
+  font-family: 'Plus Jakarta Sans', sans-serif
+}
+
+.btn-clear-filters:hover {
+  background: var(--orange);
+  color: white;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgb(244 107 14 / 0.2)
+}
 
 /* ── MODAL ── */
-.modal-bg{position:fixed;inset:0;z-index:100;background:rgba(28,16,8,.5);backdrop-filter:blur(8px);display:none;align-items:center;justify-content:center;padding:20px}
-[data-theme="dark"] .modal-bg{background:rgba(0,0,0,.7)}
-.modal-bg.open{display:flex}
-.modal{background:var(--modal-bg);border-radius:20px;width:100%;max-width:560px;max-height:90vh;overflow-y:auto;position:relative;animation:su .22s ease;box-shadow:var(--shadow-lg);border:1.5px solid var(--border);transition:background .3s,border-color .3s}
-.modal::-webkit-scrollbar{width:3px}
-.modal::-webkit-scrollbar-thumb{background:var(--border);border-radius:2px}
-@keyframes su{from{opacity:0;transform:translateY(18px)}to{opacity:1;transform:translateY(0)}}
-.modal-top{padding:26px 26px 0}
-.modal-top-actions{position:absolute;top:14px;right:14px;display:flex;gap:6px}
-.close-btn,.modal-compare-btn{width:30px;height:30px;border-radius:8px;border:1.5px solid var(--border);background:var(--bg);color:var(--ink3);cursor:pointer;font-size:14px;display:flex;align-items:center;justify-content:center;transition:all .18s}
-.close-btn:hover{border-color:var(--orange);color:var(--orange);background:var(--orange-pale)}
-.modal-compare-btn:hover,.modal-compare-btn.active{border-color:var(--blue);color:var(--blue);background:rgba(26,86,219,.06)}
-.m-cat{margin-bottom:8px}
-.m-name{font-family:'Playfair Display',serif;font-size:21px;font-weight:900;color:var(--ink);line-height:1.2;padding-right:80px;margin-bottom:4px;transition:color .3s}
-.m-desc{font-size:13px;color:var(--ink3);line-height:1.7;padding:0 26px 16px}
-.modal-body{padding:0 26px 26px}
-.ms-title{font-size:10px;font-weight:700;color:var(--muted);letter-spacing:.1em;text-transform:uppercase;margin-bottom:8px}
-.m-metrics{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-bottom:16px}
-.mc{background:var(--bg);border:1.5px solid var(--border2);border-radius:11px;padding:11px;text-align:center;transition:background .3s,border-color .3s}
-.mc .mv{font-family:'Playfair Display',serif;font-size:19px;font-weight:900;margin-bottom:2px}
-.mc .ml{font-size:9px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em}
-.prog{height:3px;background:var(--border2);border-radius:2px;overflow:hidden;margin-top:6px}
-.prog-fill{height:100%;border-radius:2px}
-.gh-box{background:var(--bg);border:1.5px solid var(--border2);border-radius:11px;padding:12px 14px;margin-bottom:16px;transition:background .3s,border-color .3s}
-.gh-box-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
-.gh-box-title{font-size:10px;font-weight:700;color:var(--muted);letter-spacing:.09em;text-transform:uppercase}
-.gh-grid{display:grid;grid-template-columns:repeat(5,1fr);gap:6px}
-.gls{text-align:center}
-.gls .gv{font-family:'Playfair Display',serif;font-size:14px;font-weight:900;color:var(--ink);transition:color .3s}
-.gls .gl{font-size:9px;color:var(--muted);margin-top:2px;text-transform:uppercase;letter-spacing:.05em}
-.gh-fetch{display:inline-flex;align-items:center;gap:4px;background:var(--ink);color:var(--bg);border:none;border-radius:6px;padding:5px 10px;font-size:10px;font-weight:700;cursor:pointer;font-family:'Plus Jakarta Sans',sans-serif;transition:background .18s,color .18s}
-.gh-fetch:hover{background:var(--orange);color:white}
-.m-tags{display:flex;flex-wrap:wrap;gap:5px;margin-bottom:16px}
-.m-tag{font-size:11px;padding:4px 10px;border-radius:6px;border:1.5px solid var(--border);color:var(--ink3);background:var(--bg);font-weight:500;transition:background .3s,border-color .3s,color .3s}
-.timeline{font-size:12px;color:var(--ink3);line-height:2;margin-bottom:16px}
-.modal-cta{display:inline-flex;align-items:center;gap:8px;background:var(--orange);color:white;padding:11px 20px;border-radius:10px;font-size:13px;font-weight:700;text-decoration:none;transition:background .18s}
-.modal-cta:hover{background:var(--orange-deep)}
-.modal-ideas-link{display:inline-flex;align-items:center;gap:8px;background:var(--green);color:white;padding:11px 20px;border-radius:10px;font-size:13px;font-weight:700;text-decoration:none;transition:background .18s;margin-right:10px}
-.modal-ideas-link:hover{background:#00654d;opacity:.95}
-.modal-ideas-link:focus-visible{outline:2px solid var(--green);outline-offset:2px}
-[data-theme="dark"] .modal-ideas-link{background:#0FA673;color:#FFFFFF}
-[data-theme="dark"] .modal-ideas-link:hover{background:#096247;opacity:1}
-.modal-ideas-text{color:var(--muted);font-size:13px;font-style:italic;padding:10px 0;display:block}
+.modal-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(28, 16, 8, .5);
+  backdrop-filter: blur(8px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px
+}
+
+[data-theme="dark"] .modal-bg {
+  background: rgba(0, 0, 0, .7)
+}
+
+.modal-bg.open {
+  display: flex
+}
+
+.modal {
+  background: var(--modal-bg);
+  border-radius: 20px;
+  width: 100%;
+  max-width: 560px;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  animation: su .22s ease;
+  box-shadow: var(--shadow-lg);
+  border: 1.5px solid var(--border);
+  transition: background .3s, border-color .3s
+}
+
+.modal::-webkit-scrollbar {
+  width: 3px
+}
+
+.modal::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px
+}
+
+@keyframes su {
+  from {
+    opacity: 0;
+    transform: translateY(18px)
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)
+  }
+}
+
+.modal-top {
+  padding: 26px 26px 0
+}
+
+.modal-top-actions {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: flex;
+  gap: 6px
+}
+
+.close-btn,
+.modal-compare-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  border: 1.5px solid var(--border);
+  background: var(--bg);
+  color: var(--ink3);
+  cursor: pointer;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all .18s
+}
+
+.close-btn:hover {
+  border-color: var(--orange);
+  color: var(--orange);
+  background: var(--orange-pale)
+}
+
+.modal-compare-btn:hover,
+.modal-compare-btn.active {
+  border-color: var(--blue);
+  color: var(--blue);
+  background: rgba(26, 86, 219, .06)
+}
+
+.m-cat {
+  margin-bottom: 8px
+}
+
+.m-name {
+  font-family: 'Playfair Display', serif;
+  font-size: 21px;
+  font-weight: 900;
+  color: var(--ink);
+  line-height: 1.2;
+  padding-right: 80px;
+  margin-bottom: 4px;
+  transition: color .3s
+}
+
+.m-desc {
+  font-size: 13px;
+  color: var(--ink3);
+  line-height: 1.7;
+  padding: 0 26px 16px
+}
+
+.modal-body {
+  padding: 0 26px 26px
+}
+
+.ms-title {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--muted);
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  margin-bottom: 8px
+}
+
+.m-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-bottom: 16px
+}
+
+.mc {
+  background: var(--bg);
+  border: 1.5px solid var(--border2);
+  border-radius: 11px;
+  padding: 11px;
+  text-align: center;
+  transition: background .3s, border-color .3s
+}
+
+.mc .mv {
+  font-family: 'Playfair Display', serif;
+  font-size: 19px;
+  font-weight: 900;
+  margin-bottom: 2px
+}
+
+.mc .ml {
+  font-size: 9px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: .07em
+}
+
+.prog {
+  height: 3px;
+  background: var(--border2);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 6px
+}
+
+.prog-fill {
+  height: 100%;
+  border-radius: 2px
+}
+
+.gh-box {
+  background: var(--bg);
+  border: 1.5px solid var(--border2);
+  border-radius: 11px;
+  padding: 12px 14px;
+  margin-bottom: 16px;
+  transition: background .3s, border-color .3s
+}
+
+.gh-box-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px
+}
+
+.gh-box-title {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--muted);
+  letter-spacing: .09em;
+  text-transform: uppercase
+}
+
+.gh-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px
+}
+
+.gls {
+  text-align: center
+}
+
+.gls .gv {
+  font-family: 'Playfair Display', serif;
+  font-size: 14px;
+  font-weight: 900;
+  color: var(--ink);
+  transition: color .3s
+}
+
+.gls .gl {
+  font-size: 9px;
+  color: var(--muted);
+  margin-top: 2px;
+  text-transform: uppercase;
+  letter-spacing: .05em
+}
+
+.gh-fetch {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--ink);
+  color: var(--bg);
+  border: none;
+  border-radius: 6px;
+  padding: 5px 10px;
+  font-size: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  transition: background .18s, color .18s
+}
+
+.gh-fetch:hover {
+  background: var(--orange);
+  color: white
+}
+
+.m-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-bottom: 16px
+}
+
+.m-tag {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1.5px solid var(--border);
+  color: var(--ink3);
+  background: var(--bg);
+  font-weight: 500;
+  transition: background .3s, border-color .3s, color .3s
+}
+
+.timeline {
+  font-size: 12px;
+  color: var(--ink3);
+  line-height: 2;
+  margin-bottom: 16px
+}
+
+.modal-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--orange);
+  color: white;
+  padding: 11px 20px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: background .18s
+}
+
+.modal-cta:hover {
+  background: var(--orange-deep)
+}
+
+.modal-ideas-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--green);
+  color: white;
+  padding: 11px 20px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: background .18s;
+  margin-right: 10px
+}
+
+.modal-ideas-link:hover {
+  background: #00654d;
+  opacity: .95
+}
+
+.modal-ideas-link:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 2px
+}
+
+[data-theme="dark"] .modal-ideas-link {
+  background: #0FA673;
+  color: #FFFFFF
+}
+
+[data-theme="dark"] .modal-ideas-link:hover {
+  background: #096247;
+  opacity: 1
+}
+
+.modal-ideas-text {
+  color: var(--muted);
+  font-size: 13px;
+  font-style: italic;
+  padding: 10px 0;
+  display: block
+}
 
 /* ── COMPARE PANEL ── */
-.compare-bg{position:fixed;inset:0;z-index:150;background:rgba(28,16,8,.55);backdrop-filter:blur(10px);display:none;align-items:center;justify-content:center;padding:20px}
-[data-theme="dark"] .compare-bg{background:rgba(0,0,0,.75)}
-.compare-bg.open{display:flex}
-.compare-panel{background:var(--modal-bg);border-radius:20px;width:100%;max-width:900px;max-height:92vh;overflow-y:auto;position:relative;animation:su .25s ease;box-shadow:var(--shadow-lg);border:1.5px solid var(--border)}
-.compare-panel::-webkit-scrollbar{width:3px}
-.compare-panel::-webkit-scrollbar-thumb{background:var(--border);border-radius:2px}
-.compare-header{padding:22px 26px 16px;border-bottom:1px solid var(--border2);display:flex;align-items:center;justify-content:space-between}
-.compare-header h2{font-family:'Playfair Display',serif;font-size:20px;font-weight:900;color:var(--ink)}
-.compare-header p{font-size:12px;color:var(--muted);margin-top:2px}
-.compare-body{padding:22px 26px}
-.compare-slots{display:grid;grid-template-columns:1fr 1fr 1fr;gap:14px;margin-bottom:22px}
-.compare-slot{background:var(--bg);border:2px dashed var(--border);border-radius:12px;padding:16px;min-height:80px;display:flex;align-items:center;justify-content:center;flex-direction:column;gap:6px;cursor:pointer;transition:all .2s;text-align:center}
-.compare-slot.filled{border-style:solid;border-color:var(--orange-border);background:var(--orange-pale);cursor:default;align-items:flex-start;justify-content:flex-start}
-.compare-slot.filled .slot-name{font-family:'Playfair Display',serif;font-size:13px;font-weight:700;color:var(--ink);text-align:left;line-height:1.3}
-.compare-slot .slot-empty{font-size:11px;color:var(--muted);font-weight:600}
-.compare-slot .slot-cat{font-size:9px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;margin-bottom:4px}
-.slot-remove{display:inline-flex;align-items:center;gap:3px;margin-top:6px;padding:3px 8px;border-radius:5px;border:1px solid var(--border);background:var(--white);color:var(--muted);font-size:10px;font-weight:600;cursor:pointer;transition:all .15s}
-.slot-remove:hover{border-color:var(--red);color:var(--red)}
+.compare-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 150;
+  background: rgba(28, 16, 8, .55);
+  backdrop-filter: blur(10px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px
+}
+
+[data-theme="dark"] .compare-bg {
+  background: rgba(0, 0, 0, .75)
+}
+
+.compare-bg.open {
+  display: flex
+}
+
+.compare-panel {
+  background: var(--modal-bg);
+  border-radius: 20px;
+  width: 100%;
+  max-width: 900px;
+  max-height: 92vh;
+  overflow-y: auto;
+  position: relative;
+  animation: su .25s ease;
+  box-shadow: var(--shadow-lg);
+  border: 1.5px solid var(--border)
+}
+
+.compare-panel::-webkit-scrollbar {
+  width: 3px
+}
+
+.compare-panel::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px
+}
+
+.compare-header {
+  padding: 22px 26px 16px;
+  border-bottom: 1px solid var(--border2);
+  display: flex;
+  align-items: center;
+  justify-content: space-between
+}
+
+.compare-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 20px;
+  font-weight: 900;
+  color: var(--ink)
+}
+
+.compare-header p {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 2px
+}
+
+.compare-body {
+  padding: 22px 26px
+}
+
+.compare-slots {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 14px;
+  margin-bottom: 22px
+}
+
+.compare-slot {
+  background: var(--bg);
+  border: 2px dashed var(--border);
+  border-radius: 12px;
+  padding: 16px;
+  min-height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 6px;
+  cursor: pointer;
+  transition: all .2s;
+  text-align: center
+}
+
+.compare-slot.filled {
+  border-style: solid;
+  border-color: var(--orange-border);
+  background: var(--orange-pale);
+  cursor: default;
+  align-items: flex-start;
+  justify-content: flex-start
+}
+
+.compare-slot.filled .slot-name {
+  font-family: 'Playfair Display', serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--ink);
+  text-align: left;
+  line-height: 1.3
+}
+
+.compare-slot .slot-empty {
+  font-size: 11px;
+  color: var(--muted);
+  font-weight: 600
+}
+
+.compare-slot .slot-cat {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  margin-bottom: 4px
+}
+
+.slot-remove {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-top: 6px;
+  padding: 3px 8px;
+  border-radius: 5px;
+  border: 1px solid var(--border);
+  background: var(--white);
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all .15s
+}
+
+.slot-remove:hover {
+  border-color: var(--red);
+  color: var(--red)
+}
+
 /* comparison table */
-.compare-table{width:100%;border-collapse:collapse;font-size:12px}
-.compare-table th{padding:10px 12px;text-align:left;font-size:10px;font-weight:700;color:var(--muted);letter-spacing:.08em;text-transform:uppercase;border-bottom:1.5px solid var(--border2)}
-.compare-table th:not(:first-child){text-align:center}
-.compare-table td{padding:10px 12px;border-bottom:1px solid var(--border2);vertical-align:middle}
-.compare-table td:not(:first-child){text-align:center}
-.compare-table tr:last-child td{border-bottom:none}
-.compare-table .row-label{font-weight:600;color:var(--ink3);font-size:11px;white-space:nowrap}
-.cmp-best{font-weight:700;color:var(--green)}
-.cmp-worst{color:var(--red)}
-.cmp-val{font-family:'Fira Code',monospace;color:var(--ink)}
-.cmp-bar-wrap{display:flex;align-items:center;gap:6px}
-.cmp-bar-track{flex:1;height:5px;background:var(--border2);border-radius:3px;overflow:hidden;min-width:60px}
-.cmp-bar-fill{height:100%;border-radius:3px;background:linear-gradient(90deg,var(--orange),#FBBC04)}
-.compare-hint{font-size:11px;color:var(--muted);text-align:center;padding:20px;border:1.5px dashed var(--border);border-radius:10px;margin-top:4px}
+.compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px
+}
+
+.compare-table th {
+  padding: 10px 12px;
+  text-align: left;
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--muted);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  border-bottom: 1.5px solid var(--border2)
+}
+
+.compare-table th:not(:first-child) {
+  text-align: center
+}
+
+.compare-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border2);
+  vertical-align: middle
+}
+
+.compare-table td:not(:first-child) {
+  text-align: center
+}
+
+.compare-table tr:last-child td {
+  border-bottom: none
+}
+
+.compare-table .row-label {
+  font-weight: 600;
+  color: var(--ink3);
+  font-size: 11px;
+  white-space: nowrap
+}
+
+.cmp-best {
+  font-weight: 700;
+  color: var(--green)
+}
+
+.cmp-worst {
+  color: var(--red)
+}
+
+.cmp-val {
+  font-family: 'Fira Code', monospace;
+  color: var(--ink)
+}
+
+.cmp-bar-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px
+}
+
+.cmp-bar-track {
+  flex: 1;
+  height: 5px;
+  background: var(--border2);
+  border-radius: 3px;
+  overflow: hidden;
+  min-width: 60px
+}
+
+.cmp-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  background: linear-gradient(90deg, var(--orange), #FBBC04)
+}
+
+.compare-hint {
+  font-size: 11px;
+  color: var(--muted);
+  text-align: center;
+  padding: 20px;
+  border: 1.5px dashed var(--border);
+  border-radius: 10px;
+  margin-top: 4px
+}
 
 /* ── ANALYTICS PANEL ── */
-.an-bg{position:fixed;inset:0;z-index:200;background:rgba(28,16,8,.5);backdrop-filter:blur(8px);display:none;align-items:center;justify-content:center;padding:20px}
-[data-theme="dark"] .an-bg{background:rgba(0,0,0,.7)}
-.an-bg.open{display:flex}
-.an-panel{background:var(--white);border-radius:20px;width:100%;max-width:660px;max-height:88vh;overflow-y:auto;box-shadow:var(--shadow-lg);animation:su .22s ease;border:1.5px solid var(--border);transition:background .3s,border-color .3s}
-.an-header{padding:24px 26px 0;display:flex;align-items:flex-start;justify-content:space-between}
-.an-header h2{font-family:'Playfair Display',serif;font-size:21px;font-weight:900;color:var(--ink);transition:color .3s}
-.an-header p{font-size:12px;color:var(--muted);margin-top:3px}
-.an-body{padding:18px 26px 24px}
-.an-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:20px}
-.astat{background:var(--an-bg);border:1.5px solid var(--border2);border-radius:11px;padding:14px;text-align:center;transition:background .3s,border-color .3s}
-.astat .av{font-family:'Playfair Display',serif;font-size:22px;font-weight:900;color:var(--ink);transition:color .3s}
-.astat .al{font-size:10px;color:var(--muted);letter-spacing:.07em;text-transform:uppercase;margin-top:3px}
-.astat.hi{background:var(--orange-pale);border-color:var(--orange-border)}
-.astat.hi .av{color:var(--orange-deep)}
-.chart-sec{margin-bottom:16px}
-.chart-title{font-size:10px;font-weight:700;color:var(--muted);letter-spacing:.1em;text-transform:uppercase;margin-bottom:9px}
-.bar-chart{display:flex;flex-direction:column;gap:7px}
-.bar-row{display:flex;align-items:center;gap:9px}
-.bar-lbl{width:110px;text-align:right;font-size:11px;color:var(--ink3);flex-shrink:0}
-.bar-track{flex:1;background:var(--border2);border-radius:100px;height:6px;overflow:hidden}
-.bar-fill{height:100%;border-radius:100px;background:linear-gradient(90deg,var(--orange),#FBBC04);transition:width .8s cubic-bezier(.22,1,.36,1)}
-.bar-val{width:30px;font-size:10px;color:var(--muted);font-family:'Fira Code',monospace;flex-shrink:0}
-.search-chips{display:flex;flex-wrap:wrap;gap:5px}
-.sch{background:var(--bg);border:1px solid var(--border);border-radius:100px;padding:3px 10px;font-size:11px;color:var(--ink3);font-weight:500;transition:background .3s,border-color .3s}
-.sch.hot{background:var(--orange-pale);border-color:var(--orange-border);color:var(--orange-deep)}
-.an-note{font-size:11px;color:var(--muted);text-align:center;padding-top:13px;border-top:1px solid var(--border2);margin-top:4px;line-height:1.6}
+.an-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(28, 16, 8, .5);
+  backdrop-filter: blur(8px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px
+}
+
+[data-theme="dark"] .an-bg {
+  background: rgba(0, 0, 0, .7)
+}
+
+.an-bg.open {
+  display: flex
+}
+
+.an-panel {
+  background: var(--white);
+  border-radius: 20px;
+  width: 100%;
+  max-width: 660px;
+  max-height: 88vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-lg);
+  animation: su .22s ease;
+  border: 1.5px solid var(--border);
+  transition: background .3s, border-color .3s
+}
+
+.an-header {
+  padding: 24px 26px 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between
+}
+
+.an-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 21px;
+  font-weight: 900;
+  color: var(--ink);
+  transition: color .3s
+}
+
+.an-header p {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 3px
+}
+
+.an-body {
+  padding: 18px 26px 24px
+}
+
+.an-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-bottom: 20px
+}
+
+.astat {
+  background: var(--an-bg);
+  border: 1.5px solid var(--border2);
+  border-radius: 11px;
+  padding: 14px;
+  text-align: center;
+  transition: background .3s, border-color .3s
+}
+
+.astat .av {
+  font-family: 'Playfair Display', serif;
+  font-size: 22px;
+  font-weight: 900;
+  color: var(--ink);
+  transition: color .3s
+}
+
+.astat .al {
+  font-size: 10px;
+  color: var(--muted);
+  letter-spacing: .07em;
+  text-transform: uppercase;
+  margin-top: 3px
+}
+
+.astat.hi {
+  background: var(--orange-pale);
+  border-color: var(--orange-border)
+}
+
+.astat.hi .av {
+  color: var(--orange-deep)
+}
+
+.chart-sec {
+  margin-bottom: 16px
+}
+
+.chart-title {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--muted);
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  margin-bottom: 9px
+}
+
+.bar-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 7px
+}
+
+.bar-row {
+  display: flex;
+  align-items: center;
+  gap: 9px
+}
+
+.bar-lbl {
+  width: 110px;
+  text-align: right;
+  font-size: 11px;
+  color: var(--ink3);
+  flex-shrink: 0
+}
+
+.bar-track {
+  flex: 1;
+  background: var(--border2);
+  border-radius: 100px;
+  height: 6px;
+  overflow: hidden
+}
+
+.bar-fill {
+  height: 100%;
+  border-radius: 100px;
+  background: linear-gradient(90deg, var(--orange), #FBBC04);
+  transition: width .8s cubic-bezier(.22, 1, .36, 1)
+}
+
+.bar-val {
+  width: 30px;
+  font-size: 10px;
+  color: var(--muted);
+  font-family: 'Fira Code', monospace;
+  flex-shrink: 0
+}
+
+.search-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px
+}
+
+.sch {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  padding: 3px 10px;
+  font-size: 11px;
+  color: var(--ink3);
+  font-weight: 500;
+  transition: background .3s, border-color .3s
+}
+
+.sch.hot {
+  background: var(--orange-pale);
+  border-color: var(--orange-border);
+  color: var(--orange-deep)
+}
+
+.an-note {
+  font-size: 11px;
+  color: var(--muted);
+  text-align: center;
+  padding-top: 13px;
+  border-top: 1px solid var(--border2);
+  margin-top: 4px;
+  line-height: 1.6
+}
 
 /* ── FOOTER ── */
-footer{border-top:1.5px solid var(--border);padding:24px;text-align:center;transition:border-color .3s}
-.footer-inner{max-width:1340px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:10px;font-size:12px;color:var(--muted)}
-footer a{color:var(--orange);text-decoration:none;font-weight:600}
-footer a:hover{text-decoration:underline}
-[data-theme="dark"] select option{background:#1A1108;color:var(--ink)}
+footer {
+  border-top: 1.5px solid var(--border);
+  padding: 24px;
+  text-align: center;
+  transition: border-color .3s
+}
+
+.footer-inner {
+  max-width: 1340px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--muted)
+}
+
+footer a {
+  color: var(--orange);
+  text-decoration: none;
+  font-weight: 600
+}
+
+footer a:hover {
+  text-decoration: underline
+}
+
+[data-theme="dark"] select option {
+  background: #1A1108;
+  color: var(--ink)
+}
 
 /* ── SKELETON CARDS ── */
-.skeleton-card{background:var(--card-bg);border-radius:12px;padding:20px;height:220px;}
-.skeleton-head{display:flex;gap:12px;margin-bottom:16px;}
-.skeleton-logo{width:48px;height:48px;border-radius:10px;flex-shrink:0;background-image:linear-gradient(90deg,var(--skeleton-base) 25%,var(--skeleton-shine) 50%,var(--skeleton-base) 75%);background-size:200% 100%;animation:shimmer 1.5s infinite linear;}
-.skeleton-lines{flex:1;display:flex;flex-direction:column;gap:8px;}
-.skeleton-line{height:12px;border-radius:4px;background-image:linear-gradient(90deg,var(--skeleton-base) 25%,var(--skeleton-shine) 50%,var(--skeleton-base) 75%);background-size:200% 100%;animation:shimmer 1.5s infinite linear;}
-.skeleton-title{width:70%;}
-.skeleton-subtitle{width:50%;}
-.skeleton-body{height:40px;border-radius:6px;margin-bottom:12px;background-image:linear-gradient(90deg,var(--skeleton-base) 25%,var(--skeleton-shine) 50%,var(--skeleton-base) 75%);background-size:200% 100%;animation:shimmer 1.5s infinite linear;}
-.skeleton-tags{display:flex;gap:8px;}
-.skeleton-pill{width:60px;height:20px;border-radius:100px;background-image:linear-gradient(90deg,var(--skeleton-base) 25%,var(--skeleton-shine) 50%,var(--skeleton-base) 75%);background-size:200% 100%;animation:shimmer 1.5s infinite linear;}
-@keyframes shimmer{0%{background-position:200% 0;}100%{background-position:-200% 0;}}
-@media(prefers-reduced-motion:reduce){.skeleton-logo,.skeleton-line,.skeleton-body,.skeleton-pill{animation:none}}
+.skeleton-card {
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 20px;
+  height: 220px;
+}
+
+.skeleton-head {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.skeleton-logo {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  flex-shrink: 0;
+  background-image: linear-gradient(90deg, var(--skeleton-base) 25%, var(--skeleton-shine) 50%, var(--skeleton-base) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite linear;
+}
+
+.skeleton-lines {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 4px;
+  background-image: linear-gradient(90deg, var(--skeleton-base) 25%, var(--skeleton-shine) 50%, var(--skeleton-base) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite linear;
+}
+
+.skeleton-title {
+  width: 70%;
+}
+
+.skeleton-subtitle {
+  width: 50%;
+}
+
+.skeleton-body {
+  height: 40px;
+  border-radius: 6px;
+  margin-bottom: 12px;
+  background-image: linear-gradient(90deg, var(--skeleton-base) 25%, var(--skeleton-shine) 50%, var(--skeleton-base) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite linear;
+}
+
+.skeleton-tags {
+  display: flex;
+  gap: 8px;
+}
+
+.skeleton-pill {
+  width: 60px;
+  height: 20px;
+  border-radius: 100px;
+  background-image: linear-gradient(90deg, var(--skeleton-base) 25%, var(--skeleton-shine) 50%, var(--skeleton-base) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite linear;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media(prefers-reduced-motion:reduce) {
+
+  .skeleton-logo,
+  .skeleton-line,
+  .skeleton-body,
+  .skeleton-pill {
+    animation: none
+  }
+}
 
 /* ── TABLET ── */
-@media(max-width:900px){
-  .nav-title{display:none}
-  .btn-contribute{display:none}
-  .compare-slots{grid-template-columns:1fr 1fr}
+@media(max-width:900px) {
+  .nav-title {
+    display: none
+  }
+
+  .btn-contribute {
+    display: none
+  }
+
+  .compare-slots {
+    grid-template-columns: 1fr 1fr
+  }
 }
 
 /* ── MOBILE ── */
@@ -428,136 +2720,476 @@ footer a:hover{text-decoration:underline}
 /* ═══════════════════════════════════════════
    RESPONSIVE — Tablet (≤900px)
 ═══════════════════════════════════════════ */
-@media(max-width:900px){
-  .nav-inner{gap:6px}
-  .nav-right{gap:6px}
-  .stats-bar{overflow-x:auto;-webkit-overflow-scrolling:touch;padding-bottom:4px;flex-wrap:nowrap}
-  .stat-item{flex-shrink:0;min-width:64px}
-  .compare-panel{max-width:98vw}
-  .m-metrics{grid-template-columns:repeat(2,1fr)}
+@media(max-width:900px) {
+  .nav-inner {
+    gap: 6px
+  }
+
+  .nav-right {
+    gap: 6px
+  }
+
+  .stats-bar {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 4px;
+    flex-wrap: nowrap
+  }
+
+  .stat-item {
+    flex-shrink: 0;
+    min-width: 64px
+  }
+
+  .compare-panel {
+    max-width: 98vw
+  }
+
+  .m-metrics {
+    grid-template-columns: repeat(2, 1fr)
+  }
 }
 
 /* ═══════════════════════════════════════════
    RESPONSIVE — Phone (≤640px)
 ═══════════════════════════════════════════ */
-@media(max-width:640px){
+@media(max-width:640px) {
+
   /* Nav */
-  .nav-inner{padding:0 12px;gap:4px;flex-wrap:nowrap;overflow-x:auto}
-  .nav-logo{font-size:14px;flex-shrink:0}
-  .nav-right{gap:4px;flex-shrink:0}
-  .nav-right .btn-contribute span{display:none}
-  .compare-btn span:first-child,.analytics-btn span:first-child{display:none}
-  .compare-btn,.analytics-btn{padding:5px 10px;font-size:11px}
+  .nav-inner {
+    padding: 0 12px;
+    gap: 4px;
+    flex-wrap: nowrap;
+    overflow-x: auto
+  }
+
+  .nav-logo {
+    font-size: 14px;
+    flex-shrink: 0
+  }
+
+  .nav-right {
+    gap: 4px;
+    flex-shrink: 0
+  }
+
+  .nav-right .btn-contribute span {
+    display: none
+  }
+
+  .compare-btn span:first-child,
+  .analytics-btn span:first-child {
+    display: none
+  }
+
+  .compare-btn,
+  .analytics-btn {
+    padding: 5px 10px;
+    font-size: 11px
+  }
 
   /* Stats bar */
-  .stats-bar{overflow-x:auto;-webkit-overflow-scrolling:touch;padding:0 12px 6px;flex-wrap:nowrap;gap:6px;justify-content:flex-start}
-  .stat-item{flex-shrink:0;padding:8px 12px;min-width:72px}
-  .stat-num{font-size:18px}
-  .stat-lbl{font-size:9px}
+  .stats-bar {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 0 12px 6px;
+    flex-wrap: nowrap;
+    gap: 6px;
+    justify-content: flex-start
+  }
+
+  .stat-item {
+    flex-shrink: 0;
+    padding: 8px 12px;
+    min-width: 72px
+  }
+
+  .stat-num {
+    font-size: 18px
+  }
+
+  .stat-lbl {
+    font-size: 9px
+  }
 
   /* Countdown */
-  .countdown-banner{padding:10px 12px;flex-direction:column;gap:6px;text-align:center}
-  .countdown-units{gap:8px}
-  .cd-unit .cd-num{font-size:20px}
+  .countdown-banner {
+    padding: 10px 12px;
+    flex-direction: column;
+    gap: 6px;
+    text-align: center
+  }
+
+  .countdown-units {
+    gap: 8px
+  }
+
+  .cd-unit .cd-num {
+    font-size: 20px
+  }
 
   /* Filters */
-  .wrap{padding:0 12px}
-  .filter-card{padding:12px}
-  .filter-label{font-size:12px}
-  .filters-row{flex-direction:column;gap:8px}
-  .fg{width:100%}
-  .fg label{font-size:10px}
-  .fg select,.search-input{min-width:0!important;width:100%;box-sizing:border-box;font-size:13px;padding:9px 12px}
-  .search-box{width:100%}
-  .search-input{font-size:13px}
-  .btn-reset{width:100%;text-align:center;padding:9px}
-  .chips-row{flex-wrap:wrap;gap:5px}
-  .chip{font-size:11px;padding:5px 10px}
-  .pills-section{gap:6px}
-  .pill{font-size:11px;padding:4px 10px}
+  .wrap {
+    padding: 0 12px
+  }
+
+  .filter-card {
+    padding: 12px
+  }
+
+  .filter-label {
+    font-size: 12px
+  }
+
+  .filters-row {
+    flex-direction: column;
+    gap: 8px
+  }
+
+  .fg {
+    width: 100%
+  }
+
+  .fg label {
+    font-size: 10px
+  }
+
+  .fg select,
+  .search-input {
+    min-width: 0 !important;
+    width: 100%;
+    box-sizing: border-box;
+    font-size: 13px;
+    padding: 9px 12px
+  }
+
+  .search-box {
+    width: 100%
+  }
+
+  .search-input {
+    font-size: 13px
+  }
+
+  .btn-reset {
+    width: 100%;
+    text-align: center;
+    padding: 9px
+  }
+
+  .chips-row {
+    flex-wrap: wrap;
+    gap: 5px
+  }
+
+  .chip {
+    font-size: 11px;
+    padding: 5px 10px
+  }
+
+  .pills-section {
+    gap: 6px
+  }
+
+  .pill {
+    font-size: 11px;
+    padding: 4px 10px
+  }
 
   /* Results row */
-  .results-row{flex-direction:column;gap:6px;align-items:flex-start}
-  .result-count{font-size:12px}
-  .sort-row{width:100%}
-  .sort-row select{width:100%;font-size:13px}
+  .results-row {
+    flex-direction: column;
+    gap: 6px;
+    align-items: flex-start
+  }
+
+  .result-count {
+    font-size: 12px
+  }
+
+  .sort-row {
+    width: 100%
+  }
+
+  .sort-row select {
+    width: 100%;
+    font-size: 13px
+  }
 
   /* Grid */
-  .grid{grid-template-columns:1fr;gap:10px;margin-bottom:40px}
-  .org-card{padding:14px;animation:none;opacity:1}
-  .org-card:hover{transform:none}
-  .card-header-row{gap:10px}
-  .org-logo{width:40px;height:40px}
-  .org-name{font-size:13px}
-  .org-desc{font-size:12px;-webkit-line-clamp:2;line-clamp:2;display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden}
-  .tags{gap:4px}
-  .tag{font-size:10px;padding:2px 7px}
-  .badges{gap:4px}
-  .b{font-size:10px;padding:2px 7px}
-  .gh-mini{gap:6px;flex-wrap:wrap}
-  .gh-s{font-size:10px}
+  .grid {
+    grid-template-columns: 1fr;
+    gap: 10px;
+    margin-bottom: 40px
+  }
+
+  .org-card {
+    padding: 14px;
+    animation: none;
+    opacity: 1
+  }
+
+  .org-card:hover {
+    transform: none
+  }
+
+  .card-header-row {
+    gap: 10px
+  }
+
+  .org-logo {
+    width: 40px;
+    height: 40px
+  }
+
+  .org-name {
+    font-size: 13px
+  }
+
+  .org-desc {
+    font-size: 12px;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    overflow: hidden
+  }
+
+  .tags {
+    gap: 4px
+  }
+
+  .tag {
+    font-size: 10px;
+    padding: 2px 7px
+  }
+
+  .badges {
+    gap: 4px
+  }
+
+  .b {
+    font-size: 10px;
+    padding: 2px 7px
+  }
+
+  .gh-mini {
+    gap: 6px;
+    flex-wrap: wrap
+  }
+
+  .gh-s {
+    font-size: 10px
+  }
 
   /* Modal */
-  .modal-bg{padding:8px}
-  .modal{border-radius:16px;max-height:96vh}
-  .modal-top{padding:18px 16px 0}
-  .m-desc{padding:0 16px 12px;font-size:12px}
-  .modal-body{padding:0 16px 20px}
-  .m-name{font-size:17px;padding-right:60px}
-  .m-metrics{grid-template-columns:repeat(2,1fr);gap:6px}
-  .mc{padding:9px 8px}
-  .mv{font-size:15px}
-  .gh-grid{grid-template-columns:repeat(3,1fr);gap:5px}
-  .m-tags{gap:4px}
-  .m-tag{font-size:10px;padding:3px 8px}
-  .modal-cta{font-size:12px;padding:9px 16px}
-  .modal-ideas-link{font-size:12px;padding:9px 16px;margin-right:8px}
+  .modal-bg {
+    padding: 8px
+  }
+
+  .modal {
+    border-radius: 16px;
+    max-height: 96vh
+  }
+
+  .modal-top {
+    padding: 18px 16px 0
+  }
+
+  .m-desc {
+    padding: 0 16px 12px;
+    font-size: 12px
+  }
+
+  .modal-body {
+    padding: 0 16px 20px
+  }
+
+  .m-name {
+    font-size: 17px;
+    padding-right: 60px
+  }
+
+  .m-metrics {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 6px
+  }
+
+  .mc {
+    padding: 9px 8px
+  }
+
+  .mv {
+    font-size: 15px
+  }
+
+  .gh-grid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 5px
+  }
+
+  .m-tags {
+    gap: 4px
+  }
+
+  .m-tag {
+    font-size: 10px;
+    padding: 3px 8px
+  }
+
+  .modal-cta {
+    font-size: 12px;
+    padding: 9px 16px
+  }
+
+  .modal-ideas-link {
+    font-size: 12px;
+    padding: 9px 16px;
+    margin-right: 8px
+  }
 
   /* Compare */
-  .compare-panel{border-radius:14px;max-height:95vh}
-  .compare-header{padding:14px 16px}
-  .compare-body{padding:12px 16px}
-  .compare-table{font-size:11px}
-  .compare-table th,.compare-table td{padding:7px 8px}
+  .compare-panel {
+    border-radius: 14px;
+    max-height: 95vh
+  }
+
+  .compare-header {
+    padding: 14px 16px
+  }
+
+  .compare-body {
+    padding: 12px 16px
+  }
+
+  .compare-table {
+    font-size: 11px
+  }
+
+  .compare-table th,
+  .compare-table td {
+    padding: 7px 8px
+  }
 
   /* API Banner */
-  .api-banner{padding:8px 12px;gap:8px;font-size:11px}
+  .api-banner {
+    padding: 8px 12px;
+    gap: 8px;
+    font-size: 11px
+  }
 
   /* Footer */
-  footer{padding:20px 12px}
-  .footer-inner{flex-direction:column;gap:4px;text-align:center;font-size:11px}
+  footer {
+    padding: 20px 12px
+  }
+
+  .footer-inner {
+    flex-direction: column;
+    gap: 4px;
+    text-align: center;
+    font-size: 11px
+  }
 
   /* Issues page */
-  .issues-controls{flex-direction:column;align-items:stretch;gap:8px}
-  .issues-controls select,.issues-search{width:100%;box-sizing:border-box;min-width:0}
-  .btn-fetch-issues{width:100%;justify-content:center}
-  .issues-stats{gap:8px}
-  .istat{padding:8px 12px;min-width:60px}
-  .issue-card{padding:12px 14px;gap:10px}
-  .issue-logo{width:30px;height:30px}
-  .issue-title{font-size:12px}
+  .issues-controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px
+  }
+
+  .issues-controls select,
+  .issues-search {
+    width: 100%;
+    box-sizing: border-box;
+    min-width: 0
+  }
+
+  .btn-fetch-issues {
+    width: 100%;
+    justify-content: center
+  }
+
+  .issues-stats {
+    gap: 8px
+  }
+
+  .istat {
+    padding: 8px 12px;
+    min-width: 60px
+  }
+
+  .issue-card {
+    padding: 12px 14px;
+    gap: 10px
+  }
+
+  .issue-logo {
+    width: 30px;
+    height: 30px
+  }
+
+  .issue-title {
+    font-size: 12px
+  }
 
   /* Trending */
-  .trend-card{min-width:140px;padding:8px 10px}
-  .trend-name{font-size:11px}
+  .trend-card {
+    min-width: 140px;
+    padding: 8px 10px
+  }
+
+  .trend-name {
+    font-size: 11px
+  }
 
   /* Analytics */
-  .an-grid{grid-template-columns:repeat(2,1fr);gap:8px}
-  .an-num{font-size:22px}
+  .an-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px
+  }
+
+  .an-num {
+    font-size: 22px
+  }
 }
 
 /* ═══════════════════════════════════════════
    RESPONSIVE — Small Phone (≤380px)
 ═══════════════════════════════════════════ */
-@media(max-width:380px){
-  .nav-inner{padding:0 8px}
-  .compare-btn,.analytics-btn{display:none}
-  .cd-num{font-size:18px}
-  .stat-num{font-size:15px}
-  .stat-lbl{font-size:8px}
-  .org-card{padding:12px}
-  .org-logo{width:34px;height:34px}
-  .org-name{font-size:12px}
+@media(max-width:380px) {
+  .nav-inner {
+    padding: 0 8px
+  }
+
+  .compare-btn,
+  .analytics-btn {
+    display: none
+  }
+
+  .cd-num {
+    font-size: 18px
+  }
+
+  .stat-num {
+    font-size: 15px
+  }
+
+  .stat-lbl {
+    font-size: 8px
+  }
+
+  .org-card {
+    padding: 12px
+  }
+
+  .org-logo {
+    width: 34px;
+    height: 34px
+  }
+
+  .org-name {
+    font-size: 12px
+  }
 }
 
 /* Style of scroll-to-top button */
@@ -575,7 +3207,7 @@ footer a:hover{text-decoration:underline}
   cursor: pointer;
   display: none;
   z-index: 50;
-  box-shadow: 0 3px 10px rgba(244,107,14,.35);
+  box-shadow: 0 3px 10px rgba(244, 107, 14, .35);
   transition: opacity .2s;
 }
 


### PR DESCRIPTION
## Description
Fix Flash of Unstyled Icons (FOUI) where Material Symbols rendered as 
raw text for 1-2 seconds on initial page load due to font loading after DOM render.

- Combined all fonts into a single preload request with display=block
- Added CSS to hide .material-symbols-outlined (opacity: 0) until font is ready
- Used document.fonts.ready to add fonts-loaded class, fading icons in smoothly

## Related Issue
Closes #153

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Tested on Chrome DevTools → Network → Slow 3G throttling
- Hard refresh (Ctrl+Shift+R) — no raw text flash observed
- Icons fade in smoothly within ~150ms

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested my changes locally
- [x] No unrelated files were modified
- [x] I have linked the related issue

## Program
GSSOC