### PR TITLE
fix: search jump, stale modal stats, stale-data indicator (#646)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2792,10 +2792,25 @@ if(org.ideas){
       document.getElementById('searchInput').value = e.target.value;
       if (!heroScrolledForThisFocus && e.target.value.length > 0) {
         const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        document.getElementById('orgs').scrollIntoView({
-          behavior: prefersReducedMotion ? 'auto' : 'smooth',
-          block: 'start'
-        });
+        const orgsSection = document.getElementById('orgs');
+        if (prefersReducedMotion) {
+          const root = document.documentElement;
+          const previousScrollBehavior = root.style.scrollBehavior;
+          try {
+            root.style.scrollBehavior = 'auto';
+            orgsSection.scrollIntoView({
+              behavior: 'auto',
+              block: 'start'
+            });
+          } finally {
+            root.style.scrollBehavior = previousScrollBehavior;
+          }
+        } else {
+          orgsSection.scrollIntoView({
+            behavior: 'smooth',
+            block: 'start'
+          });
+        }
         heroScrolledForThisFocus = true;
       }
       applyFilters();

--- a/index.html
+++ b/index.html
@@ -2601,6 +2601,25 @@
     document.getElementById('mTech').innerHTML = org.tags.map(t => `<span class="tech-tag">${escapeHtml(t)}</span>`).join('');
     document.getElementById('mFit').innerHTML = org.fit.map(f => `<span class="fit-tag">${escapeHtml(f)}</span>`).join('');
 
+    // Fix #646(2): reset live-stats placeholders when switching orgs so the
+    // previous org's numbers don't bleed through until the user clicks Fetch.
+    const mStarsEl = document.getElementById('mStars');
+    const mForksEl = document.getElementById('mForks');
+    const mIssuesEl = document.getElementById('mIssues');
+    const mActivityEl = document.getElementById('mActivity');
+    if (mStarsEl) mStarsEl.textContent = '---';
+    if (mForksEl) mForksEl.textContent = '---';
+    if (mIssuesEl) mIssuesEl.textContent = '---';
+    if (mActivityEl) {
+      mActivityEl.textContent = '---';
+      mActivityEl.className = 'gh-stat-item text-zinc-400';
+    }
+    const mFetchBtnEl = document.getElementById('mFetchBtn');
+    if (mFetchBtnEl) {
+      mFetchBtnEl.textContent = 'Fetch Live Stats';
+      mFetchBtnEl.disabled = false;
+    }
+
     // Timeline
     let timelineHtml = '';
     for(let y=2020; y<=2026; y++) {
@@ -2761,12 +2780,24 @@ if(org.ideas){
   document.getElementById('surpriseBtn')?.addEventListener('click', openRandomOrg);
 
   // Hero Search Link
+  // Fix #646(1): only scroll into the orgs section once per focus session.
+  // Previously this fired scrollIntoView on EVERY keystroke, which made the
+  // viewport jump up and down while the user was typing.
   const heroSearch = document.getElementById('hero-search');
   if (heroSearch) {
     heroSearch.value = document.getElementById('searchInput')?.value || new URLSearchParams(location.search).get('q') || '';
+    let heroScrolledForThisFocus = false;
+    heroSearch.addEventListener('focus', () => { heroScrolledForThisFocus = false; });
     heroSearch.addEventListener('input', (e) => {
       document.getElementById('searchInput').value = e.target.value;
-      document.getElementById('orgs').scrollIntoView({ behavior: 'smooth' });
+      if (!heroScrolledForThisFocus && e.target.value.length > 0) {
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        document.getElementById('orgs').scrollIntoView({
+          behavior: prefersReducedMotion ? 'auto' : 'smooth',
+          block: 'start'
+        });
+        heroScrolledForThisFocus = true;
+      }
       applyFilters();
     });
   }
@@ -2855,9 +2886,25 @@ if(org.ideas){
       const lastUpdatedEl = document.getElementById('issuesLastUpdated');
       if (lastUpdatedEl) {
         if (data.updated_at) {
-          const mins = Math.max(1, Math.floor((Date.now() - new Date(data.updated_at).getTime()) / 60000));
+          const ageMs = Date.now() - new Date(data.updated_at).getTime();
+          const mins = Math.max(1, Math.floor(ageMs / 60000));
           const relative = mins < 60 ? `${mins} min ago` : `${Math.floor(mins / 60)} hours ago`;
-          lastUpdatedEl.textContent = `Last updated: ${relative}`;
+          // Fix #646(3): the dataset is refreshed by a scheduled workflow that
+          // opens a PR; if the PR isn't merged the dataset can drift well past
+          // the advertised 6-hour cadence. Surface that honestly to the user
+          // instead of silently showing stale data as 'fresh'.
+          const STALE_THRESHOLD_MS = 12 * 60 * 60 * 1000; // 12h
+          if (ageMs > STALE_THRESHOLD_MS) {
+            lastUpdatedEl.textContent = `Last updated: ${relative} (may be stale)`;
+            lastUpdatedEl.classList.remove('text-green-600');
+            lastUpdatedEl.classList.add('text-amber-600');
+            lastUpdatedEl.title = 'Dataset has not refreshed in over 12 hours; the maintainer may not have merged the latest auto-refresh PR yet.';
+          } else {
+            lastUpdatedEl.textContent = `Last updated: ${relative}`;
+            lastUpdatedEl.classList.remove('text-amber-600');
+            lastUpdatedEl.classList.add('text-green-600');
+            lastUpdatedEl.removeAttribute('title');
+          }
         } else {
           lastUpdatedEl.textContent = 'Last updated: unavailable';
         }


### PR DESCRIPTION
## 🚀 Program
GSSoC

## 📝 Description

Fixes the three bugs reported in #646:

1. **Search box layout shift while typing** — the hero-search `input` handler called `scrollIntoView({behavior:'smooth'})` on **every keystroke**, causing the viewport to bounce while the user typed. Now triggers scroll **once per focus session**, only on the first non-empty input, and respects `prefers-reduced-motion`.

2. **"Fetch Live Stats" shows previous org's data after switching orgs** — `openModal()` populated the header / metrics / desc / tags, but **never reset** `#mStars` / `#mForks` / `#mIssues` / `#mActivity`, so the previous org's numbers persisted across modal opens. Now resets all four placeholders (and the Fetch button label / disabled state) at the top of `openModal()`.

3. **Pre-fetched issues stale despite "every 6 hours" claim** — investigation: the cron workflow IS running every 6 h and succeeds, but it opens an auto-refresh PR (`refresh-issues`) that is currently unmerged (PR #240, open since 2026-05-09). Data on `main` is exactly as old as that PR. UX honesty fix: `#issuesLastUpdated` now turns **amber** with `(may be stale)` and a tooltip when the dataset is older than 12 hours, instead of silently presenting stale data as fresh. (The merge-policy side is left to maintainers — happy to follow up with a workflow change once the desired policy is confirmed.)

Files changed: `index.html` only (+50, −3). No new dependencies. Zero-build / zero-dep philosophy preserved.

## 🔗 Related Issue
Closes #646

## 🔄 Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [x] 🎨 Style / UI improvement
- [x] ♿ Accessibility improvement <!-- prefers-reduced-motion handling -->
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test

1. Serve the repo locally (`python3 -m http.server 8000`) and open `http://localhost:8000`.

**Bug 1 — Search no longer jumps**
1. Click the hero search input.
2. Type quickly: `kub` → `kuber` → `kubernetes`.
3. ✅ Page scrolls to the orgs section **once** on the first character, then stays still while typing.
4. Click outside, click back in, type again → scrolls once more (new focus session).
5. With "Reduce motion" enabled in OS settings, the scroll happens instantly (no smooth animation).

**Bug 2 — Modal stats reset on org switch**
1. Open any org card → click **Fetch Live Stats** → wait for numbers.
2. Close the modal, open a *different* org.
3. ✅ Stars / Forks / Issues / Activity all show `---` (not the previous org's numbers). Button reads "Fetch Live Stats" and is enabled.

**Bug 3 — Stale indicator**
1. Scroll to the **Pre-fetched Issues Ready** section.
2. ✅ Pill reads `Last updated: 140 hours ago (may be stale)` in amber with a tooltip.
3. Fresh-path check: temporarily bump `data/issues.json#updated_at` to `now` and reload → pill is green, no warning.

## 📸 Screenshots (if applicable)
<!-- Will add before/after capture in a follow-up comment if requested -->

## ✅ Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
