### PR TITLE
fix: verify mentor contact info for UC OSPO (#427)

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -3002,20 +3002,19 @@
   },
   "UC OSPO": {
   "org": "UC OSPO",
-  "ideasUrl": "https://ucsc-ospo.github.io/gsoc/",
+  "ideasUrl": "https://ucsc-ospo.github.io/osre26/",
   "channels": [
     {
-      "type": "GitHub Discussions",
-      "url": "https://github.com/ucsc-ospo/ucsc-ospo.github.io/discussions",
-      "label": "UC OSPO GitHub Discussions"
+      "type": "Slack",
+      "url": "https://ucsc-ospo.github.io/osredocs/forstudents/",
+      "label": "OSRE Slack (request access via org admins)"
     }
   ],
   "mentors": [],
   "mailingLists": [],
-  "tip": "Introduce yourself in GitHub Discussions before asking project-specific questions.",
+  "tip": "Request access to the OSRE Slack channel via org admins, then introduce yourself there before asking project-specific questions.",
   "status": "ok",
-  "lastFetched": "2026-05-09T16:09:12.548Z"
-},
+  },
   "Unikraft": {
     "org": "Unikraft",
     "ideasUrl": "https://github.com/unikraft/docs/tree/main/content/docs/contributing/gsoc",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -3001,15 +3001,21 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "UC OSPO": {
-    "org": "UC OSPO",
-    "ideasUrl": "https://ucsc-ospo.github.io/gsoc/",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "fetch-failed",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
-  },
+  "org": "UC OSPO",
+  "ideasUrl": "https://ucsc-ospo.github.io/gsoc/",
+  "channels": [
+    {
+      "type": "GitHub Discussions",
+      "url": "https://github.com/ucsc-ospo/ucsc-ospo.github.io/discussions",
+      "label": "UC OSPO GitHub Discussions"
+    }
+  ],
+  "mentors": [],
+  "mailingLists": [],
+  "tip": "Introduce yourself in GitHub Discussions before asking project-specific questions.",
+  "status": "ok",
+  "lastFetched": "2026-05-09T16:09:12.548Z"
+},
   "Unikraft": {
     "org": "Unikraft",
     "ideasUrl": "https://github.com/unikraft/docs/tree/main/content/docs/contributing/gsoc",


### PR DESCRIPTION
## Related Issue

Closes #427
program: GSSoC'2026
---

## Description

Verified and updated mentor contact information for UC OSPO in `data/mentors.json`.

Updated:

* Added communication channel
* Updated status to `ok`
* Added contributor tip

---

## Type of PR

* [x] Documentation update

---

## Checklist

* [x] Issue assigned to me
* [x] PR links the issue
* [x] Changes are minimal and focused
* [x] JSON formatting verified
