### PR TITLE
fix(mentors): verify and fix Learning Unlimited contact info

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1617,16 +1617,22 @@
     "status": "no-contact-found",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
-  "Learning Unlimited": {
-    "org": "Learning Unlimited",
-    "ideasUrl": "https://github.com/learning-unlimited/ESP-Website/wiki/GSoC-2026",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
-  },
+"Learning Unlimited": {
+  "org": "Learning Unlimited",
+  "ideasUrl": "https://github.com/learning-unlimited/ESP-Website/issues?q=label%3A%22GSoC+2026%22",
+  "channels": [
+    {
+      "type": "GitHub",
+      "url": "https://github.com/learning-unlimited/ESP-Website",
+      "label": "ESP-Website GitHub Repository"
+    }
+  ],
+  "mentors": [],
+  "mailingLists": [],
+  "tip": "",
+  "status": "ok",
+  "lastFetched": "2026-05-09T16:09:12.548Z"
+},
 "LibreCube Initiative": {
   "org": "LibreCube Initiative",
   "ideasUrl": "https://librecube.org/google-summer-of-code/",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1623,7 +1623,7 @@
   "channels": [
     {
       "type": "GitHub",
-      "url": "https://github.com/learning-unlimited/ESP-Website",
+      "url": "https://github.com/learning-unlimited/ESP-Website/discussions",
       "label": "ESP-Website GitHub Repository"
     }
   ],


### PR DESCRIPTION
Closes #339

### Description
Manually researched and verified Learning Unlimited mentor contact info which had status `no-contact-found`.

### Related Issue
Closes #339

### Type of Change
- [x] Bug fix / Data fix

### Changes
- Fixed `ideasUrl` to correct GitHub issues page with GSoC 2026 label
- Added GitHub channel for ESP-Website repository
- Updated status from `no-contact-found` to `ok`

### Program
- [x] GSSoC

### Checklist
- [x] Sign commits using `git commit -s`
- [x] Link a valid issue (`Closes #339`)
- [x] Keep changes focused and relevant
- [x] Do not include unrelated modifications