### PR TITLE
feat: add clear filters button for resetting search and filter state

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ These mentors help guide and review contributions for the GSSoC program:
 <a href="https://github.com/abdussamad567"><img src="https://github.com/abdussamad567.png" width="50px" alt="abdussamad567" /></a>
 <a href="https://github.com/anirudh645"><img src="https://github.com/anirudh645.png" width="50px" alt="anirudh645" /></a>
 <a href="https://github.com/bhaktiyadav08"><img src="https://github.com/bhaktiyadav08.png" width="50px" alt="bhaktiyadav08" /></a>
+<a href="https://github.com/bhavyanjain3004"><img src="https://github.com/bhavyanjain3004.png" width="50px" alt="bhavyanjain3004" /></a>
 <a href="https://github.com/bipinchaudhary28899"><img src="https://github.com/bipinchaudhary28899.png" width="50px" alt="bipinchaudhary28899" /></a>
 <a href="https://github.com/diksha78dev"><img src="https://github.com/diksha78dev.png" width="50px" alt="diksha78dev" /></a>
 <a href="https://github.com/gloooomed"><img src="https://github.com/gloooomed.png" width="50px" alt="gloooomed" /></a>

--- a/index.html
+++ b/index.html
@@ -659,7 +659,7 @@
 <section id="orgs" class="px-6 max-w-7xl mx-auto pb-20">
   <div class="flex items-center justify-between mb-8">
     <p class="font-label text-xs uppercase tracking-widest text-zinc-500">Showing <strong id="orgCount">184</strong> of 184 organizations</p>
-    <div class="flex items-center gap-4">
+    <div class="flex flex-wrap items-center gap-4">
       <select id="categoryFilter" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-0 cursor-pointer text-zinc-600">
         <option value="all">Categories: All</option>
         <option value="web">Web</option>
@@ -686,6 +686,10 @@
         <option value="stars">GitHub Stars</option>
         <option value="gfi">Good First Issues</option>
       </select>
+      <button type="button" onclick="clearAllFilters()" class="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-zinc-200 bg-white text-xs font-bold text-zinc-600 hover:border-primary hover:text-primary hover:bg-orange-50 transition-colors shadow-sm">
+        <span class="material-symbols-outlined text-base">restart_alt</span>
+        Clear Filters
+      </button>
     </div>
   </div>
   
@@ -2459,21 +2463,33 @@ if(org.ideas){
   }
 
   window.clearAllFilters = function() {
-    document.getElementById('searchInput').value = '';
-    document.getElementById('categoryFilter').value = 'all';
-    document.getElementById('complexityFilter').value = 'all';
-    if (document.getElementById('sortSelect')) document.getElementById('sortSelect').value = 'alpha';
+    const searchInput = document.getElementById('searchInput');
     const heroSearch = document.getElementById('hero-search');
+    const categoryFilter = document.getElementById('categoryFilter');
+    const complexityFilter = document.getElementById('complexityFilter');
+    const sortSelect = document.getElementById('sortSelect');
+    const languageToggle = document.getElementById('matchAllLanguagesToggle');
+
+    if (searchInput) searchInput.value = '';
     if (heroSearch) heroSearch.value = '';
-    
-    // Reset chips
+    if (categoryFilter) categoryFilter.value = 'all';
+    if (complexityFilter) complexityFilter.value = 'all';
+    if (sortSelect) sortSelect.value = 'alpha';
+    if (languageToggle) languageToggle.checked = false;
+
+    selectedLanguages.clear();
+    renderSelectedLanguages();
+    matchAllLanguages = false;
+    globalThis.matchAllLanguages = matchAllLanguages;
+    updateLanguageModeHint();
+
+    activeChip = null;
     document.querySelectorAll('.filter-chip').forEach(chip => {
       chip.classList.remove('bg-orange-600', 'text-white');
       chip.classList.add('bg-surface-container-highest');
     });
 
-    filteredOrgs = [...ORGS];
-    renderOrgs(true);
+    applyFilters();
   };
 
   document.getElementById('searchInput').addEventListener('input', applyFilters);

--- a/index.html
+++ b/index.html
@@ -708,7 +708,7 @@
     <div class="text-6xl mb-4">🔍</div>
     <h3 class="text-2xl font-bold text-zinc-900 dark:text-white mb-2">No organizations match your current filters.</h3>
     <p class="text-zinc-500 dark:text-zinc-400 mb-8">Try adjusting your search or clearing some filters.</p>
-    <button onclick="clearAllFilters()" class="px-8 py-3 bg-primary text-white rounded-xl font-bold hover:bg-orange-600 transition-colors shadow-lg shadow-primary/20">
+    <button type="button" title="Clear All Filters" aria-label="Clear All Filters" onclick="clearAllFilters()" class="px-8 py-3 bg-primary text-white rounded-xl font-bold hover:bg-orange-600 transition-colors shadow-lg shadow-primary/20">
       Clear All Filters
     </button>
   </div>


### PR DESCRIPTION
# GSSoC PR Submission

## 📌 Program

program: gssoc

## ✨ Description of Changes

* Added a dedicated **Clear Filters** button
* Reset functionality clears:

  * Search query
  * Category filters
  * Tech stack filters
  * Sorting preferences
* Restores default filter state instantly without page refresh
* Improved overall filter usability and user experience

## 🔗 Related Issue

Closes #556 

## 🛠 Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] UI enhancement
* [ ] Refactor

## 🧪 Testing Steps

1. Apply multiple filters and search inputs
2. Click the **Clear Filters** button
3. Verify all filters and inputs reset correctly
4. Ensure data reloads to default state without refreshing the page

## 📷 Screenshots
<img width="1646" height="787" alt="Screenshot 2026-05-15 191829" src="https://github.com/user-attachments/assets/1c5263ee-68c6-42c7-b762-dfb1d36b8110" />
<img width="1896" height="782" alt="Screenshot 2026-05-15 191811" src="https://github.com/user-attachments/assets/4677571e-a09d-4bb9-845f-4573ad3b4cbc" />


## ✅ Checklist

* [x] Code follows project guidelines
* [x] Tested locally
* [x] No breaking changes introduced
* [x] Linked related issue
* [x] Ready for review
