### PR TITLE
fix: update mentor contact info for Rust Foundation, Mifos Initiative, stdlib, LibreOffice

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1777,16 +1777,43 @@
   "LibreOffice": {
     "org": "LibreOffice",
     "ideasUrl": "https://wiki.documentfoundation.org/Development/GSoC/2026",
-    "channels": [],
-    "mentors": [],
+    "channels": [
+      {
+        "type": "IRC",
+        "url": "ircs://irc.libera.chat:6697/#libreoffice-dev",
+        "label": "IRC #libreoffice-dev on Libera.Chat"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Khaled Hosny",
+        "github": "khaledhosny",
+        "githubUrl": "https://github.com/khaledhosny"
+      },
+      {
+        "name": "Xisco Faulí",
+        "github": "x1sc0",
+        "githubUrl": "https://github.com/x1sc0"
+      },
+      {
+        "name": "Jonathan Clark",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
     "mailingLists": [
       {
         "type": "Mailing list",
         "url": "https://lists.freedesktop.org/mailman/listinfo/libreoffice",
         "label": "LibreOffice developer list"
+      },
+      {
+        "type": "Mailing list",
+        "url": "mailto:mentoring@documentfoundation.org",
+        "label": "LibreOffice mentoring email"
       }
     ],
-    "tip": "Send a short intro email with your background and the idea you're interested in.",
+    "tip": "Subscribe to the developer list, introduce yourself on #libreoffice-dev IRC, and discuss your idea before applying.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
@@ -3081,17 +3108,98 @@
   },
   "stdlib": {
     "org": "stdlib",
-    "ideasUrl": "https://github.com/stdlib-js/google-summer-of-code",
+    "ideasUrl": "https://github.com/stdlib-js/google-summer-of-code/blob/main/ideas.md",
     "channels": [
       {
         "type": "Zulip",
         "url": "https://stdlib.zulipchat.com/",
-        "label": "GSoC Questions"
+        "label": "stdlib Zulip (#gsoc-questions channel)"
       }
     ],
-    "mentors": [],
+    "mentors": [
+      {
+        "name": "Athan Reines",
+        "github": "kgryte",
+        "githubUrl": "https://github.com/kgryte"
+      },
+      {
+        "name": "Philipp Burckhardt",
+        "github": "Planeshifter",
+        "githubUrl": "https://github.com/Planeshifter"
+      },
+      {
+        "name": "Ricky Reusser",
+        "github": "rreusser",
+        "githubUrl": "https://github.com/rreusser"
+      },
+      {
+        "name": "Pranav",
+        "github": "Pranavchiku",
+        "githubUrl": "https://github.com/Pranavchiku"
+      },
+      {
+        "name": "Gaurav",
+        "github": "czgdp1807",
+        "githubUrl": "https://github.com/czgdp1807"
+      },
+      {
+        "name": "Stephannie Jimenez Gacha",
+        "github": "steff456",
+        "githubUrl": "https://github.com/steff456"
+      },
+      {
+        "name": "Gunj Joshi",
+        "github": "gunjjoshi",
+        "githubUrl": "https://github.com/gunjjoshi"
+      },
+      {
+        "name": "Snehil Shah",
+        "github": "Snehil-Shah",
+        "githubUrl": "https://github.com/Snehil-Shah"
+      },
+      {
+        "name": "Jaysukh Makvana",
+        "github": "Jaysukh-409",
+        "githubUrl": "https://github.com/Jaysukh-409"
+      },
+      {
+        "name": "Aman Bhansali",
+        "github": "aman-095",
+        "githubUrl": "https://github.com/aman-095"
+      },
+      {
+        "name": "Mara Averick",
+        "github": "batpigandme",
+        "githubUrl": "https://github.com/batpigandme"
+      },
+      {
+        "name": "Aayush Khanna",
+        "github": "aayush0325",
+        "githubUrl": "https://github.com/aayush0325"
+      },
+      {
+        "name": "Gururaj Gurram",
+        "github": "gururaj1512",
+        "githubUrl": "https://github.com/gururaj1512"
+      },
+      {
+        "name": "Muhammad Haris",
+        "github": "headlessNode",
+        "githubUrl": "https://github.com/headlessNode"
+      },
+      {
+        "name": "Karan Anand",
+        "github": "anandkaranubc",
+        "githubUrl": "https://github.com/anandkaranubc"
+      },
+      {
+        "name": "Robert Gislason",
+        "github": "rgizz",
+        "githubUrl": "https://github.com/rgizz"
+      }
+    ],
     "mailingLists": [],
-    "tip": "Post a new topic in the GSoC stream with your background and interest.",
+    "tip": "Join the #gsoc-questions channel on stdlib Zulip to discuss project ideas before applying.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
@@ -3680,12 +3788,65 @@
   },
   "The Mifos Initiative": {
     "org": "The Mifos Initiative",
-    "ideasUrl": "https://mifosforge.jira.com/wiki/spaces/MDZ/pages/92274820/Google+Summer+of+Code+2026",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
+    "ideasUrl": "https://mifosforge.jira.com/wiki/spaces/RES/pages/5021990914/2026+Google+Summer+of+Code+Ideas+List",
+    "channels": [
+      {
+        "type": "Slack",
+        "url": "https://join.slack.com/t/mifos/shared_invite/zt-3m6x47dgj-iX0Oqv8KS0VGgouNnuJrAg",
+        "label": "Mifos Slack (#gsoc channel)"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Ed Cable",
+        "github": "edcable",
+        "githubUrl": "https://github.com/edcable"
+      },
+      {
+        "name": "David Higgins",
+        "github": "DavidH-1",
+        "githubUrl": "https://github.com/DavidH-1"
+      },
+      {
+        "name": "Dmitry Pankov",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Aru Sharma",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Keshav Arora",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Tom Daly",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Craig Rosario",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Gopi Kishan",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Mailing list",
+        "url": "https://groups.google.com/g/mifosdeveloper",
+        "label": "mifos-developer mailing list"
+      }
+    ],
+    "tip": "Join the Mifos Slack (link above), introduce yourself in #gsoc, and attend the weekly standup.",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "The NetBSD Foundation": {
@@ -3859,15 +4020,35 @@
   },
   "The Rust Foundation": {
     "org": "The Rust Foundation",
-    "ideasUrl": "https://github.com/rust-lang/google-summer-of-code",
+    "ideasUrl": "https://github.com/rust-lang/google-summer-of-code/blob/main/README.md",
     "channels": [
       {
         "type": "Zulip",
         "url": "https://rust-lang.zulipchat.com/",
-        "label": "Zulip"
+        "label": "Rust Zulip (#gsoc stream)"
       }
     ],
     "mentors": [
+      {
+        "name": "Jakub Beránek",
+        "github": "Kobzol",
+        "githubUrl": "https://github.com/Kobzol"
+      },
+      {
+        "name": "Jack Huey",
+        "github": "jackh726",
+        "githubUrl": "https://github.com/jackh726"
+      },
+      {
+        "name": "Jieyou Xu",
+        "github": "jieyouxu",
+        "githubUrl": "https://github.com/jieyouxu"
+      },
+      {
+        "name": "Antoni Boucher",
+        "github": "antoyo",
+        "githubUrl": "https://github.com/antoyo"
+      },
       {
         "name": "",
         "github": "ZuseZ4",
@@ -3879,7 +4060,7 @@
         "githubUrl": "https://github.com/Teapot4195"
       },
       {
-        "name": "",
+        "name": "Trevor Gross",
         "github": "tgross35",
         "githubUrl": "https://github.com/tgross35"
       },
@@ -3887,10 +4068,25 @@
         "name": "",
         "github": "obi1kenobi",
         "githubUrl": "https://github.com/obi1kenobi"
+      },
+      {
+        "name": "rami3l",
+        "github": "rami3l",
+        "githubUrl": "https://github.com/rami3l"
+      },
+      {
+        "name": "Chayim Refael Friedman",
+        "github": "ChayimFriedman2",
+        "githubUrl": "https://github.com/ChayimFriedman2"
+      },
+      {
+        "name": "Oli Scherer",
+        "github": "oli-obk",
+        "githubUrl": "https://github.com/oli-obk"
       }
     ],
     "mailingLists": [],
-    "tip": "Post a new topic in the GSoC stream with your background and interest.",
+    "tip": "Post in the #gsoc Zulip stream with your background and project interest before applying.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },


### PR DESCRIPTION
## Summary

This PR adds/updates verified mentor contact information for 4 GSoC 2026 organizations in \data/mentors.json\.

### Changes

- **The Rust Foundation** (Closes #424): Added 7 additional mentors (Kobzol, jackh726, jieyouxu, antoyo, rami3l, ChayimFriedman2, oli-obk) to existing 4, updated ideas URL to README.md, improved channel label
- **The Mifos Initiative** (Closes #419): Added Slack channel with invite link, 8 mentors (edcable, DavidH-1 + 6 named), mifos-developer mailing list
- **stdlib** (Closes #403): Added 16 verified mentors to previously empty list, updated ideas URL to ideas.md, improved channel label
- **LibreOffice** (Closes #341): Added IRC channel, 3 mentors (khaledhosny, x1sc0, Jonathan Clark), mentoring email

I am contributing under GSSoC'26

program: gssoc