### PR TITLE
fix: add missing Accord Project mentors to mentors.json

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -87,13 +87,37 @@
         "label": "Accord Project Discord"
       }
     ],
-    "mentors": [
-  "Sanket Shevkar",
-  "Niall Roche",
-  "Matt Roberts",
-  "Dan Selman",
-  "Ertugrul Karademir",
-  "Priyanshu Singh"
+   "mentors": [
+  {
+    "name": "Sanket Shevkar",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Niall Roche",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Matt Roberts",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Dan Selman",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Ertugrul Karademir",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Priyanshu Singh",
+    "github": "",
+    "githubUrl": ""
+  }
 ],
     "mailingLists": [],
     "tip": "Introduce yourself in the public channel before asking project-specific questions.",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -87,7 +87,14 @@
         "label": "Accord Project Discord"
       }
     ],
-    "mentors": [],
+    "mentors": [
+  "Sanket Shevkar",
+  "Niall Roche",
+  "Matt Roberts",
+  "Dan Selman",
+  "Ertugrul Karademir",
+  "Priyanshu Singh"
+],
     "mailingLists": [],
     "tip": "Introduce yourself in the public channel before asking project-specific questions.",
     "status": "ok",


### PR DESCRIPTION
Closes #835

Added 6 missing mentors for Accord Project:
- Sanket Shevkar
- Niall Roche
- Matt Roberts
- Dan Selman
- Ertugrul Karademir
- Priyanshu Singh

Data sourced from official GSoC 2026 ideas page:
https://github.com/accordproject/techdocs/wiki/Google-Summer-of-Code-2026-Ideas-List