### PR TITLE
fix: expand search to match descriptions, technologies, tags, and topics

### DIFF
--- a/index.html
+++ b/index.html
@@ -3448,7 +3448,11 @@ if(org.ideas){
     const sort = document.getElementById('sortSelect')?.value || 'alpha';
 
     filteredOrgs = ORGS.filter(o => {
-      const matchSearch = o.name.toLowerCase().includes(query);
+      const matchSearch = !query
+        || o.name.toLowerCase().includes(query)
+        || o.desc.toLowerCase().includes(query)
+        || (o.tags || []).some(t => t.toLowerCase().includes(query))
+        || o.cat.toLowerCase().includes(query);
       const matchCat = !cat || o.cat === cat;
       const matchComp = comp === 'all' || o.codebase === comp;
       const tags = (o.tags || []).map(t => String(t).toLowerCase());


### PR DESCRIPTION
The homepage search currently only matches organization names. This fix expands the search to also match descriptions, technologies/tags, and categories.

Changes:
- index.html: Updated matchSearch in applyFilters() to check o.name, o.desc, o.tags, and o.cat against the search query

Closes #1141

program: gssoc
/label gssoc:approved