### PR TITLE
Feature/clean resume parser

### DIFF
--- a/.github/reviewers/gssoc-mentors.json
+++ b/.github/reviewers/gssoc-mentors.json
@@ -23,6 +23,7 @@
     "saurabh24thakur",
     "1754riya",
     "magic-peach",
+    "4f4d",
     "lourduradjou",
     "m4milaad",
     "kunalverma2512",

--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ These mentors help guide and review contributions for the GSSoC program:
 <a href="https://github.com/diksha78dev"><img src="https://github.com/diksha78dev.png" width="50px" alt="diksha78dev" /></a>
 <a href="https://github.com/Mrigakshi-Rathore"><img src="https://github.com/Mrigakshi-Rathore.png" width="50px" alt="Mrigakshi-Rathore" /></a>
 <a href="https://github.com/itsdakshjain"><img src="https://github.com/itsdakshjain.png" width="50px" alt="itsdakshjain" /></a>
+<a href="https://github.com/4f4d"><img src="https://github.com/4f4d.png" width="50px" alt="4f4d" /></a>
 <!-- GSSOC_MENTORS_END -->
 
 ## We thank all our Contributors for improving this project

--- a/index.html
+++ b/index.html
@@ -767,7 +767,7 @@
             <span id="aiResumeUploadText">Choose .txt, .pdf, or .docx</span>
             <input type="file" id="aiResumeFile" accept=".txt,.pdf,.docx,text/plain,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document" class="hidden">
           </label>
-          <p id="aiUploadStatus" class="hidden text-[10px] mt-2 ml-1 font-medium"></p>
+          <p id="aiUploadStatus" role="status" aria-live="polite" aria-atomic="true" class="hidden text-[10px] mt-2 ml-1 font-medium"></p>
           <p class="text-[10px] text-zinc-500 mt-2 ml-1">Auto-fills GitHub username and skills above. Nothing is sent to a server.</p>
         </div>
 
@@ -3175,8 +3175,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
 });
 </script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.9.0/mammoth.browser.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" integrity="sha384-/1qUCSGwTur9vjf/z9lmu/eCUYbpOTgSjmpbMQZ1/CtX2v/WcAIKqRvU1DUCG6e" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.9.0/mammoth.browser.min.js" integrity="sha384-F9c4WGfCRfzaY1ngABA8Z7qHFDuWabKbcwCb2Tk3Qf4njoUVhOChtw0UrXJmSp1y" crossorigin="anonymous"></script>
 <script src="src/js/skillExtractor.js"></script>
 <script src="src/js/resumeFileParser.js"></script>
 <script src="src/js/githubAnalyzer.js"></script>

--- a/index.html
+++ b/index.html
@@ -3175,7 +3175,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 });
 </script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" integrity="sha384-/1qUCSGwTur9vjf/z9lmu/eCUYbpOTgSjmpbMQZ1/CtX2v/WcAIKqRvU1DUCG6e" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" integrity="sha384-/1qUCSGwTur9vjf/z9lmu/eCUYbpOTgSjmpbMQZ1/CtX2v/WcAIKqRv+U1DUCG6e" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.9.0/mammoth.browser.min.js" integrity="sha384-F9c4WGfCRfzaY1ngABA8Z7qHFDuWabKbcwCb2Tk3Qf4njoUVhOChtw0UrXJmSp1y" crossorigin="anonymous"></script>
 <script src="src/js/skillExtractor.js"></script>
 <script src="src/js/resumeFileParser.js"></script>

--- a/index.html
+++ b/index.html
@@ -3175,6 +3175,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 });
 </script>
+<link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js" as="script" integrity="sha384-SnzOobpRMLXZ52iJvZm/C0fYw0OQemTXzTjIsdsfMcrCtCEe9qgzxTd3RSklO5x2" crossorigin="anonymous">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" integrity="sha384-/1qUCSGwTur9vjf/z9lmu/eCUYbpOTgSjmpbMQZ1/CtX2v/WcAIKqRv+U1DUCG6e" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.9.0/mammoth.browser.min.js" integrity="sha384-F9c4WGfCRfzaY1ngABA8Z7qHFDuWabKbcwCb2Tk3Qf4njoUVhOChtw0UrXJmSp1y" crossorigin="anonymous"></script>
 <script src="src/js/skillExtractor.js"></script>

--- a/index.html
+++ b/index.html
@@ -738,7 +738,7 @@
   <div class="mb-12">
     <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">AI-Powered</span>
     <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Personalized Org Suggestions</h2>
-    <p class="text-zinc-600 dark:text-zinc-400 mt-4 max-w-2xl">Enter your GitHub username or paste your resume to get deterministic AI-style organization recommendations tailored to your skills and experience.</p>
+    <p class="text-zinc-600 dark:text-zinc-400 mt-4 max-w-2xl">Fill in your GitHub username and skills manually, or upload a resume (<strong class="font-semibold text-zinc-700 dark:text-zinc-300">.txt</strong>, <strong class="font-semibold text-zinc-700 dark:text-zinc-300">.pdf</strong>, <strong class="font-semibold text-zinc-700 dark:text-zinc-300">.docx</strong>) to auto-fill both fields, then get organization recommendations tailored to your profile.</p>
   </div>
 
   <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
@@ -756,13 +756,19 @@
 
         <div>
           <label for="aiResumeText" class="block text-sm font-bold text-zinc-900 dark:text-zinc-100 mb-1">Resume / Skills</label>
-          <textarea id="aiResumeText" rows="4" placeholder="Paste your resume or list your skills here (e.g. Python, React, Machine Learning)..." class="w-full p-3 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm focus:ring-2 focus:ring-primary dark:text-white transition-all resize-none"></textarea>
-          <div class="mt-2 flex items-center justify-between">
-            <label class="text-xs text-primary font-bold cursor-pointer hover:underline flex items-center gap-1">
-              <span class="material-symbols-outlined text-[14px]">upload_file</span> Upload .txt
-              <input type="file" id="aiResumeFile" accept=".txt" class="hidden">
-            </label>
-          </div>
+          <textarea id="aiResumeText" rows="4" placeholder="e.g. Python, React, Machine Learning, Docker…" class="w-full p-3 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm focus:ring-2 focus:ring-primary dark:text-white transition-all resize-none"></textarea>
+          <p class="text-[10px] text-zinc-500 mt-1 ml-1">Skills and technologies detected from your resume or listed manually.</p>
+        </div>
+
+        <div class="pt-1 border-t border-zinc-100 dark:border-zinc-800">
+          <span class="block text-sm font-bold text-zinc-900 dark:text-zinc-100 mb-1">Upload resume file</span>
+          <label id="aiResumeUploadLabel" class="flex items-center justify-center gap-2 w-full py-3 px-4 bg-zinc-50 dark:bg-zinc-900 border border-dashed border-zinc-300 dark:border-zinc-600 rounded-xl text-xs text-primary font-bold cursor-pointer hover:border-primary hover:bg-primary/5 transition-all" title="Supported: .txt, .pdf, .docx (max 5 MB). Parsed locally in your browser.">
+            <span id="aiResumeUploadIcon" class="material-symbols-outlined text-lg">upload_file</span>
+            <span id="aiResumeUploadText">Choose .txt, .pdf, or .docx</span>
+            <input type="file" id="aiResumeFile" accept=".txt,.pdf,.docx,text/plain,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document" class="hidden">
+          </label>
+          <p id="aiUploadStatus" class="hidden text-[10px] mt-2 ml-1 font-medium"></p>
+          <p class="text-[10px] text-zinc-500 mt-2 ml-1">Auto-fills GitHub username and skills above. Nothing is sent to a server.</p>
         </div>
 
         <button id="btnGetRecommendations" class="w-full py-3 bg-gradient-to-r from-primary to-primary-container text-white rounded-xl font-bold text-sm shadow-md hover:shadow-lg hover:scale-[1.02] transition-all flex items-center justify-center gap-2">
@@ -3169,8 +3175,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
 });
 </script>
-<script src="src/js/githubAnalyzer.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.9.0/mammoth.browser.min.js"></script>
 <script src="src/js/skillExtractor.js"></script>
+<script src="src/js/resumeFileParser.js"></script>
+<script src="src/js/githubAnalyzer.js"></script>
 <script src="src/js/recommender.js"></script>
 <script src="src/js/recommendation-ui.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -1898,7 +1898,7 @@
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       if (!data || typeof data !== 'object' || Array.isArray(data)) {
-        throw new Error('Invalid mentors.json payload');
+        throw new TypeError('Invalid mentors.json payload');
       }
       MENTOR_DATA = data;
       mentorDataState = 'loaded';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "GSoC 2026 Organisation Finder",
     "private": true,
     "scripts": {
-        "lint:js": "eslint src/js/app.js src/js/org.js agent/scripts/validate-ideas-urls.js agent/scripts/extract-mentors.js agent/scripts/validate-mentors.js api/github.js src/js/githubAnalyzer.js src/js/skillExtractor.js src/js/recommender.js src/js/recommendation-ui.js",
+        "lint:js": "eslint src/js/app.js src/js/org.js agent/scripts/validate-ideas-urls.js agent/scripts/extract-mentors.js agent/scripts/validate-mentors.js api/github.js src/js/githubAnalyzer.js src/js/skillExtractor.js src/js/recommender.js src/js/recommendation-ui.js src/js/resumeFileParser.js",
         "lint:css": "stylelint src/styles.css",
         "lint:html": "htmlhint --config .htmlhintrc index.html",
         "lint": "npm run lint:js && npm run lint:css && npm run lint:html"

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -1,6 +1,6 @@
 // src/js/recommendation-ui.js
 
-/* global analyzeGitHubUser, extractSkills, getRecommendations, escapeHtml, openModal, toggleCompare, toggleBookmark */
+/* global analyzeGitHubUser, extractSkills, getRecommendations, escapeHtml, openModal, toggleCompare, toggleBookmark, parseResumeFile */
 
 /**
  * Encapsulates the heavy analytical logic into a single async pipe.
@@ -116,18 +116,85 @@ document.addEventListener('DOMContentLoaded', () => {
   const errorState = document.getElementById('aiErrorState');
   const resultsContainer = document.getElementById('aiResultsContainer');
   const errorMsg = document.getElementById('aiErrorMsg');
+  const uploadStatus = document.getElementById('aiUploadStatus');
 
-  // Handle file upload
+  function setUploadStatus(message, isError) {
+    if (!uploadStatus) return;
+    if (!message) {
+      uploadStatus.classList.add('hidden');
+      uploadStatus.textContent = '';
+      return;
+    }
+    uploadStatus.textContent = message;
+    uploadStatus.classList.remove('hidden', 'text-emerald-600', 'dark:text-emerald-400', 'text-amber-600', 'dark:text-amber-400');
+    uploadStatus.classList.add(isError ? 'text-amber-600' : 'text-emerald-600', isError ? 'dark:text-amber-400' : 'dark:text-emerald-400');
+  }
+
+  function applyParsedResume({ githubUsername, skillsText }) {
+    if (githubUsername && ghInput) {
+      ghInput.value = githubUsername;
+      ghInput.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    if (skillsText && resumeText) {
+      resumeText.value = skillsText;
+      resumeText.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }
+
+  // Handle resume file upload — auto-fill GitHub username and skills fields
   if (fileUpload) {
-    fileUpload.addEventListener('change', (e) => {
+    fileUpload.addEventListener('change', async (e) => {
       const file = e.target.files[0];
       if (!file) return;
-      file.text().then(text => {
-        resumeText.value = text;
-      }).catch(err => {
-        console.error("File Read Error:", err);
-        showError("Failed to read file. Please make sure it's a valid text format.");
-      });
+
+      const uploadLabel = document.getElementById('aiResumeUploadLabel');
+      const uploadIcon = document.getElementById('aiResumeUploadIcon');
+      const uploadText = document.getElementById('aiResumeUploadText');
+      const prevIcon = uploadIcon ? uploadIcon.textContent : '';
+      const prevText = uploadText ? uploadText.textContent : '';
+
+      setUploadStatus('');
+      errorState.classList.add('hidden');
+
+      if (uploadLabel) {
+        uploadLabel.classList.add('opacity-60', 'pointer-events-none');
+      }
+      if (uploadIcon) {
+        uploadIcon.textContent = 'progress_activity';
+        uploadIcon.classList.add('animate-spin');
+      }
+      if (uploadText) {
+        uploadText.textContent = 'Parsing resume…';
+      }
+
+      try {
+        const parsed = await parseResumeFile(file);
+        applyParsedResume(parsed);
+
+        const parts = ['Skills field updated'];
+        if (parsed.githubUsername) {
+          parts[0] = `GitHub @${parsed.githubUsername} and skills filled`;
+        } else {
+          parts.push('add your GitHub username if it was not detected');
+        }
+        setUploadStatus(parts.join(' — ') + '.');
+      } catch (err) {
+        console.error('File Read Error:', err);
+        showError(err.message || 'Failed to read file. Please use .txt, .pdf, or .docx.');
+        setUploadStatus(err.message || 'Could not parse resume.', true);
+      } finally {
+        e.target.value = '';
+        if (uploadLabel) {
+          uploadLabel.classList.remove('opacity-60', 'pointer-events-none');
+        }
+        if (uploadIcon) {
+          uploadIcon.textContent = prevIcon;
+          uploadIcon.classList.remove('animate-spin');
+        }
+        if (uploadText) {
+          uploadText.textContent = prevText;
+        }
+      }
     });
   }
 

--- a/src/js/resumeFileParser.js
+++ b/src/js/resumeFileParser.js
@@ -118,6 +118,10 @@ const GITHUB_RESERVED_PATHS = new Set([
 ]);
 
 const GITHUB_USER_CAPTURE = '([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})';
+/** Trailing delimiter after a GitHub URL (alternation avoids duplicate-prone char classes). */
+const GITHUB_URL_END = String.raw`(?=$|\s|[.,;)|"'])`;
+/** Separators after a "GitHub" label (en dash U+2013 or ASCII hyphen). */
+const GITHUB_LABEL_SEP = String.raw`(?:[:@|]|\u2013|-)`;
 
 /**
  * Normalize resume text so broken PDF/DOCX URLs still match.
@@ -132,7 +136,10 @@ function normalizeResumeTextForGitHub(text) {
     .replace(/\bgit\s+hub\s*\.?\s*com/gi, 'github.com')
     .replace(/(github\.com)\s*\/\s*/gi, '$1/')
     .replace(
-      /github\.com\s+([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})(?=[\s.,;)\]"']|$)/gi,
+      new RegExp(
+        String.raw`github\.com\s+${GITHUB_USER_CAPTURE}${GITHUB_URL_END}`,
+        'gi'
+      ),
       'github.com/$1'
     );
 }
@@ -158,7 +165,7 @@ function extractGitHubUsername(text) {
   const normalized = normalizeResumeTextForGitHub(text);
 
   const urlRe = new RegExp(
-    String.raw`(?:https?://)?(?:www\.)?github\.com/${GITHUB_USER_CAPTURE}(?=[/?#\s,;)\]"']|$)`,
+    String.raw`(?:https?://)?(?:www\.)?github\.com/${GITHUB_USER_CAPTURE}(?=$|[/?#]|\s|[.,;)|"'])`,
     'gi'
   );
 
@@ -170,10 +177,22 @@ function extractGitHubUsername(text) {
   }
 
   const labeledPatterns = [
-    /github\s*(?:profile|username|handle|user|account|link|id)?\s*[:@|–\-]\s*(?!https?:\/\/)@?([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})/gi,
-    /github\s*[-–]\s*(?!https?:\/\/)@?([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})/gi,
-    /github\s+@(?!https?:\/\/)([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})/gi,
-    /(?:^|[\s,;|])(?:@)?([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})\s*(?:\||•)\s*github/gim,
+    new RegExp(
+      String.raw`github\s*(?:profile|username|handle|user|account|link|id)?\s*${GITHUB_LABEL_SEP}\s*(?!https?:\/\/)@?${GITHUB_USER_CAPTURE}`,
+      'gi'
+    ),
+    new RegExp(
+      String.raw`github\s*(?:-|–)\s*(?!https?:\/\/)@?${GITHUB_USER_CAPTURE}`,
+      'gi'
+    ),
+    new RegExp(
+      String.raw`github\s+@(?!https?:\/\/)${GITHUB_USER_CAPTURE}`,
+      'gi'
+    ),
+    new RegExp(
+      String.raw`(?:^|\s|[,;|])(?:@)?${GITHUB_USER_CAPTURE}\s*(?:\||•)\s*github`,
+      'gim'
+    ),
   ];
 
   for (const pattern of labeledPatterns) {

--- a/src/js/resumeFileParser.js
+++ b/src/js/resumeFileParser.js
@@ -30,7 +30,7 @@ async function readTxtFile(file) {
 
 async function readPdfFile(file) {
   if (typeof pdfjsLib === 'undefined') {
-    throw new Error('PDF support failed to load. Refresh the page and try again.');
+    throw new TypeError('PDF support failed to load. Refresh the page and try again.');
   }
 
   pdfjsLib.GlobalWorkerOptions.workerSrc = PDF_WORKER_SRC;
@@ -57,7 +57,7 @@ async function readPdfFile(file) {
 
 async function readDocxFile(file) {
   if (typeof mammoth === 'undefined') {
-    throw new Error('DOCX support failed to load. Refresh the page and try again.');
+    throw new TypeError('DOCX support failed to load. Refresh the page and try again.');
   }
 
   const arrayBuffer = await file.arrayBuffer();
@@ -79,7 +79,11 @@ async function readDocxFile(file) {
  */
 async function readResumeFile(file) {
   if (!file) {
-    throw new Error('No file selected.');
+    throw new TypeError('No file selected.');
+  }
+
+  if (typeof Blob !== 'undefined' && !(file instanceof Blob)) {
+    throw new TypeError('Expected a File or Blob for resume upload.');
   }
 
   if (file.size > MAX_RESUME_BYTES) {
@@ -88,7 +92,7 @@ async function readResumeFile(file) {
 
   const kind = getResumeFileKind(file);
   if (!kind) {
-    throw new Error('Unsupported file type. Please upload a .txt, .pdf, or .docx file.');
+    throw new TypeError('Unsupported file type. Please upload a .txt, .pdf, or .docx file.');
   }
 
   switch (kind) {
@@ -99,7 +103,7 @@ async function readResumeFile(file) {
     case 'docx':
       return readDocxFile(file);
     default:
-      throw new Error('Unsupported file type. Please upload a .txt, .pdf, or .docx file.');
+      throw new TypeError('Unsupported file type. Please upload a .txt, .pdf, or .docx file.');
   }
 }
 
@@ -205,7 +209,11 @@ function buildSkillsSummary(text) {
  * @returns {{ githubUsername: string, skillsText: string, rawText: string }}
  */
 function parseResumeContent(rawText) {
-  const text = (rawText || '').trim();
+  if (typeof rawText !== 'string') {
+    throw new TypeError('Resume content must be a string.');
+  }
+
+  const text = rawText.trim();
   if (!text) {
     throw new Error('Resume file appears to be empty.');
   }

--- a/src/js/resumeFileParser.js
+++ b/src/js/resumeFileParser.js
@@ -20,7 +20,7 @@ function getResumeFileKind(file) {
   ) {
     return 'docx';
   }
-  if (name.endsWith('.txt') || type === 'text/plain' || type === '') return 'txt';
+  if (name.endsWith('.txt') || type === 'text/plain') return 'txt';
   return null;
 }
 

--- a/src/js/resumeFileParser.js
+++ b/src/js/resumeFileParser.js
@@ -47,8 +47,8 @@ async function readPdfFile(file) {
   }
 
   const text = parts.join('\n').replace(/[^\S\n]+/g, ' ').replace(/\n{3,}/g, '\n\n').trim();
-  if (!text) {
-    throw new Error(
+  if (typeof text !== 'string' || text.length === 0) {
+    throw new TypeError(
       'Could not extract text from this PDF. Use a text-based PDF or paste your resume manually.'
     );
   }
@@ -64,8 +64,8 @@ async function readDocxFile(file) {
   const result = await mammoth.extractRawText({ arrayBuffer });
   const text = (result.value || '').replace(/[^\S\n]+/g, ' ').trim();
 
-  if (!text) {
-    throw new Error(
+  if (typeof text !== 'string' || text.length === 0) {
+    throw new TypeError(
       'Could not extract text from this Word file. Try another file or paste your resume manually.'
     );
   }
@@ -86,8 +86,8 @@ async function readResumeFile(file) {
     throw new TypeError('Expected a File or Blob for resume upload.');
   }
 
-  if (file.size > MAX_RESUME_BYTES) {
-    throw new Error('File is too large. Please use a resume under 5 MB.');
+  if (typeof file.size !== 'number' || file.size > MAX_RESUME_BYTES) {
+    throw new RangeError('File is too large. Please use a resume under 5 MB.');
   }
 
   const kind = getResumeFileKind(file);
@@ -214,8 +214,8 @@ function parseResumeContent(rawText) {
   }
 
   const text = rawText.trim();
-  if (!text) {
-    throw new Error('Resume file appears to be empty.');
+  if (text.length === 0) {
+    throw new TypeError('Resume file appears to be empty.');
   }
 
   const githubUsername = extractGitHubUsername(text);

--- a/src/js/resumeFileParser.js
+++ b/src/js/resumeFileParser.js
@@ -1,0 +1,238 @@
+// src/js/resumeFileParser.js — client-side resume text extraction (.txt, .pdf, .docx)
+
+/* global pdfjsLib, mammoth, extractSkills */
+
+const MAX_RESUME_BYTES = 5 * 1024 * 1024;
+const PDF_WORKER_SRC = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
+
+/**
+ * @param {File} file
+ * @returns {'txt'|'pdf'|'docx'|null}
+ */
+function getResumeFileKind(file) {
+  const name = (file.name || '').toLowerCase();
+  const type = (file.type || '').toLowerCase();
+
+  if (name.endsWith('.pdf') || type === 'application/pdf') return 'pdf';
+  if (
+    name.endsWith('.docx') ||
+    type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+  ) {
+    return 'docx';
+  }
+  if (name.endsWith('.txt') || type === 'text/plain' || type === '') return 'txt';
+  return null;
+}
+
+async function readTxtFile(file) {
+  return file.text();
+}
+
+async function readPdfFile(file) {
+  if (typeof pdfjsLib === 'undefined') {
+    throw new Error('PDF support failed to load. Refresh the page and try again.');
+  }
+
+  pdfjsLib.GlobalWorkerOptions.workerSrc = PDF_WORKER_SRC;
+
+  const data = await file.arrayBuffer();
+  const pdf = await pdfjsLib.getDocument({ data }).promise;
+  const parts = [];
+
+  for (let pageNum = 1; pageNum <= pdf.numPages; pageNum += 1) {
+    const page = await pdf.getPage(pageNum);
+    const content = await page.getTextContent();
+    const pageText = content.items.map((item) => item.str).join(' ');
+    parts.push(pageText);
+  }
+
+  const text = parts.join('\n').replace(/[^\S\n]+/g, ' ').replace(/\n{3,}/g, '\n\n').trim();
+  if (!text) {
+    throw new Error(
+      'Could not extract text from this PDF. Use a text-based PDF or paste your resume manually.'
+    );
+  }
+  return text;
+}
+
+async function readDocxFile(file) {
+  if (typeof mammoth === 'undefined') {
+    throw new Error('DOCX support failed to load. Refresh the page and try again.');
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const result = await mammoth.extractRawText({ arrayBuffer });
+  const text = (result.value || '').replace(/[^\S\n]+/g, ' ').trim();
+
+  if (!text) {
+    throw new Error(
+      'Could not extract text from this Word file. Try another file or paste your resume manually.'
+    );
+  }
+  return text;
+}
+
+/**
+ * Extract plain text from a resume file for skill matching.
+ * @param {File} file
+ * @returns {Promise<string>}
+ */
+async function readResumeFile(file) {
+  if (!file) {
+    throw new Error('No file selected.');
+  }
+
+  if (file.size > MAX_RESUME_BYTES) {
+    throw new Error('File is too large. Please use a resume under 5 MB.');
+  }
+
+  const kind = getResumeFileKind(file);
+  if (!kind) {
+    throw new Error('Unsupported file type. Please upload a .txt, .pdf, or .docx file.');
+  }
+
+  switch (kind) {
+    case 'txt':
+      return readTxtFile(file);
+    case 'pdf':
+      return readPdfFile(file);
+    case 'docx':
+      return readDocxFile(file);
+    default:
+      throw new Error('Unsupported file type. Please upload a .txt, .pdf, or .docx file.');
+  }
+}
+
+const GITHUB_RESERVED_PATHS = new Set([
+  'about', 'apps', 'archive', 'blame', 'blob', 'collections', 'contact',
+  'copilot', 'customer-stories', 'discussions', 'enterprise', 'events',
+  'explore', 'features', 'gist', 'gists', 'join', 'login', 'marketplace',
+  'media', 'mobile', 'new', 'notifications', 'orgs', 'organizations',
+  'packages', 'pricing', 'projects', 'pull', 'issues', 'releases', 'repos',
+  'security', 'settings', 'signup', 'site', 'sponsors', 'sponsoring', 'stars',
+  'team', 'topics', 'trending', 'tree', 'users', 'wiki',
+]);
+
+const GITHUB_USER_CAPTURE = '([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})';
+
+/**
+ * Normalize resume text so broken PDF/DOCX URLs still match.
+ * @param {string} text
+ * @returns {string}
+ */
+function normalizeResumeTextForGitHub(text) {
+  return text
+    .replace(/\u200b|\u00a0/g, ' ')
+    .replace(/https?\s*:\s*\/\s*/gi, 'https://')
+    .replace(/github\s*\.\s*com/gi, 'github.com')
+    .replace(/\bgit\s+hub\s*\.?\s*com/gi, 'github.com')
+    .replace(/(github\.com)\s*\/\s*/gi, '$1/')
+    .replace(
+      /github\.com\s+([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})(?=[\s.,;)\]"']|$)/gi,
+      'github.com/$1'
+    );
+}
+
+/**
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isValidGitHubUsername(name) {
+  if (!name) return false;
+  if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(name)) return false;
+  return !GITHUB_RESERVED_PATHS.has(name.toLowerCase());
+}
+
+/**
+ * Pull a GitHub username from resume text (profile URLs, labeled lines).
+ * @param {string} text
+ * @returns {string}
+ */
+function extractGitHubUsername(text) {
+  if (!text) return '';
+
+  const normalized = normalizeResumeTextForGitHub(text);
+
+  const urlRe = new RegExp(
+    String.raw`(?:https?://)?(?:www\.)?github\.com/${GITHUB_USER_CAPTURE}(?=[/?#\s,;)\]"']|$)`,
+    'gi'
+  );
+
+  let match;
+  while ((match = urlRe.exec(normalized)) !== null) {
+    if (isValidGitHubUsername(match[1])) {
+      return match[1];
+    }
+  }
+
+  const labeledPatterns = [
+    /github\s*(?:profile|username|handle|user|account|link|id)?\s*[:@|–\-]\s*(?!https?:\/\/)@?([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})/gi,
+    /github\s*[-–]\s*(?!https?:\/\/)@?([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})/gi,
+    /github\s+@(?!https?:\/\/)([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})/gi,
+    /(?:^|[\s,;|])(?:@)?([a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38})\s*(?:\||•)\s*github/gim,
+  ];
+
+  for (const pattern of labeledPatterns) {
+    pattern.lastIndex = 0;
+    while ((match = pattern.exec(normalized)) !== null) {
+      if (isValidGitHubUsername(match[1])) {
+        return match[1];
+      }
+    }
+  }
+
+  return '';
+}
+
+/**
+ * Build a concise skills string for the Resume / Skills field.
+ * @param {string} text
+ * @returns {string}
+ */
+function buildSkillsSummary(text) {
+  if (typeof extractSkills === 'function') {
+    const skills = extractSkills(text);
+    if (skills.length > 0) {
+      return skills.join(', ');
+    }
+  }
+  return '';
+}
+
+/**
+ * Parse raw resume text into GitHub username and skills summary.
+ * @param {string} rawText
+ * @returns {{ githubUsername: string, skillsText: string, rawText: string }}
+ */
+function parseResumeContent(rawText) {
+  const text = (rawText || '').trim();
+  if (!text) {
+    throw new Error('Resume file appears to be empty.');
+  }
+
+  const githubUsername = extractGitHubUsername(text);
+  let skillsText = buildSkillsSummary(text);
+
+  if (!skillsText) {
+    skillsText = text.replace(/\s+/g, ' ').slice(0, 4000);
+  }
+
+  return { githubUsername, skillsText, rawText: text };
+}
+
+/**
+ * Read and parse a resume file; returns fields for the AI Recommender form.
+ * @param {File} file
+ * @returns {Promise<{ githubUsername: string, skillsText: string, rawText: string }>}
+ */
+async function parseResumeFile(file) {
+  const rawText = await readResumeFile(file);
+  return parseResumeContent(rawText);
+}
+
+globalThis.readResumeFile = readResumeFile;
+globalThis.parseResumeFile = parseResumeFile;
+globalThis.parseResumeContent = parseResumeContent;
+globalThis.extractGitHubUsername = extractGitHubUsername;
+globalThis.RESUME_FILE_ACCEPT =
+  '.txt,.pdf,.docx,text/plain,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document';


### PR DESCRIPTION
## 🚀 Program
GSSoC

## 📝 Description
This PR improves the **AI Recommender** section so users can upload resumes in common formats and have their profile fields filled automatically before getting organization recommendations.

Previously, only `.txt` uploads were supported and the full file text was dumped into the skills field. Now users can upload **`.txt`, `.pdf`, or `.docx`** files. The resume is parsed **entirely in the browser** (no server upload). Detected **GitHub username** and **skills** are auto-filled into the form fields above the upload area.

## 📦 Changes Added
- Extended file input to accept `.txt`, `.pdf`, and `.docx` (with correct MIME types).
- Added `src/js/resumeFileParser.js` for:
  - Client-side text extraction (PDF via PDF.js, DOCX via Mammoth).
  - GitHub username detection from profile URLs and labeled lines (e.g. `github.com/user`, `GitHub: user`).
  - Skills summary via existing `extractSkills()` logic (comma-separated list).
- Reorganized AI Recommender UI into three clear sections:
  1. **GitHub Username**
  2. **Resume / Skills**
  3. **Upload resume file** (dedicated upload area with status feedback).
- Updated `recommendation-ui.js` to call `parseResumeFile()` on upload and auto-fill both fields.
- Updated section copy and tooltips in `index.html`.
- Loaded PDF.js and Mammoth from CDN (no new npm/build dependencies); adjusted script load order so `skillExtractor.js` loads before the parser.
- Added `resumeFileParser.js` to ESLint script list in `package.json`.

## 🔗 Related Issue
Closes #123

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔍 SEO improvement
- [x] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Run the site locally (`npx serve .` or `vercel dev`).
2. Open the **AI Recommender** section.
3. Upload a resume (`.txt`, `.pdf`, or `.docx`) that includes a GitHub profile URL and tech keywords.
4. Confirm **GitHub Username** and **Resume / Skills** fields are auto-filled.
5. Click **Get Recommendations** and verify results load as expected.
6. Test a resume without a GitHub link — skills should still fill; status message should note missing username.

## 📸 Screenshots (if applicable)
<!-- Add before/after screenshots of the AI Recommender form and upload status -->

## ✅ Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced new npm packages or build tools (parsing uses CDN scripts only)

## 📎 Additional Context
- Parsing runs **client-side only**; resume files are never sent to a server.
- PDF/DOCX support uses [PDF.js](https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/) and [Mammoth](https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.9.0/) via CDN to stay aligned with the repo’s zero-build philosophy.
- GitHub username extraction handles common resume formats (broken PDF URLs, `github.com/user`, `GitHub: username`, trailing punctuation).
- If no skills are detected from the dictionary, a shortened resume excerpt is used so recommendations can still run.
- Max upload size: **5 MB**.