### PR TITLE
fix: prevent FETCH-FAILED badge from shrinking on multi-line org titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -2407,7 +2407,7 @@ sections.forEach(sectionId => {
             <p class="text-[10px] font-label uppercase tracking-widest text-primary mb-1">${escapeHtml(org.cat)}</p>
             <h3 class="font-headline text-xl font-bold text-zinc-900">${escapeHtml(org.name)}</h3>
           </div>
-          <span class="text-xs font-bold uppercase tracking-widest px-2 py-1 rounded-full ${statusClass}">${escapeHtml(entry.status)}</span>
+          <span class="text-xs font-bold uppercase tracking-widest px-2 py-1 rounded-full shrink-0 ${statusClass}">${escapeHtml(entry.status)}</span>
         </div>
         ${bodyHtml}
         <div class="mt-5 pt-4 border-t border-zinc-100">


### PR DESCRIPTION
Adds shrink-0 (flex-shrink: 0) to the status badge span in the mentor card so it maintains its natural width even when the organization name wraps to multiple lines.

Closes #992

program: gssoc
/label gssoc:approved