### PR TITLE
fix: add favicon to website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <link rel="icon" type="image/png" href="src/assets/icon-512.png">
+  <link rel="apple-touch-icon" href="src/assets/icon-512.png">
   <meta charset="utf-8" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <title>Live GSoC 2026 Org Finder & Good First Issue Tracker | FindMyGSoC</title>


### PR DESCRIPTION
## 📝 Description

This PR adds a favicon to the website so that the FindMyGSoC logo appears on the browser tab instead of the default blank icon, improving branding and user experience.

## 🔧 Changes Made

* Added `<link rel="icon">` tag inside the `<head>` section of `index.html`
* Added `<link rel="apple-touch-icon">` for iOS home screen support
* Used the existing asset `src/assets/icon-512.png` (no new files added)

## ✅ Testing Done

* Verified favicon appears correctly in browser tab
* Tested locally using Live Server
* Confirmed no existing functionality was affected

## 🌱 Contributor Checklist

* [x] I am participating via GSSoC
* [x] I have read the contribution guidelines
* [x] I checked for existing issues before creating this
* [x] My changes do not break existing functionality
* [x] I tested my changes locally
