### PR TITLE
fix: close org detail modal when clicking outside (backdrop)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2303,6 +2303,9 @@
   document.getElementById('compareModal')?.addEventListener('click', (e) => {
     if (e.target.id === 'compareModal') closeCompareModal();
   });
+  document.getElementById('orgModal')?.addEventListener('click', (e) => {
+    if (e.target.id === 'orgModal') closeModal();
+  });
 
   document.addEventListener('keydown', (e) => {
     if (e.key !== 'Escape') return;


### PR DESCRIPTION
Adds click listener on orgModal backdrop to close the modal when clicking outside the modal panel, matching the existing behavior of the compare modal.

Closes #831

/label gssoc:approved