### PR TITLE
feat: integrate Compare button directly into watchlist cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -2503,6 +2503,7 @@
     }
     renderOrgs(true);
     renderCompare();
+    renderWatchlist();
   }
 
   function renderCompare() {
@@ -2835,6 +2836,7 @@
         ? `https://github.com/${githubOwner}.png?size=80`
         : '';
       const category = getCategoryMeta(org.cat);
+      const isComparing = compareList.includes(org.name);
 
       const topTags = (org.tags || []).slice(0, 4)
         .map(t => `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded text-zinc-600">${escapeHtml(t)}</span>`)
@@ -2877,11 +2879,18 @@
                 ${escapeHtml(org.competition || '—')}
               </span>
             </div>
-            <button data-bookmark-org="${escapeHtml(org.name)}"
-                    class="bookmark-btn text-[10px] font-bold uppercase tracking-widest text-red-400 hover:text-red-600 flex items-center gap-1 transition-colors">
-              <span class="material-symbols-outlined text-xs">bookmark_remove</span>
-              Remove
-            </button>
+            <div class="flex items-center gap-3">
+              <button onclick="event.stopPropagation(); toggleCompare(event, '${escapeHtml(org.name)}')"
+                      class="text-[10px] font-bold uppercase tracking-widest ${isComparing ? 'text-green-600' : 'text-primary'} hover:text-zinc-900 flex items-center gap-1 transition-colors">
+                <span class="material-symbols-outlined text-xs">${isComparing ? 'check_circle' : 'compare_arrows'}</span>
+                ${isComparing ? 'Comparing' : 'Compare'}
+              </button>
+              <button data-bookmark-org="${escapeHtml(org.name)}"
+                      class="bookmark-btn text-[10px] font-bold uppercase tracking-widest text-red-400 hover:text-red-600 flex items-center gap-1 transition-colors">
+                <span class="material-symbols-outlined text-xs">bookmark_remove</span>
+                Remove
+              </button>
+            </div>
           </div>
         </div>`;
 


### PR DESCRIPTION
### Contribution Program
GSSoC'26

### Description
This pull request adds an interactive **"Compare"** button directly to each card inside the Watchlist panel.

### Proposed Changes
1. Added a "Compare" button next to the "Remove" button inside watchlist cards.
2. Dynamically styled the button between Compare (primary color, compare_arrows icon) and Comparing (green color, check icon) depending on whether the organization is in the comparison list.
3. Synchronized comparison states in real-time so that changes in one place seamlessly propagate across search directory cards, details modals, and watchlist cards.

### Checklist
- [x] Issue is assigned to me
- [x] PR links an issue using `Closes #1300`
- [x] I mentioned my contribution program (GSSoC'26)
- [x] No unnecessary dependencies added
- [x] Changes are minimal and focused
- [x] Code follows repository architecture
- [x] I tested the changes locally

Closes #1300