### PR TITLE
Fix: Actively Maintained chip now filters orgs with 5+ GSoC years

### DIFF
--- a/index.html
+++ b/index.html
@@ -2703,6 +2703,9 @@ if(org.ideas){
       else if (activeChip === 'newcomers')   matchChip = o.years <= 3;
       else if (activeChip === 'low-competition')  matchChip = o.competition === 'chill';
       else if (activeChip === 'high-competition') matchChip = o.competition === 'hot';
+      // Previously 'active' chip had no filter condition, showing all 184 orgs instead of filtering.
+      // Fixed: orgs with 5+ GSoC years are considered actively maintained.
+      else if (activeChip === 'active') matchChip = o.years >= 5;  
 
       return matchSearch && matchCat && matchComp && matchLang && matchChip;
     });


### PR DESCRIPTION
## Bug Fix: Actively Maintained chip had no filter logic

The 'Actively Maintained' quick-filter chip was not filtering 
any organizations — it showed all 184 orgs when clicked.

Fixed by adding a missing else-if condition that filters orgs 
with 5+ years of GSoC participation as actively maintained.

Note: Re-opening this PR from a feature branch as requested by maintainer.