### PR TITLE
fix: add missing Accord Project mentors to mentors.json

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -87,13 +87,37 @@
         "label": "Accord Project Discord"
       }
     ],
-    "mentors": [
-  "Sanket Shevkar",
-  "Niall Roche",
-  "Matt Roberts",
-  "Dan Selman",
-  "Ertugrul Karademir",
-  "Priyanshu Singh"
+   "mentors": [
+  {
+    "name": "Sanket Shevkar",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Niall Roche",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Matt Roberts",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Dan Selman",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Ertugrul Karademir",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "Priyanshu Singh",
+    "github": "",
+    "githubUrl": ""
+  }
 ],
     "mailingLists": [],
     "tip": "Introduce yourself in the public channel before asking project-specific questions.",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -87,7 +87,14 @@
         "label": "Accord Project Discord"
       }
     ],
-    "mentors": [],
+    "mentors": [
+  "Sanket Shevkar",
+  "Niall Roche",
+  "Matt Roberts",
+  "Dan Selman",
+  "Ertugrul Karademir",
+  "Priyanshu Singh"
+],
     "mailingLists": [],
     "tip": "Introduce yourself in the public channel before asking project-specific questions.",
     "status": "ok",


### PR DESCRIPTION
## Program Tag
gssoc

## Description
Added 6 missing Accord Project mentors to data/mentors.json 
in proper object schema with name, github, and githubUrl fields.
Mentors were listed on their official GSoC 2026 ideas page 
but were not populated in our data file.

## Related Issue
Closes #835

## Type of Change
- [x] Data fix

## Checklist
- [x] Mentor data added in correct object schema format
- [x] Data sourced from official GSoC 2026 ideas page
- [x] No breaking changes