### PR TITLE
feat: add CSV and JSON export for filtered orgs and bookmarks

### DIFF
--- a/index.html
+++ b/index.html
@@ -3054,27 +3054,6 @@ if(org.ideas){
   renderGoodFirstIssues();
   renderCompare();
 
-function openHelpModal() {
-  helpModal.classList.add('open');
-}
-
-function closeHelpModal() {
-  helpModal.classList.remove('open');
-}
-
-helpBtn.addEventListener('click', openHelpModal);
-
-document.addEventListener('keydown', (e) => {
-
-  if (e.key === '?') {
-    openHelpModal();
-  }
-
-  if (e.key === 'Escape') {
-    closeHelpModal();
-  }
-
-});
   // ══════════════════════════════════════════════
   // EXPORT  (added for issue #697)
   // ══════════════════════════════════════════════

--- a/index.html
+++ b/index.html
@@ -665,7 +665,16 @@
 <!-- ═══════════════════ ORG DIRECTORY ═══════════════════ -->
 <section id="orgs" class="px-6 max-w-7xl mx-auto pb-20">
   <div class="flex items-center justify-between mb-8">
-    <p class="font-label text-xs uppercase tracking-widest text-zinc-500">Showing <strong id="orgCount">184</strong> of 184 organizations</p>
+    <div class="flex items-center gap-3 flex-wrap">
+      <p class="font-label text-xs uppercase tracking-widest text-zinc-500">Showing <strong id="orgCount">184</strong> of 184 organizations</p>
+      <!-- Export buttons — CSV exports the current filtered list, JSON exports bookmarks only -->
+      <button onclick="exportFilteredCSV()" title="Download current filtered list as CSV" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-bold text-zinc-600 hover:border-primary hover:text-primary transition-colors">
+        <span class="material-symbols-outlined text-sm">download</span> Export CSV (<span id="csvCount">184</span>)
+      </button>
+      <button onclick="exportBookmarksJSON()" title="Download bookmarked organizations as JSON" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-white border border-zinc-200 text-xs font-bold text-zinc-600 hover:border-primary hover:text-primary transition-colors">
+        <span class="material-symbols-outlined text-sm">bookmark</span> JSON
+      </button>
+    </div>
     <div class="flex items-center gap-4">
       <select id="categoryFilter" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
         <option value="all">Categories: All</option>
@@ -2132,6 +2141,9 @@
     });
 
     document.getElementById('orgCount').textContent = filteredOrgs.length;
+    // keep the CSV button count in sync with the org count (added for issue #697)
+    const csvCountEl = document.getElementById('csvCount');
+    if (csvCountEl) csvCountEl.textContent = filteredOrgs.length;
     document.getElementById('loadMoreContainer').style.display = (visibleCount < filteredOrgs.length) ? 'flex' : 'none';
   }
 
@@ -3041,6 +3053,76 @@ if(org.ideas){
   loadMentorData();
   renderGoodFirstIssues();
   renderCompare();
+
+function openHelpModal() {
+  helpModal.classList.add('open');
+}
+
+function closeHelpModal() {
+  helpModal.classList.remove('open');
+}
+
+helpBtn.addEventListener('click', openHelpModal);
+
+document.addEventListener('keydown', (e) => {
+
+  if (e.key === '?') {
+    openHelpModal();
+  }
+
+  if (e.key === 'Escape') {
+    closeHelpModal();
+  }
+
+});
+  // ══════════════════════════════════════════════
+  // EXPORT  (added for issue #697)
+  // ══════════════════════════════════════════════
+
+  // shared helper — one org → flat row, used by both CSV and JSON so fields stay in sync
+  function orgToExportRow(o) {
+    const path = githubPathFromValue(o.github);
+    return {
+      Name: o.name,
+      Category: o.cat,
+      Years: o.years,
+      'First Year': o.firstYear,
+      Competition: o.competition,
+      'GitHub URL': path ? `https://github.com/${path}` : '',
+      'Ideas URL': o.ideas || '',
+      Tags: (o.tags || []).join('; '),
+    };
+  }
+
+  // triggers a file download from a Blob 
+  function triggerDownload(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  // exports the current filtered list — respects active search/filters at click time
+  globalThis.exportFilteredCSV = function() {
+    if (!filteredOrgs.length) { alert('No organizations to export.'); return; }
+    const headers = ['Name','Category','Years','First Year','Competition','GitHub URL','Ideas URL','Tags'];
+    const esc = v => `"${String(v).replaceAll('"', '""')}"`; // RFC 4180: quote fields, double internal quotes
+    const rows = filteredOrgs.map(o => {
+      const r = orgToExportRow(o);
+      return headers.map(h => esc(r[h])).join(',');
+    });
+    const csv = [headers.map(esc).join(','), ...rows].join('\r\n');
+    triggerDownload(new Blob([csv], { type: 'text/csv;charset=utf-8;' }), `gsoc-orgs-filtered-${Date.now()}.csv`);
+  };
+
+  // exports only bookmarked orgs as JSON — handy for offline use or sharing a curated list
+  globalThis.exportBookmarksJSON = function() {
+    const orgs = ORGS.filter(o => bookmarkedSet.has(o.name)).map(orgToExportRow);
+    if (!orgs.length) { alert('No bookmarked organizations to export.'); return; }
+    triggerDownload(new Blob([JSON.stringify(orgs, null, 2)], { type: 'application/json' }), `gsoc-bookmarks-${Date.now()}.json`);
+  };
 
   // Export helpers to global scope
   globalThis.toggleCompare = toggleCompare;


### PR DESCRIPTION
🚀 Program
GSSoC

📝 Description
Adds two export buttons next to the "Showing X of 184 organizations" count line:
- Export CSV - downloads the current filtered org list, respects all active search/filter/language pill state at click time
- JSON - downloads only the user's bookmarked organizations

🔗 Related Issue
Closes #697

🔄 Type of Change
- ✨ New feature

🧪 How to Test

0. Run `vercel dev` and open http://localhost:3000

1. Apply any filter (e.g. search "django", select Python pill, pick a category)
2. Click "Export CSV (N)" — a CSV file downloads with only the filtered orgs
3. Bookmark a few orgs using the star button
4. Click "JSON" — a JSON file downloads with only your bookmarked orgs
5. Click "JSON" with no bookmarks — an alert appears saying no bookmarks to export

📸 Screenshots 

<img width="1900" height="1079" alt="image" src="https://github.com/user-attachments/assets/b2c92885-e0d9-4e8d-963b-2053870b2dcc" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/17104acd-6f8c-41ac-a356-2445ede96c87" />
<img width="1524" height="1079" alt="image" src="https://github.com/user-attachments/assets/10988d11-a9cc-4bb6-82fb-82d96ffc1afe" />
<img width="577" height="488" alt="image" src="https://github.com/user-attachments/assets/15a01a96-cec6-4164-8bdb-015154e01457" />


✅ Checklist

- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. feat: add scroll button)
