### PR TITLE
feat: add native JSON import/export for local storage backup (#873)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1067,6 +1067,15 @@
       <button onclick="openCompareModal()" class="inline-flex items-center gap-2 px-8 py-4 bg-primary text-white font-bold rounded-xl hover:scale-95 transition-all shadow-lg">
         <span class="material-symbols-outlined">compare</span> Open Comparison Tool
       </button>
+      <div class="flex flex-wrap items-center gap-3 mt-4">
+    <button id="exportWorkspaceBtn" class="inline-flex items-center gap-1.5 px-4 py-2 bg-zinc-800 text-white dark:bg-zinc-200 dark:text-zinc-900 rounded-xl text-xs font-bold hover:scale-95 transition-all shadow-sm">
+        <span class="material-symbols-outlined text-sm">download</span> Export Backup
+    </button>
+    <label for="importWorkspaceFile" id="importWorkspaceLabel" tabindex="0" class="inline-flex items-center gap-1.5 px-4 py-2 bg-zinc-200 text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200 rounded-xl text-xs font-bold hover:scale-95 transition-all shadow-sm cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary" onkeydown="if(event.key === 'Enter' || event.key === ' ') document.getElementById('importWorkspaceFile').click();">
+        <span class="material-symbols-outlined text-sm">upload</span> Import Backup
+    </label>
+    <input type="file" id="importWorkspaceFile" accept=".json" class="hidden" style="display: none;">
+</div>
     </div>
     <div id="compare" class="bg-surface-container-low rounded-3xl p-8 border border-zinc-100">
       <div class="grid grid-cols-3 gap-4 text-center">


### PR DESCRIPTION

### 📝 Description
This PR resolves the architectural data-loss limitation outlined in #873. Currently, user research data (such as bookmarks and theme layouts) is stored strictly inside the browser's `localStorage` with no backup mechanism.

To fix this, I have implemented a native, lightweight JSON Import/Export utility using vanilla JavaScript. This allows users to seamlessly download a snapshot of their research state and reload it on any device or browser instance without needing an external database.

### 🛠️ Changes Made
- **UI Integration (`index.html`):** Added sleek, Tailwind-styled "Export Backup" and "Import Backup" buttons directly inside the Compare Organizations module.
- **Data Migration Logic (`agent/scripts/orgs.js`):** Implemented `exportWorkspaceData()` to download the stored arrays into a formatted JSON file, and `importWorkspaceData()` using the `FileReader()` API to parse and restore states safely.

### 📋 Type of Change
- [x] New feature (non-breaking change which adds functionality)

### ✅ Contributor Checklist
- [x] Sign commits using git commit -s
- [x] Link a valid issue (Closes #873)
- [x] Keep changes focused and relevant
- [x] Do not include unrelated modifications
- [x] Ensure workflows/build/tests are passing
- [x] Read the appropriate contributor guide