### PR TITLE
feat: replace native selects with custom styled dropdowns

### DIFF
--- a/index.html
+++ b/index.html
@@ -429,6 +429,73 @@
       color: #fb923c;
       background: #1c0f05;
     }
+    /*---------Custom Dropdowns--------------*/
+    .cd-wrapper { position: relative; display: inline-block; }
+
+    .cd-trigger {
+      display: flex; align-items: center; gap: 8px;
+      background: #ffffff; color: #3f3f46;
+      border: 1.5px solid #e4e4e7; border-radius: 12px;
+      padding: 8px 14px; font-size: 12px; font-weight: 700;
+      cursor: pointer; user-select: none; min-width: 160px;
+      justify-content: space-between; transition: border-color 0.2s;
+    }
+    .cd-trigger:hover { border-color: #f97316; color: #f97316; }
+    .cd-dot { width: 8px; height: 8px; border-radius: 50%; background: #f97316; flex-shrink: 0; }
+    .cd-chevron { font-size: 14px; color: #f97316; transition: transform 0.2s; }
+    .cd-wrapper.open .cd-chevron { transform: rotate(180deg); }
+
+                  /* ── LIGHT MODE PANEL ── */
+    .cd-panel {
+      position: absolute; top: calc(100% + 8px); left: 0;
+      background: #ffffff; border: 1.5px solid #e4e4e7;
+      border-radius: 14px; padding: 8px;
+      min-width: 210px; z-index: 999;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.1);
+      display: none;
+    }
+    .cd-wrapper.open .cd-panel { display: block; }
+
+    .cd-section-label {
+      font-size: 10px; font-weight: 800; letter-spacing: 0.12em;
+      color: #9ca3af; text-transform: uppercase; padding: 4px 8px 8px;
+    }
+
+    .cd-item {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 9px 12px; border-radius: 10px;
+    font-size: 13px; font-weight: 600; color: #3f3f46;
+    cursor: pointer; transition: background 0.15s;
+  }
+  .cd-item:hover { background: rgba(249,115,22,0.1); color: #f97316; }
+  .cd-item.cd-active { background: rgba(249,115,22,0.12); color: #f97316; }
+
+  .cd-count {
+    background: #f3f4f6; color: #6b7280;
+    font-size: 11px; font-weight: 700;
+    padding: 2px 8px; border-radius: 99px;
+    min-width: 28px; text-align: center;
+  }
+  .cd-item.cd-active .cd-count { background: #ffedd5; color: #f97316; }
+
+                  /* ── DARK MODE TRIGGER ── */
+  .dark .cd-trigger {
+    background: #27272a; color: #d4d4d8;
+    border-color: #3f3f46;
+  }
+  .dark .cd-trigger:hover { border-color: #f97316; color: #f97316; }
+
+    /* ── DARK MODE PANEL ── */
+  .dark .cd-panel {
+    background: #16213e; border-color: #2e2e4a;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+  }
+  .dark .cd-section-label { color: #6b7280; }
+  .dark .cd-item { color: #c9c9d0; }
+  .dark .cd-item:hover { background: rgba(249,115,22,0.12); color: #f97316; }
+  .dark .cd-item.cd-active { background: #7c2900; color: #f97316; }
+  .dark .cd-count { background: #1e2a3a; color: #8899aa; }
+  .dark .cd-item.cd-active .cd-count { background: #5c1e00; color: #f97316; }
   </style>
   <link rel="manifest" href="manifest.json" />
   <meta name="theme-color" content="#F46B0E" />
@@ -660,33 +727,73 @@
   <div class="flex items-center justify-between mb-8">
     <p class="font-label text-xs uppercase tracking-widest text-zinc-500">Showing <strong id="orgCount">184</strong> of 184 organizations</p>
     <div class="flex items-center gap-4">
-      <select id="categoryFilter" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
-        <option value="all">Categories: All</option>
-        <option value="web">Web</option>
-        <option value="programming">Programming</option>
-        <option value="science">Science</option>
-        <option value="os">OS</option>
-        <option value="infra">Infra</option>
-        <option value="security">Security</option>
-        <option value="data">Data</option>
-        <option value="media">Media</option>
-        <option value="other">Other</option>
-      </select>
-      <select id="complexityFilter" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
-        <option value="all">Complexity: All</option>
-        <option value="beginner">Beginner</option>
-        <option value="intermediate">Intermediate</option>
-        <option value="advanced">Advanced</option>
-      </select>
-      <select id="sortSelect" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
-        <option value="alpha">Sort: A-Z</option>
-        <option value="years-desc">Years (High-Low)</option>
-        <option value="years-asc">Years (Low-High)</option>
-        <option value="comp-low">Competition (Chill First)</option>
-        <option value="stars">GitHub Stars</option>
-        <option value="gfi">Good First Issues</option>
-      </select>
+
+  <!-- Category Dropdown -->
+  <div class="cd-wrapper" id="catDropdown">
+    <div class="cd-trigger" id="catTrigger">
+      <div style="display:flex;align-items:center;gap:8px;">
+        <span class="cd-dot"></span>
+        <span id="catLabel">All categories</span>
+      </div>
+      <span class="cd-chevron">▾</span>
     </div>
+    <div class="cd-panel">
+      <div class="cd-section-label">Filter by category</div>
+      <div class="cd-item cd-active" data-value="all">All categories <span class="cd-count">184</span></div>
+      <div class="cd-item" data-value="web">Web <span class="cd-count">38</span></div>
+      <div class="cd-item" data-value="programming">Programming <span class="cd-count">52</span></div>
+      <div class="cd-item" data-value="science">Science <span class="cd-count">21</span></div>
+      <div class="cd-item" data-value="os">OS <span class="cd-count">14</span></div>
+      <div class="cd-item" data-value="infra">Infra <span class="cd-count">18</span></div>
+      <div class="cd-item" data-value="security">Security <span class="cd-count">11</span></div>
+      <div class="cd-item" data-value="data">Data <span class="cd-count">19</span></div>
+      <div class="cd-item" data-value="media">Media <span class="cd-count">7</span></div>
+      <div class="cd-item" data-value="other">Other <span class="cd-count">4</span></div>
+    </div>
+    <input type="hidden" id="categoryFilter" value="all" />
+  </div>
+
+  <!-- Complexity Dropdown -->
+  <div class="cd-wrapper" id="compDropdown">
+    <div class="cd-trigger" id="compTrigger">
+      <div style="display:flex;align-items:center;gap:8px;">
+        <span class="cd-dot"></span>
+        <span id="compLabel">Complexity: All</span>
+      </div>
+      <span class="cd-chevron">▾</span>
+    </div>
+    <div class="cd-panel">
+      <div class="cd-section-label">Filter by complexity</div>
+      <div class="cd-item cd-active" data-value="all">All levels</div>
+      <div class="cd-item" data-value="beginner">Beginner</div>
+      <div class="cd-item" data-value="intermediate">Intermediate</div>
+      <div class="cd-item" data-value="advanced">Advanced</div>
+    </div>
+    <input type="hidden" id="complexityFilter" value="all" />
+  </div>
+
+  <!-- Sort Dropdown -->
+  <div class="cd-wrapper" id="sortDropdown">
+    <div class="cd-trigger" id="sortTrigger">
+      <div style="display:flex;align-items:center;gap:8px;">
+        <span class="cd-dot"></span>
+        <span id="sortLabel">Sort: A-Z</span>
+      </div>
+      <span class="cd-chevron">▾</span>
+    </div>
+    <div class="cd-panel">
+      <div class="cd-section-label">Sort organizations</div>
+      <div class="cd-item cd-active" data-value="alpha">A – Z</div>
+      <div class="cd-item" data-value="years-desc">Years (High → Low)</div>
+      <div class="cd-item" data-value="years-asc">Years (Low → High)</div>
+      <div class="cd-item" data-value="comp-low">Competition (Chill first)</div>
+      <div class="cd-item" data-value="stars">GitHub Stars</div>
+      <div class="cd-item" data-value="gfi">Good First Issues</div>
+    </div>
+    <input type="hidden" id="sortSelect" value="alpha" />
+  </div>
+</div>
+    
   </div>
   
   <!-- Hidden search input for JavaScript compatibility -->
@@ -3093,6 +3200,76 @@ document.addEventListener('DOMContentLoaded', () => {
   window.closeHelpModal = closeHelpModal;
 
 });
+//-----------Custom Dropdown Logic (category + complexity + sort)--------
+(function(){
+  function initDropdown({ wrapperId, triggerId, labelId, hiddenId, labelPrefix, onSelect }) {
+    const wrapper = document.getElementById(wrapperId);
+    const trigger = document.getElementById(triggerId);
+    const label   = document.getElementById(labelId);
+    const hidden  = document.getElementById(hiddenId);
+    if (!wrapper || !trigger || !label || !hidden) return;
+    const items = wrapper.querySelectorAll('.cd-item');
+
+    trigger.addEventListener('click', e => {
+      e.stopPropagation();
+      // close all others first
+      document.querySelectorAll('.cd-wrapper').forEach(w => {
+        if (w !== wrapper) w.classList.remove('open');
+      });
+      wrapper.classList.toggle('open');
+    });
+
+    items.forEach(item => {
+      item.addEventListener('click', () => {
+        items.forEach(i => i.classList.remove('cd-active'));
+        item.classList.add('cd-active');
+        const text = item.firstChild.textContent.trim();
+        label.textContent = labelPrefix ? labelPrefix + text : text;
+        hidden.value = item.dataset.value;
+        wrapper.classList.remove('open');
+        if (onSelect) onSelect(item.dataset.value);
+      });
+    });
+  }
+
+  // Category
+  initDropdown({
+    wrapperId: 'catDropdown', triggerId: 'catTrigger',
+    labelId: 'catLabel', hiddenId: 'categoryFilter',
+    labelPrefix: '',
+    onSelect: () => applyFilters()
+  });
+
+  // Complexity
+  initDropdown({
+    wrapperId: 'compDropdown', triggerId: 'compTrigger',
+    labelId: 'compLabel', hiddenId: 'complexityFilter',
+    labelPrefix: 'Complexity: ',
+    onSelect: () => applyFilters()
+  });
+
+  // Sort
+  initDropdown({
+    wrapperId: 'sortDropdown', triggerId: 'sortTrigger',
+    labelId: 'sortLabel', hiddenId: 'sortSelect',
+    labelPrefix: 'Sort: ',
+    onSelect: () => applyFilters()
+  });
+
+  // Close all on outside click
+  document.addEventListener('click', e => {
+    if (!e.target.closest('.cd-wrapper')) {
+      document.querySelectorAll('.cd-wrapper').forEach(w => w.classList.remove('open'));
+    }
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') {
+      document.querySelectorAll('.cd-wrapper').forEach(w => w.classList.remove('open'));
+    }
+  });
+})();
 </script>
 <script src="src/js/app.js"></script>
 <script src="src/js/githubAnalyzer.js"></script>


### PR DESCRIPTION
GSSOC-2026

Description
Replaced the three native `<select>` dropdowns (Category, Complexity, Sort) 
in the Org Directory section with custom styled dropdown components that match 
the overall design language of the site.

Changes Made
- `index.html` — replaced native `<select>` elements with custom `cd-wrapper` dropdown components
- Added CSS for custom dropdown styling (`.cd-wrapper`, `.cd-trigger`, `.cd-panel`, `.cd-item`, `.cd-count`)
- Added JS initialization logic for all three dropdowns

Visual Improvements
- Light mode: white panel background, subtle border, orange hover effect
- Dark mode: dark panel background with orange accents (matches existing dark theme)
- Category dropdown shows item counts as badges (e.g. Web: 38, Programming: 52)
- Smooth chevron rotation animation on open/close
- Closes on outside click and Escape key

What was NOT changed
- Zero changes to filtering logic
- Zero changes to `applyFilters()` function
- All existing `id` attributes preserved (`categoryFilter`, `complexityFilter`, `sortSelect`) so JS compatibility is maintained via hidden inputs

Related Issue
Closes #771

Checklist
- [x] I have read the contributing guidelines
- [x] My changes do not break any existing functionality
- [x] I have tested in both light and dark mode
- [x] No logic or JS functionality was modified
- [x] My commit is signed off (DCO)

Screenshots:

Type of Change
LIGHT THEME:

<img width="799" height="359" alt="Screenshot 2026-05-16 161012" src="https://github.com/user-attachments/assets/d900df5e-de60-4647-b89b-85bc443ab6d5" />

DARK THEME:

<img width="757" height="405" alt="Screenshot 2026-05-16 160947" src="https://github.com/user-attachments/assets/341dc9e9-3ddb-4b83-87db-7f3471112293" />

- [X ] Bug fix
- [Done] UI Enhancement
- [ X] New feature
- [ X] Breaking change