### PR TITLE
fix: add mentor contact info for AFLplusplus

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -134,14 +134,26 @@
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
-  "AFLplusplus": {
+ "AFLplusplus": {
     "org": "AFLplusplus",
     "ideasUrl": "https://github.com/AFLplusplus/LibAFL/issues/3706",
-    "channels": [],
-    "mentors": [],
+    "channels": [
+      {
+        "type": "Discord",
+        "url": "https://discord.gg/fuzzing",
+        "label": "Fuzzing Discord"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "rmalmain",
+        "github": "rmalmain",
+        "githubUrl": "https://github.com/rmalmain"
+      }
+    ],
     "mailingLists": [],
     "tip": "",
-    "status": "no-contact-found",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Alaska": {


### PR DESCRIPTION
GSSOC

## Description
Added missing mentor contact information for AFLplusplus organization in data/mentors.json. The automated extractor couldn't pull this info, so it was researched and added manually.

## Related Issue
Fixes #256

## Type of Change
- [x] Bug fix / Data fix

## Checklist
- [x] I have read the contributing guidelines
- [x] My changes follow the existing code style
- [x] I have tested my changes
- [x] DCO sign-off is included in my commit