### PR TITLE
fix: add guard clause to help modal keyboard shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -3151,7 +3151,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.addEventListener('keydown', (e) => {
 
-    if (e.key === '?') {
+    if (e.key === '?' && !['INPUT', 'TEXTAREA', 'SELECT'].includes(document.activeElement?.tagName)) {
       openHelpModal();
     }
 


### PR DESCRIPTION
## Program Declaration
- **program: gssoc


## Description of Changes
Added a guard clause to the global `?` keyboard shortcut event listener in `index.html`. Previously, pressing `?` would trigger the Help Modal even if the user was actively typing a query inside a search bar or text area. 

The logic now checks `document.activeElement?.tagName` and ignores the shortcut if the user is currently focused inside an `<input>`, `<textarea>`, or `<select>`.

## Related Issue
Closes : #1105 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing Steps
1. Opened the application locally.
2. Clicked inside the Hero Search input and typed `C++?`. Verified the Help Modal did not appear and the character typed normally.
3. Clicked inside the AI Recommender textarea and typed `?`. Verified the Help Modal did not appear.
4. Clicked outside any inputs on the page background and pressed `?`. Verified the Help Modal opened successfully.

## Screenshots
*N/A - This is a behavioral JavaScript event fix.*

## Checklist
- [x] My issue is assigned to me.
- [x] My PR links to the issue using `Closes #N`.
- [x] I mentioned my contribution program (GSSoC).
- [x] No unnecessary dependencies were added.
- [x] I tested the changes locally.
- [x] I understand the code I submitted.