### PR TITLE
feat: Add Export Watchlist functionality - Markdown & CSV support

### DIFF
--- a/index.html
+++ b/index.html
@@ -796,12 +796,26 @@
         <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Watchlist.</h2>
         <p class="text-zinc-600 mt-4 max-w-2xl">Curate your open-source journey. Track organizations, monitor deadlines, and prepare your proposals for GSoC 2026.</p>
       </div>
-      <button id="clearAllBookmarksBtn"
-        class="hidden mt-8 flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-red-500 border border-red-200 rounded-full px-4 py-2 hover:bg-red-50 transition-colors"
-        title="Remove all bookmarks">
-        <span class="material-symbols-outlined text-sm">delete_sweep</span>
-        Clear All
-      </button>
+      <div class="hidden mt-8 flex-shrink-0 flex items-center gap-2" id="watchlistActions">
+        <button id="exportMarkdownBtn"
+          class="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-green-600 border border-green-200 rounded-full px-4 py-2 hover:bg-green-50 transition-colors"
+          title="Export watchlist as Markdown">
+          <span class="material-symbols-outlined text-sm">download</span>
+          Export MD
+        </button>
+        <button id="exportCsvBtn"
+          class="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-blue-600 border border-blue-200 rounded-full px-4 py-2 hover:bg-blue-50 transition-colors"
+          title="Export watchlist as CSV">
+          <span class="material-symbols-outlined text-sm">download</span>
+          Export CSV
+        </button>
+        <button id="clearAllBookmarksBtn"
+          class="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-red-500 border border-red-200 rounded-full px-4 py-2 hover:bg-red-50 transition-colors"
+          title="Remove all bookmarks">
+          <span class="material-symbols-outlined text-sm">delete_sweep</span>
+          Clear All
+        </button>
+      </div>
     </div>
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
       <div class="lg:col-span-2 space-y-4" id="watchlistContainer">
@@ -2370,6 +2384,10 @@
   // Wire up "Clear All" button
   document.getElementById('clearAllBookmarksBtn')?.addEventListener('click', clearAllBookmarks);
 
+  // Wire up export buttons
+  document.getElementById('exportMarkdownBtn')?.addEventListener('click', exportWatchlistAsMarkdown);
+  document.getElementById('exportCsvBtn')?.addEventListener('click', exportWatchlistAsCsv);
+
   function clearAllBookmarks() {
     if (!bookmarkedSet.size) return;
     if (!confirm(`Remove all ${bookmarkedSet.size} bookmarked organization(s)? This cannot be undone.`)) return;
@@ -2384,6 +2402,7 @@
   function renderWatchlist() {
     const container = document.getElementById('watchlistContainer');
     const clearBtn  = document.getElementById('clearAllBookmarksBtn');
+    const actionsDiv = document.getElementById('watchlistActions');
     if (!container) return;
 
     container.innerHTML = '';
@@ -2392,7 +2411,8 @@
       .map(name => ORGS.find(o => o.name === name))
       .filter(Boolean);
 
-    // Show / hide "Clear All" button
+    // Show / hide action buttons (Clear All, Export)
+    if (actionsDiv) actionsDiv.classList.toggle('hidden', bookmarks.length === 0);
     if (clearBtn) clearBtn.classList.toggle('hidden', bookmarks.length === 0);
 
     // ── Empty state ───────────────────────────────────────────────────────────
@@ -2486,6 +2506,100 @@
       container.appendChild(item);
       attachOrgCardListeners(item);
     });
+  }
+
+  // ── exportWatchlistAsMarkdown ────────────────────────────────────────────────
+  function exportWatchlistAsMarkdown() {
+    const bookmarks = [...bookmarkedSet]
+      .map(name => ORGS.find(o => o.name === name))
+      .filter(Boolean);
+
+    if (bookmarks.length === 0) {
+      alert('Your watchlist is empty. Add some organizations first!');
+      return;
+    }
+
+    let markdown = '# GSoC 2026 Watchlist\n\n';
+    markdown += `*Exported from [FindMyGSoC](https://findmygsoc.vercel.app/) on ${new Date().toLocaleDateString()}*\n\n`;
+    markdown += `**Total Organizations:** ${bookmarks.length}\n\n`;
+    markdown += '---\n\n';
+
+    bookmarks.forEach((org, idx) => {
+      const repoUrl = org.github ? `https://github.com/${org.github}` : '#';
+      const tags = (org.tags || []).slice(0, 5).join(', ');
+      const category = {
+        science:'Science', programming:'Programming', data:'Data', web:'Web',
+        os:'OS / Systems', security:'Security', media:'Media', infra:'Infrastructure',
+        ai:'AI / ML', dev:'Dev Tools', other:'Other',
+      }[org.cat] || org.cat;
+
+      markdown += `## ${idx + 1}. ${org.name}\n\n`;
+      markdown += `**Category:** ${category}\n\n`;
+      markdown += `**Description:** ${org.desc || 'N/A'}\n\n`;
+      markdown += `**GSoC History:** ${org.years} years\n\n`;
+      markdown += `**Competition Level:** ${org.competition || 'N/A'}\n\n`;
+      markdown += `**Tech Stack:** ${tags || 'N/A'}\n\n`;
+      markdown += `**GitHub Repository:** [${org.github}](${repoUrl})\n\n`;
+      markdown += '---\n\n';
+    });
+
+    const blob = new Blob([markdown], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `GSoC-2026-Watchlist-${new Date().toISOString().slice(0,10)}.md`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  // ── exportWatchlistAsCsv ─────────────────────────────────────────────────────
+  function exportWatchlistAsCsv() {
+    const bookmarks = [...bookmarkedSet]
+      .map(name => ORGS.find(o => o.name === name))
+      .filter(Boolean);
+
+    if (bookmarks.length === 0) {
+      alert('Your watchlist is empty. Add some organizations first!');
+      return;
+    }
+
+    // CSV Header
+    const headers = ['Organization', 'Category', 'Description', 'GSoC Years', 'Competition Level', 'Tech Stack', 'GitHub Repository'];
+    const rows = [headers];
+
+    bookmarks.forEach(org => {
+      const category = {
+        science:'Science', programming:'Programming', data:'Data', web:'Web',
+        os:'OS / Systems', security:'Security', media:'Media', infra:'Infrastructure',
+        ai:'AI / ML', dev:'Dev Tools', other:'Other',
+      }[org.cat] || org.cat;
+      const tags = (org.tags || []).slice(0, 5).join('; ');
+      const repoUrl = org.github ? `https://github.com/${org.github}` : '';
+
+      const row = [
+        `"${(org.name || '').replace(/"/g, '""')}"`,
+        `"${(category || '').replace(/"/g, '""')}"`,
+        `"${(org.desc || '').replace(/"/g, '""')}"`,
+        `"${(org.years || '').toString()}"`,
+        `"${(org.competition || '').replace(/"/g, '""')}"`,
+        `"${(tags || '').replace(/"/g, '""')}"`,
+        `"${(repoUrl || '').replace(/"/g, '""')}"`
+      ];
+      rows.push(row);
+    });
+
+    const csv = rows.map(row => row.join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `GSoC-2026-Watchlist-${new Date().toISOString().slice(0,10)}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
   }
 
   // ── updateAIInsights ─────────────────────────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -2508,16 +2508,68 @@
     });
   }
 
-  // ── exportWatchlistAsMarkdown ────────────────────────────────────────────────
-  function exportWatchlistAsMarkdown() {
+  // ── Watchlist Export Helpers ────────────────────────────────────────────────
+  // Category label mapping for consistent display across export formats
+  const CATEGORY_LABELS = {
+    science: 'Science',
+    programming: 'Programming',
+    data: 'Data',
+    web: 'Web',
+    os: 'OS / Systems',
+    security: 'Security',
+    media: 'Media',
+    infra: 'Infrastructure',
+    ai: 'AI / ML',
+    dev: 'Dev Tools',
+    other: 'Other'
+  };
+
+  /**
+   * Retrieves bookmarked organizations and validates watchlist is not empty.
+   * Alerts user and returns null if watchlist is empty.
+   * @returns {Array|null} Array of bookmarked org objects or null if empty
+   */
+  function getWatchlistOrAlertEmpty() {
     const bookmarks = [...bookmarkedSet]
       .map(name => ORGS.find(o => o.name === name))
       .filter(Boolean);
 
     if (bookmarks.length === 0) {
       alert('Your watchlist is empty. Add some organizations first!');
-      return;
+      return null;
     }
+
+    return bookmarks;
+  }
+
+  /**
+   * Escapes Markdown special characters to prevent formatting injection.
+   * Protects against potential content injection in generated Markdown files.
+   * @param {string} text - Raw text to escape
+   * @returns {string} Escaped text safe for Markdown
+   */
+  function escapeMarkdown(text) {
+    if (!text) return '';
+    return String(text)
+      .replace(/\\/g, '\\\\')      // Escape backslashes first
+      .replace(/[[\]()#*+\-_.!`]/g, '\\$&');  // Escape Markdown special chars
+  }
+
+  /**
+   * Escapes text for safe inclusion in CSV format.
+   * Wraps in quotes and escapes internal quotes.
+   * @param {string} text - Raw text to escape
+   * @returns {string} CSV-escaped text
+   */
+  function escapeCsv(text) {
+    const str = (text || '').toString();
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+
+  // ── exportWatchlistAsMarkdown ────────────────────────────────────────────────
+  function exportWatchlistAsMarkdown() {
+    const bookmarks = getWatchlistOrAlertEmpty();
+    if (!bookmarks) return;
 
     let markdown = '# GSoC 2026 Watchlist\n\n';
     markdown += `*Exported from [FindMyGSoC](https://findmygsoc.vercel.app/) on ${new Date().toLocaleDateString()}*\n\n`;
@@ -2527,19 +2579,16 @@
     bookmarks.forEach((org, idx) => {
       const repoUrl = org.github ? `https://github.com/${org.github}` : '#';
       const tags = (org.tags || []).slice(0, 5).join(', ');
-      const category = {
-        science:'Science', programming:'Programming', data:'Data', web:'Web',
-        os:'OS / Systems', security:'Security', media:'Media', infra:'Infrastructure',
-        ai:'AI / ML', dev:'Dev Tools', other:'Other',
-      }[org.cat] || org.cat;
+      const categoryLabel = CATEGORY_LABELS[org.cat] || org.cat;
 
-      markdown += `## ${idx + 1}. ${org.name}\n\n`;
-      markdown += `**Category:** ${category}\n\n`;
-      markdown += `**Description:** ${org.desc || 'N/A'}\n\n`;
-      markdown += `**GSoC History:** ${org.years} years\n\n`;
-      markdown += `**Competition Level:** ${org.competition || 'N/A'}\n\n`;
-      markdown += `**Tech Stack:** ${tags || 'N/A'}\n\n`;
-      markdown += `**GitHub Repository:** [${org.github}](${repoUrl})\n\n`;
+      // Escape dynamic content for Markdown security
+      markdown += `## ${idx + 1}. ${escapeMarkdown(org.name)}\n\n`;
+      markdown += `**Category:** ${escapeMarkdown(categoryLabel)}\n\n`;
+      markdown += `**Description:** ${escapeMarkdown(org.desc || 'N/A')}\n\n`;
+      markdown += `**GSoC History:** ${escapeMarkdown(String(org.years))} years\n\n`;
+      markdown += `**Competition Level:** ${escapeMarkdown(org.competition || 'N/A')}\n\n`;
+      markdown += `**Tech Stack:** ${escapeMarkdown(tags || 'N/A')}\n\n`;
+      markdown += `**GitHub Repository:** [${escapeMarkdown(org.github || '')}](${escapeMarkdown(repoUrl)})\n\n`;
       markdown += '---\n\n';
     });
 
@@ -2547,7 +2596,7 @@
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = `GSoC-2026-Watchlist-${new Date().toISOString().slice(0,10)}.md`;
+    link.download = `GSoC-2026-Watchlist-${new Date().toISOString().slice(0, 10)}.md`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -2556,36 +2605,26 @@
 
   // ── exportWatchlistAsCsv ─────────────────────────────────────────────────────
   function exportWatchlistAsCsv() {
-    const bookmarks = [...bookmarkedSet]
-      .map(name => ORGS.find(o => o.name === name))
-      .filter(Boolean);
-
-    if (bookmarks.length === 0) {
-      alert('Your watchlist is empty. Add some organizations first!');
-      return;
-    }
+    const bookmarks = getWatchlistOrAlertEmpty();
+    if (!bookmarks) return;
 
     // CSV Header
     const headers = ['Organization', 'Category', 'Description', 'GSoC Years', 'Competition Level', 'Tech Stack', 'GitHub Repository'];
     const rows = [headers];
 
     bookmarks.forEach(org => {
-      const category = {
-        science:'Science', programming:'Programming', data:'Data', web:'Web',
-        os:'OS / Systems', security:'Security', media:'Media', infra:'Infrastructure',
-        ai:'AI / ML', dev:'Dev Tools', other:'Other',
-      }[org.cat] || org.cat;
+      const categoryLabel = CATEGORY_LABELS[org.cat] || org.cat;
       const tags = (org.tags || []).slice(0, 5).join('; ');
       const repoUrl = org.github ? `https://github.com/${org.github}` : '';
 
       const row = [
-        `"${(org.name || '').replace(/"/g, '""')}"`,
-        `"${(category || '').replace(/"/g, '""')}"`,
-        `"${(org.desc || '').replace(/"/g, '""')}"`,
-        `"${(org.years || '').toString()}"`,
-        `"${(org.competition || '').replace(/"/g, '""')}"`,
-        `"${(tags || '').replace(/"/g, '""')}"`,
-        `"${(repoUrl || '').replace(/"/g, '""')}"`
+        escapeCsv(org.name),
+        escapeCsv(categoryLabel),
+        escapeCsv(org.desc || 'N/A'),
+        escapeCsv(String(org.years || '')),
+        escapeCsv(org.competition || 'N/A'),
+        escapeCsv(tags || 'N/A'),
+        escapeCsv(repoUrl)
       ];
       rows.push(row);
     });
@@ -2595,7 +2634,7 @@
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = `GSoC-2026-Watchlist-${new Date().toISOString().slice(0,10)}.csv`;
+    link.download = `GSoC-2026-Watchlist-${new Date().toISOString().slice(0, 10)}.csv`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);

--- a/index.html
+++ b/index.html
@@ -2401,7 +2401,6 @@
   // ── renderWatchlist ─────────────────────────────────────────────────────────
   function renderWatchlist() {
     const container = document.getElementById('watchlistContainer');
-    const clearBtn  = document.getElementById('clearAllBookmarksBtn');
     const actionsDiv = document.getElementById('watchlistActions');
     if (!container) return;
 
@@ -2413,7 +2412,6 @@
 
     // Show / hide action buttons (Clear All, Export)
     if (actionsDiv) actionsDiv.classList.toggle('hidden', bookmarks.length === 0);
-    if (clearBtn) clearBtn.classList.toggle('hidden', bookmarks.length === 0);
 
     // ── Empty state ───────────────────────────────────────────────────────────
     if (bookmarks.length === 0) {
@@ -2579,7 +2577,7 @@
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
 
   function getWatchlistExportRows(bookmarks) {

--- a/index.html
+++ b/index.html
@@ -796,7 +796,7 @@
         <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Watchlist.</h2>
         <p class="text-zinc-600 mt-4 max-w-2xl">Curate your open-source journey. Track organizations, monitor deadlines, and prepare your proposals for GSoC 2026.</p>
       </div>
-      <div class="hidden mt-8 flex-shrink-0 flex items-center gap-2" id="watchlistActions">
+      <div class="hidden mt-8 flex-shrink-0 flex flex-wrap items-center justify-start sm:justify-end gap-2" id="watchlistActions">
         <button id="exportMarkdownBtn"
           class="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-green-600 border border-green-200 rounded-full px-4 py-2 hover:bg-green-50 transition-colors"
           title="Export watchlist as Markdown">
@@ -2566,41 +2566,70 @@
     return `"${str.replace(/"/g, '""')}"`;
   }
 
+  function formatExportDate() {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  function createDownloadFile(content, filename, mimeType) {
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  function getWatchlistExportRows(bookmarks) {
+    return bookmarks.map(org => {
+      const repoUrl = sanitizeHrefUrl(githubUrlFromValue(org.github)) || '';
+      const ideasUrl = sanitizeHrefUrl(org.ideas) || '';
+      return {
+        name: org.name || '',
+        category: CATEGORY_LABELS[org.cat] || org.cat || 'Other',
+        description: org.desc || 'N/A',
+        years: org.years || '',
+        competition: org.competition || 'N/A',
+        tags: (org.tags || []).join(', '),
+        repoLabel: githubPathFromValue(org.github) || org.github || '',
+        repoUrl,
+        ideasUrl
+      };
+    });
+  }
+
   // ── exportWatchlistAsMarkdown ────────────────────────────────────────────────
   function exportWatchlistAsMarkdown() {
     const bookmarks = getWatchlistOrAlertEmpty();
     if (!bookmarks) return;
 
+    const rows = getWatchlistExportRows(bookmarks);
+    const exportedDate = formatExportDate();
     let markdown = '# GSoC 2026 Watchlist\n\n';
-    markdown += `*Exported from [FindMyGSoC](https://findmygsoc.vercel.app/) on ${new Date().toLocaleDateString()}*\n\n`;
-    markdown += `**Total Organizations:** ${bookmarks.length}\n\n`;
+    markdown += `*Exported from [FindMyGSoC](https://findmygsoc.vercel.app/) on ${exportedDate}*\n\n`;
+    markdown += `**Total Organizations:** ${rows.length}\n\n`;
     markdown += '---\n\n';
 
-    bookmarks.forEach((org, idx) => {
-      const repoUrl = org.github ? `https://github.com/${org.github}` : '#';
-      const tags = (org.tags || []).slice(0, 5).join(', ');
-      const categoryLabel = CATEGORY_LABELS[org.cat] || org.cat;
-
-      // Escape dynamic content for Markdown security
+    rows.forEach((org, idx) => {
       markdown += `## ${idx + 1}. ${escapeMarkdown(org.name)}\n\n`;
-      markdown += `**Category:** ${escapeMarkdown(categoryLabel)}\n\n`;
-      markdown += `**Description:** ${escapeMarkdown(org.desc || 'N/A')}\n\n`;
-      markdown += `**GSoC History:** ${escapeMarkdown(String(org.years))} years\n\n`;
-      markdown += `**Competition Level:** ${escapeMarkdown(org.competition || 'N/A')}\n\n`;
-      markdown += `**Tech Stack:** ${escapeMarkdown(tags || 'N/A')}\n\n`;
-      markdown += `**GitHub Repository:** [${escapeMarkdown(org.github || '')}](${escapeMarkdown(repoUrl)})\n\n`;
+      markdown += `**Category:** ${escapeMarkdown(org.category)}\n\n`;
+      markdown += `**Description:** ${escapeMarkdown(org.description)}\n\n`;
+      markdown += `**GSoC History:** ${escapeMarkdown(String(org.years || 'N/A'))} year${org.years === 1 ? '' : 's'}\n\n`;
+      markdown += `**Competition Level:** ${escapeMarkdown(org.competition)}\n\n`;
+      markdown += `**Tech Stack:** ${escapeMarkdown(org.tags || 'N/A')}\n\n`;
+      markdown += '**Links:**\n';
+      markdown += org.repoUrl
+        ? `- GitHub: [${escapeMarkdown(org.repoLabel)}](${org.repoUrl})\n`
+        : '- GitHub: N/A\n';
+      markdown += org.ideasUrl
+        ? `- Ideas Page: ${org.ideasUrl}\n\n`
+        : '- Ideas Page: N/A\n\n';
       markdown += '---\n\n';
     });
 
-    const blob = new Blob([markdown], { type: 'text/markdown' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `GSoC-2026-Watchlist-${new Date().toISOString().slice(0, 10)}.md`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+    createDownloadFile(markdown, `GSoC-2026-Watchlist-${exportedDate}.md`, 'text/markdown;charset=utf-8;');
   }
 
   // ── exportWatchlistAsCsv ─────────────────────────────────────────────────────
@@ -2608,37 +2637,28 @@
     const bookmarks = getWatchlistOrAlertEmpty();
     if (!bookmarks) return;
 
+    const rows = getWatchlistExportRows(bookmarks);
+    const exportedDate = formatExportDate();
+
     // CSV Header
-    const headers = ['Organization', 'Category', 'Description', 'GSoC Years', 'Competition Level', 'Tech Stack', 'GitHub Repository'];
-    const rows = [headers];
+    const headers = ['Organization', 'Category', 'Description', 'GSoC Years', 'Competition Level', 'Tech Stack', 'GitHub Repository', 'Ideas Page'];
+    const csvRows = [headers];
 
-    bookmarks.forEach(org => {
-      const categoryLabel = CATEGORY_LABELS[org.cat] || org.cat;
-      const tags = (org.tags || []).slice(0, 5).join('; ');
-      const repoUrl = org.github ? `https://github.com/${org.github}` : '';
-
-      const row = [
+    rows.forEach(org => {
+      csvRows.push([
         escapeCsv(org.name),
-        escapeCsv(categoryLabel),
-        escapeCsv(org.desc || 'N/A'),
+        escapeCsv(org.category),
+        escapeCsv(org.description),
         escapeCsv(String(org.years || '')),
-        escapeCsv(org.competition || 'N/A'),
-        escapeCsv(tags || 'N/A'),
-        escapeCsv(repoUrl)
-      ];
-      rows.push(row);
+        escapeCsv(org.competition),
+        escapeCsv(org.tags || 'N/A'),
+        escapeCsv(org.repoUrl),
+        escapeCsv(org.ideasUrl)
+      ]);
     });
 
-    const csv = rows.map(row => row.join(',')).join('\n');
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `GSoC-2026-Watchlist-${new Date().toISOString().slice(0, 10)}.csv`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+    const csv = '\uFEFF' + csvRows.map(row => row.join(',')).join('\n');
+    createDownloadFile(csv, `GSoC-2026-Watchlist-${exportedDate}.csv`, 'text/csv;charset=utf-8;');
   }
 
   // ── updateAIInsights ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Implements the Export Watchlist feature so GSoC applicants can download bookmarked organizations as Markdown or CSV files using native browser APIs.

## Program
GSSoC

## Type of Change
- [x] New feature
- [x] Frontend update
- [x] Bug fix
- [x] Documentation update

## Changes Made
- Added Export MD and Export CSV buttons next to the Watchlist Clear All action
- Export buttons show only when the watchlist contains bookmarked organizations
- Added Markdown export with organization name, category, description, GSoC history, competition level, tech stack, GitHub repository, and ideas page links
- Added CSV export with escaped fields and UTF-8 BOM for spreadsheet compatibility
- Used Blob and URL.createObjectURL() with delayed URL revocation for better browser compatibility
- Kept the implementation dependency-free and aligned with the zero-build setup

## Testing
- [x] Ran `npm run lint`
- [x] Verified export functions use native browser APIs only
- [x] Verified empty watchlists do not show export actions
- [x] Verified exported data comes from the current bookmarked organizations

## Checklist
- [x] I am participating via GSSoC
- [x] I have read the contribution guidelines
- [x] My commits include DCO sign-off
- [x] I have linked the related issue
- [x] I have kept the change focused and dependency-free

Closes #801