### PR TITLE
feat: add floating scroll-to-top button for easier navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4225,8 +4225,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   window.closeHelpModal = closeHelpModal;
 
+  const scrollBtn = document.getElementById('scrollTopBtn');
+  if (scrollBtn) {
+    window.addEventListener('scroll', () => {
+      scrollBtn.classList.toggle('visible', window.scrollY > 400);
+    }, { passive: true });
+  }
+
 });
 </script>
+<button class="scroll-top-btn" id="scrollTopBtn" onclick="window.scrollTo({top:0,behavior:'smooth'})" aria-label="Scroll to top">↑</button>
 <script src="src/js/badges-mvp.js"></script>
 <script src="src/js/githubAnalyzer.js"></script>
 <script src="src/js/skillExtractor.js"></script>


### PR DESCRIPTION
## Summary
Add a floating "Scroll to Top" button that appears after scrolling down 400px, positioned at the bottom-right corner. Smoothly scrolls to the top on click. The CSS classes (.scroll-top-btn) already exist in src/styles.css ? this PR adds the missing HTML and JS wiring.

## Changes
- index.html: Add #scrollTopBtn button HTML before the external scripts
- index.html: Add scroll listener in DOMContentLoaded handler to toggle .visible class based on scrollY > 400

Closes #517

program: gssoc