### PR TITLE
fix: improve accessibility with aria-labels and descriptive alt text

### DIFF
--- a/index.html
+++ b/index.html
@@ -576,7 +576,7 @@
       <!-- Search Bar -->
       <div class="relative max-w-xl mb-6 sm:mb-8">
         <span class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400">search</span>
-        <input id="hero-search" type="text" placeholder="Search organization names..." class="w-full bg-white border-2 border-zinc-100 rounded-2xl py-3 sm:py-4 pl-12 pr-4 text-sm font-medium focus:ring-2 focus:ring-primary/30 focus:border-primary/40 transition-all shadow-lg shadow-zinc-200/50" />
+        <input id="hero-search" type="text" placeholder="Search organization names..." aria-label="Search GSoC 2026 organizations" class="w-full bg-white border-2 border-zinc-100 rounded-2xl py-3 sm:py-4 pl-12 pr-4 text-sm font-medium focus:ring-2 focus:ring-primary/30 focus:border-primary/40 transition-all shadow-lg shadow-zinc-200/50" />
       </div>
       <!-- Surprise Button -->
       <div class="mb-8 sm:mb-10">
@@ -660,7 +660,7 @@
   <div class="flex items-center justify-between mb-8">
     <p class="font-label text-xs uppercase tracking-widest text-zinc-500">Showing <strong id="orgCount">184</strong> of 184 organizations</p>
     <div class="flex items-center gap-4">
-      <select id="categoryFilter" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
+      <select id="categoryFilter" aria-label="Filter by category" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
         <option value="all">Categories: All</option>
         <option value="web">Web</option>
         <option value="programming">Programming</option>
@@ -672,13 +672,13 @@
         <option value="media">Media</option>
         <option value="other">Other</option>
       </select>
-      <select id="complexityFilter" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
+      <select id="complexityFilter" aria-label="Filter by complexity" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
         <option value="all">Complexity: All</option>
         <option value="beginner">Beginner</option>
         <option value="intermediate">Intermediate</option>
         <option value="advanced">Advanced</option>
       </select>
-      <select id="sortSelect" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
+      <select id="sortSelect" aria-label="Sort organizations" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
         <option value="alpha">Sort: A-Z</option>
         <option value="years-desc">Years (High-Low)</option>
         <option value="years-asc">Years (Low-High)</option>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -733,7 +733,7 @@ function renderGrid(orgs){
       data-filtered-idx="${i}"
       tabindex="0">
       <div class="card-header-row">
-        ${logo?`<img class="org-logo" src="${escapeHtml(logo)}" alt="${escapeHtml((o.name||'')[0]||'') }" loading="lazy" onerror="imgErr(this)">`:``}
+        ${logo?`<img class="org-logo" src="${escapeHtml(logo)}" alt="${escapeHtml(o.name||'')} logo" loading="lazy" onerror="imgErr(this)">`:``}
         <div class="org-logo-info">
           <div class="card-top-line">
             <div class="org-name">${escapeHtml(o.name)}</div>


### PR DESCRIPTION
This PR improves accessibility across the site by fixing missing and incorrect aria-label attributes and alt text on interactive elements and images. These changes ensure the site is usable by people relying on screen readers and other assistive technologies, and bring the UI closer to WCAG 2.1 compliance.

🔄 Type of Change

 ♿ Accessibility improvement


✅ Changes Made
1. Fixed descriptive alt text on organization logo images (src/js/app.js)
Before:
jsalt="${escapeHtml((o.name||'')[0]||'') }"
After:
jsalt="${escapeHtml(o.name||'')} logo"
Why: The previous code passed only the first character of the organization name as the alt text. Screen readers would announce a single letter like "D" instead of the full name. This violates WCAG 2.1 Success Criterion 1.1.1 (Non-text Content).

2. Added aria-label to the hero search input (index.html)
Before:
html<input id="hero-search" type="text" placeholder="Search organization names..." />
After:
html<input id="hero-search" type="text" placeholder="Search organization names..." aria-label="Search GSoC 2026 organizations" />
Why: Using placeholder as the only label is not reliable for screen readers. When a user focuses on the input and starts typing, the placeholder disappears and assistive technologies lose context about what the field is for.

3. Added aria-label to filter and sort <select> dropdowns (index.html)
Before:
html<select id="categoryFilter" class="...">
<select id="complexityFilter" class="...">
<select id="sortSelect" class="...">
After:
html<select id="categoryFilter" aria-label="Filter by category" class="...">
<select id="complexityFilter" aria-label="Filter by complexity" class="...">
<select id="sortSelect" aria-label="Sort organizations" class="...">
Why: These dropdowns have no associated <label> elements. Without an aria-label, screen readers announce them only as "combo box" with no context, making it impossible for assistive technology users to understand their purpose.
