### PR TITLE
fix: clearAllFilters now resets internal state and cleans URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -3517,8 +3517,15 @@ if(org.ideas){
       chip.classList.add('bg-surface-container-highest');
     });
 
-    filteredOrgs = [...ORGS];
-    renderOrgs(true);
+    // Reset internal state
+    activeChip = null;
+    selectedLanguages.clear();
+    renderSelectedLanguages();
+
+    // Clean the URL
+    history.replaceState(null, '', location.pathname);
+
+    applyFilters();
   };
 
   document.getElementById('searchInput').addEventListener('input', () => {


### PR DESCRIPTION
Fixes the ghost-filtering bug where clearAllFilters() restored visible UI elements but left internal state (activeChip, selectedLanguages) dirty. The next call to applyFilters() would silently re-apply old filters with no visible indicators.

Changes:
- Resets activeChip = null and clears selectedLanguages set
- Calls renderSelectedLanguages() to update the language strip UI
- Cleans URL query params via history.replaceState
- Calls applyFilters() instead of manually setting filteredOrgs + renderOrgs

Closes #1053

program: gssoc
/label gssoc:approved