### PR TITLE
Fix: footer issue resolved in GSoC-Org-Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,17 @@ These mentors help guide and review contributions for the GSSoC program:
 <a href="https://github.com/syedrazamd"><img src="https://github.com/syedrazamd.png" width="50px" alt="syedrazamd" /></a>
 <a href="https://github.com/vaibhavi-vaishnav"><img src="https://github.com/vaibhavi-vaishnav.png" width="50px" alt="vaibhavi-vaishnav" /></a>
 <!-- CONTRIBUTORS_END -->
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=S3DFX-CYBER%2FGSoC-Org-Finder-&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=S3DFX-CYBER/GSoC-Org-Finder-&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=S3DFX-CYBER/GSoC-Org-Finder-&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=S3DFX-CYBER/GSoC-Org-Finder-&type=date&legend=top-left" />
+ </picture>
+</a>
+
 ## 📄 License
 
 Apache 2.0 — made for GSoC beginners, by people who've been there.

--- a/index.html
+++ b/index.html
@@ -1050,6 +1050,15 @@
   </div>
 </section>
 
+
+
+
+
+
+
+
+
+
 <!-- ═══════════════════ COMPARE ═══════════════════ -->
 <section class="py-20 px-6 max-w-7xl mx-auto">
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
@@ -1079,6 +1088,11 @@
     </div>
   </div>
 </section>
+
+
+
+
+
 
 <!-- ═══════════════════ CONTACT ═══════════════════ -->
 <section id="contact" class="py-20 px-6 max-w-7xl mx-auto">
@@ -1124,7 +1138,7 @@
     <nav class="flex flex-wrap gap-6">
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://summerofcode.withgoogle.com/programs/2026/organizations" target="_blank">GSoC 2026</a>
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank">GitHub</a>
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#ai-recommender">Privacy</a>
+      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="/privacy">Privacy</a>
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#contact">Contact</a>
     </nav>
   </div>

--- a/index.html
+++ b/index.html
@@ -1124,7 +1124,7 @@
     <nav class="flex flex-wrap gap-6">
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://summerofcode.withgoogle.com/programs/2026/organizations" target="_blank">GSoC 2026</a>
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank">GitHub</a>
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#">Privacy</a>
+      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#ai-recommender">Privacy</a>
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#contact">Contact</a>
     </nav>
   </div>


### PR DESCRIPTION
🐛 Bug Fix: Privacy Link Redirect Issue
🐛 Description of the bug

Clicking on the "Privacy" link in the footer redirects users to the homepage/top section instead of opening a dedicated Privacy Policy page.

🔁 Steps to Reproduce

Open the website
Scroll down to the footer section
Click on the "Privacy" link
Observe that it redirects to the homepage (/#) instead of a Privacy Policy page

✅ Expected Behavior

The "Privacy" link should:

Open a dedicated /privacy page
OR
Redirect to a valid Privacy Policy section/page containing proper privacy-related content

❌ Actual Behavior

The link redirects to the homepage/top section (/#)
No dedicated privacy content is shown

🛠️ Proposed Fix

Update footer link routing from /# to /privacy (or correct route)


🌱 Contributor Checklist
 I am participating via GSSoC
 I have read the contribution guidelines
 I checked for existing issues before creating this
🚀 Additional Notes

This fix improves navigation clarity and ensures proper legal/privacy page accessibility for users.
closes #888