### PR TITLE
fix(devops): remove backticks from git email config string

### DIFF
--- a/.github/workflows/issue-context-assignment.yml
+++ b/.github/workflows/issue-context-assignment.yml
@@ -126,7 +126,7 @@ jobs:
         if: steps.cmd.outputs.is_assign == 'true' && steps.validate.outputs.eligible == 'true'
         run: |
           git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]`@users.noreply.github.com`"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/reviewers/pending-assignments.json
           git diff --cached --quiet || git commit -m "chore: queue assignment for ${{ steps.validate.outputs.claimant }} on issue #${{ steps.validate.outputs.issue_number }} [skip ci]"
           git pull --rebase origin "$GITHUB_REF_NAME"
@@ -193,7 +193,7 @@ jobs:
         if: steps.cmd.outputs.is_approve == 'true' && steps.process_approval.outputs.assigned == 'true'
         run: |
           git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]`@users.noreply.github.com`"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/reviewers/pending-assignments.json
           git diff --cached --quiet || git commit -m "chore: assignment approved for issue #${{ github.event.issue.number }} [skip ci]"
           git pull --rebase origin "$GITHUB_REF_NAME"


### PR DESCRIPTION
Closes #1066

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Program Classification
program: gssoc

### Description
Removed the unintended backticks around the email domain in .github/workflows/issue-context-assignment.yml. This resolves the shell command interpretation error where the workflow was crashing on /assign requests.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My commits have valid DCO sign-offs
