### PR TITLE
Fix: Remove duplicate 'Timeline' tab from navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,7 +471,6 @@
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#watchlist" data-section="watchlist">Watchlist</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#issues" data-section="issues">Issues</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#mentors" data-section="mentors">Mentors</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#timeline" data-section="timeline">Timeline</a>
       </nav>
     </div>
     


### PR DESCRIPTION
program: gssoc

## Description
Removed the duplicate "Timeline" tab from the navbar that was causing confusion for users.

## Related Issue
Fixes #1098

## Type of Change
- [x] Bug fix

## Checklist
- [x] My changes are focused and relevant
- [x] I have tested my changes
- [x] I have not included unrelated modifications