### PR TITLE
Added favicon using existing logo asset

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+   <link rel="icon" type="image/png" href="/src/assets/icon-512.png" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <title>Live GSoC 2026 Org Finder & Good First Issue Tracker | FindMyGSoC</title>
   <meta name="description" content="Live GSoC 2026 Org Finder & Good First Issue Tracker. Discover organizations, compare project fit, and track beginner-friendly GitHub issues in real time." />


### PR DESCRIPTION
## Description

Added a favicon to display the FindMyGSoC logo on the browser tab.

## Changes Made

* Added favicon link inside index.html
* Used existing asset: src/assets/icon-512.png

## Result

The website now displays the FindMyGSoC logo in the browser tab instead of the default blank icon.

Closes #424
