### PR TITLE
fix: add 192x192 icon entry to manifest.json for PWA install compliance

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,12 @@
   "icons": [
     {
       "src": "src/assets/icon-512.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "src/assets/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"


### PR DESCRIPTION
Adds the missing 192x192 icon required by Chrome on Android for the install prompt. The start_url was already present.

Closes #1216

program: gssoc
/label gssoc:approved