### PR TITLE
fix: update issue assignment push target to bot/state branch

### DIFF
--- a/.github/workflows/issue-context-assignment.yml
+++ b/.github/workflows/issue-context-assignment.yml
@@ -129,7 +129,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/reviewers/pending-assignments.json
           git diff --cached --quiet || git commit -m "chore: queue assignment for ${{ steps.validate.outputs.claimant }} on issue #${{ steps.validate.outputs.issue_number }} [skip ci]"
-          git pull --rebase origin bot/state
+          if git ls-remote --exit-code --heads origin bot/state >/dev/null; then
+            git pull --rebase origin bot/state
+          fi
+          git push origin HEAD:bot/state
           git push origin HEAD:bot/state
 
       # ── PATH B: /approve-assignment `@username` ──────────────────────────────
@@ -196,5 +199,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/reviewers/pending-assignments.json
           git diff --cached --quiet || git commit -m "chore: assignment approved for issue #${{ github.event.issue.number }} [skip ci]"
-          git pull --rebase origin bot/state
+          if git ls-remote --exit-code --heads origin bot/state >/dev/null; then
+            git pull --rebase origin bot/state
+          fi
+          git push origin HEAD:bot/state
           git push origin HEAD:bot/state

--- a/.github/workflows/issue-context-assignment.yml
+++ b/.github/workflows/issue-context-assignment.yml
@@ -197,4 +197,4 @@ jobs:
           git add .github/reviewers/pending-assignments.json
           git diff --cached --quiet || git commit -m "chore: assignment approved for issue #${{ github.event.issue.number }} [skip ci]"
           git pull --rebase origin "$GITHUB_REF_NAME"
-          git push origin HEAD:"$GITHUB_REF_NAME"
+          git push origin HEAD:bot/state

--- a/.github/workflows/issue-context-assignment.yml
+++ b/.github/workflows/issue-context-assignment.yml
@@ -126,11 +126,11 @@ jobs:
         if: steps.cmd.outputs.is_assign == 'true' && steps.validate.outputs.eligible == 'true'
         run: |
           git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]`@users.noreply.github.com`"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/reviewers/pending-assignments.json
           git diff --cached --quiet || git commit -m "chore: queue assignment for ${{ steps.validate.outputs.claimant }} on issue #${{ steps.validate.outputs.issue_number }} [skip ci]"
-          git pull --rebase origin "$GITHUB_REF_NAME"
-          git push origin HEAD:"$GITHUB_REF_NAME"
+          git pull --rebase origin bot/state
+          git push origin HEAD:bot/state
 
       # ── PATH B: /approve-assignment `@username` ──────────────────────────────
 
@@ -193,8 +193,8 @@ jobs:
         if: steps.cmd.outputs.is_approve == 'true' && steps.process_approval.outputs.assigned == 'true'
         run: |
           git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]`@users.noreply.github.com`"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/reviewers/pending-assignments.json
           git diff --cached --quiet || git commit -m "chore: assignment approved for issue #${{ github.event.issue.number }} [skip ci]"
-          git pull --rebase origin "$GITHUB_REF_NAME"
+          git pull --rebase origin bot/state
           git push origin HEAD:bot/state

--- a/.github/workflows/issue-context-assignment.yml
+++ b/.github/workflows/issue-context-assignment.yml
@@ -8,7 +8,7 @@ permissions:
   issues: write
   contents: write
 
-concurrency:
+concurrency: 
   group: issue-assignment-${{ github.event.issue.number }}
   cancel-in-progress: false
  

--- a/.github/workflows/issue-context-assignment.yml
+++ b/.github/workflows/issue-context-assignment.yml
@@ -11,7 +11,7 @@ permissions:
 concurrency:
   group: issue-assignment-${{ github.event.issue.number }}
   cancel-in-progress: false
-
+ 
 jobs:
   assign:
     if: |

--- a/.github/workflows/issue-context-assignment.yml
+++ b/.github/workflows/issue-context-assignment.yml
@@ -133,8 +133,7 @@ jobs:
             git pull --rebase origin bot/state
           fi
           git push origin HEAD:bot/state
-          git push origin HEAD:bot/state
-
+          
       # ── PATH B: /approve-assignment `@username` ──────────────────────────────
 
       - name: Process mentor approval
@@ -203,4 +202,4 @@ jobs:
             git pull --rebase origin bot/state
           fi
           git push origin HEAD:bot/state
-          git push origin HEAD:bot/state
+          


### PR DESCRIPTION
## Description
program: gssoc
This PR resolves Task 1 from the "Bugs in workflows" issue. It updates the `issue-context-assignment.yml` workflow to push updates to an unprotected `bot/state` branch instead of the protected `main` branch. This fixes the GH006 error and allows the assignment bot to function correctly.

## Related Issue
Closes #1066

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have performed a self-review of my code
- [x] I have tested the changes locally before submitting
- [x] I have followed the project contribution guidelines
- [x] I have linked the related issue properly
- [x] I have ensured existing functionality remains intact
- [x] I am participating via GSSoC