### PR TITLE
feat(org-card): tooltip on +n badge reveals hidden tech-stack tags (#730)

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
       background: #1a1c1c;
       color: #fff;
       font-family: 'Fira Code', monospace;
-      font-size: 0.65rem;
+      font-size: 0.75rem;
       line-height: 1.45;
       font-weight: 500;
       text-align: center;

--- a/index.html
+++ b/index.html
@@ -220,7 +220,11 @@
     .complexity-badge.advanced { background: #fee2e2; color: #991b1b; }
 
     /* Hidden tech-stack tags tooltip on the "+n" badge */
-    .tag-more { position: relative; cursor: help; outline: none; }
+    .tag-more { position: relative; cursor: help; }
+    .tag-more:focus-visible {
+      outline: 2px solid #8b5cf6;
+      outline-offset: 2px;
+    }
     .tag-more .tag-more-tip {
       position: absolute;
       bottom: calc(100% + 8px);
@@ -2129,7 +2133,9 @@
       
       const githubOwner = githubOwnerFromValue(org.github);
       const logoUrl = githubOwner ? `https://github.com/${githubOwner}.png?size=80` : '';
-      
+      // Unique id linking the +n tech badge to its tooltip for aria-describedby
+      const tipId = `tagtip-${org.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+
       card.innerHTML = `
         <div class="flex justify-between items-start mb-4">
           <div class="w-14 h-14 rounded-xl bg-surface-container-low flex items-center justify-center p-2 overflow-hidden">
@@ -2149,7 +2155,7 @@
         <p class="text-on-surface-variant text-sm leading-relaxed mb-4 line-clamp-2">${escapeHtml(org.desc)}</p>
         <div class="flex flex-wrap gap-1.5 mb-4">
           ${org.tags.slice(0, 3).map(t => `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded">${escapeHtml(t)}</span>`).join('')}
-          ${org.tags.length > 3 ? `<span class="tag-more px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded" tabindex="0" aria-label="${escapeHtml((org.tags.length - 3) + ' more technologies: ' + org.tags.slice(3).join(', '))}">+${escapeHtml(String(org.tags.length - 3))}<span class="tag-more-tip" role="tooltip">${escapeHtml(org.tags.slice(3).join(', '))}</span></span>` : ''}
+          ${org.tags.length > 3 ? `<span class="tag-more px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded" tabindex="0" aria-describedby="${tipId}">+${escapeHtml(String(org.tags.length - 3))}<span id="${tipId}" class="tag-more-tip" role="tooltip">${escapeHtml(org.tags.slice(3).join(', '))}</span></span>` : ''}
         </div>
 
         <div class="flex items-center justify-between pt-4 border-t border-zinc-100">

--- a/index.html
+++ b/index.html
@@ -219,6 +219,49 @@
     .complexity-badge.intermediate { background: #fef9c3; color: #854d0e; }
     .complexity-badge.advanced { background: #fee2e2; color: #991b1b; }
 
+    /* Hidden tech-stack tags tooltip on the "+n" badge */
+    .tag-more { position: relative; cursor: help; outline: none; }
+    .tag-more .tag-more-tip {
+      position: absolute;
+      bottom: calc(100% + 8px);
+      left: 50%;
+      transform: translateX(-50%) translateY(4px);
+      background: #1a1c1c;
+      color: #fff;
+      font-family: 'Fira Code', monospace;
+      font-size: 0.65rem;
+      line-height: 1.45;
+      font-weight: 500;
+      text-align: center;
+      white-space: normal;
+      width: max-content;
+      max-width: 220px;
+      padding: 0.45rem 0.65rem;
+      border-radius: 0.5rem;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      transition: opacity 0.15s ease, transform 0.15s ease;
+      z-index: 30;
+    }
+    .tag-more .tag-more-tip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: #1a1c1c;
+    }
+    .tag-more:hover .tag-more-tip,
+    .tag-more:focus .tag-more-tip,
+    .tag-more:focus-visible .tag-more-tip {
+      opacity: 1;
+      visibility: visible;
+      transform: translateX(-50%) translateY(0);
+    }
+
     /* Bookmark Button */
     .bookmark-btn { transition: all 0.2s; font-size: 1.25rem; }
     .bookmark-btn.active { color: #f59e0b; }
@@ -2106,7 +2149,7 @@
         <p class="text-on-surface-variant text-sm leading-relaxed mb-4 line-clamp-2">${escapeHtml(org.desc)}</p>
         <div class="flex flex-wrap gap-1.5 mb-4">
           ${org.tags.slice(0, 3).map(t => `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded">${escapeHtml(t)}</span>`).join('')}
-          ${org.tags.length > 3 ? `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded">+${escapeHtml(String(org.tags.length - 3))}</span>` : ''}
+          ${org.tags.length > 3 ? `<span class="tag-more px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded" tabindex="0" aria-label="${escapeHtml((org.tags.length - 3) + ' more technologies: ' + org.tags.slice(3).join(', '))}">+${escapeHtml(String(org.tags.length - 3))}<span class="tag-more-tip" role="tooltip">${escapeHtml(org.tags.slice(3).join(', '))}</span></span>` : ''}
         </div>
 
         <div class="flex items-center justify-between pt-4 border-t border-zinc-100">


### PR DESCRIPTION
## Description
Org cards show only the first 3 technologies and collapse the rest into
a static `+n` badge. Until now, the only way to see the hidden techs was
to open the org's full modal — slow when scanning many cards for a
specific secondary tech (Docker, GraphQL, etc.).

This PR turns the `+n` badge into a hover/focus tooltip that reveals the
remaining technologies inline, so the full stack is scannable directly
from the grid without opening any modal.

## Related Issue
Closes #730

## Changes
All scoped to `index.html` — the `+n` badge is rendered in only one
place; no other card renderer condenses tags, so nothing else was
touched.

- Render the hidden tags (`org.tags.slice(3)`) as a comma-separated list
  inside a `.tag-more-tip` element on the badge.
- Added `tabindex="0"` + `aria-label` so the tooltip also reveals on
  keyboard focus and is announced by screen readers (works on touch too).
- Added a small self-contained `.tag-more` / `.tag-more-tip` CSS popover
  (dark bubble with arrow, fade/slide-in, sits above neighboring cards).
  Hidden by default — zero visual change to the card until interacted with.
- All injected values go through the existing `escapeHtml`, consistent
  with the rest of the file.
- Tooltip font size bumped to `0.75rem` per review feedback for
  readability.

## Type of Change
- [x] Bug fix
- [x] UI improvement

## Checklist
- [x] Code follows project style
- [x] No unrelated changes included
- [x] Tested locally (hover, keyboard `Tab`, and touch all reveal the tooltip)
- [x] Linked valid issue

## Screenshot
<img width="884" height="942" alt="image" src="https://github.com/user-attachments/assets/70e681fc-a77d-48ee-b1de-6e71fd54a9fc" />

