### PR TITLE
fix: preserve pagination when applying chip filters (issue #1132)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2843,7 +2843,7 @@ if(org.ideas){
         activeChip = null;
       }
 
-      applyFilters();
+      applyFiltersPreservingVisibleCount();
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the double-rendering bug described in issue #1132.

### Bug

When a user clicks a filter chip (e.g., "Veterans Only") and then immediately clicks "View More Organizations", the grid shows incorrect items because the chip click handler calls `applyFilters()` which resets `visibleCount` to 12 before `renderOrgs(true)` clears the grid, discarding any pagination the user had built up.

The correct function `applyFiltersPreservingVisibleCount()` already existed (used by the bookmark refresh logic) but was not used by the chip click handler.

### Fix

Changed the chip click handler to call `applyFiltersPreservingVisibleCount()` instead of `applyFilters()`. This preserves the user's current pagination depth across chip filter changes, preventing the race condition between the two filter/render systems.

### Testing

1. Open the site, click "View More Organizations" to expand beyond 12 items
2. Click a filter chip (e.g., "Veterans Only")
3. Observe: grid should still show all previously-loaded items (not reset to 12), and "View More" continues to paginate correctly
4. Previously: clicking the chip would reset to 12 items and show wrong orgs after a subsequent "View More"

### Checklist

- [x] I am participating via GSSoC
- [x] I am participating via NSoC
- [x] I have read the contribution guidelines
- [x] I checked for existing issues before creating this