### PR TITLE
fix: remove broken Tailwind Typography prose classes from Privacy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -54,7 +54,7 @@
 
 <main class="pt-32 pb-20 px-6 max-w-4xl mx-auto">
   <h1 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mb-8">Privacy Policy</h1>
-  <div class="prose prose-zinc prose-orange max-w-none">
+  <div class="max-w-none">
     <p class="text-zinc-600 mb-6">Last updated: May 14, 2026</p>
     
     <h2 class="text-2xl font-bold mt-10 mb-4">1. Information We Collect</h2>


### PR DESCRIPTION
﻿## Summary
The Privacy page uses prose prose-zinc prose-orange classes from the Tailwind Typography plugin, but the plugin is not loaded (only the CDN Tailwind CSS is used). This causes the prose classes to have no effect.

## Changes
- privacy.html: Replace prose prose-zinc prose-orange max-w-none with max-w-none — all child elements already have explicit 	ext-zinc-600, mb-4, etc. utilities, so no visual change occurs.

Closes #1045
