### PR TITLE
fix(data): verify Genome Assembly and Annotation mentor contact info

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -932,11 +932,143 @@
     "org": "Genome Assembly and Annotation",
     "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/genome-assembly-and-annotation",
     "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "mentors": [
+      {
+        "name": "Senthilnathan Vijayaraja",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Dipayan Gupta",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "David Yuan",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Anna Lazar",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Simarpreet Kaur Bhurji",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Leanne Haggerty",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Jack Tierney",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Jose Perez-Silva",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Vianey Paola Barrera Enriquez",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Swati Sinha",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Jitender Jit Singh Cheema",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Likhitha Surapaneni",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Alexey Sokolov",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Kirill Tsukanov",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Aleksandr Zakirov",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Aleena Mushtaq",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Bilal El Houdaigui",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Christian Atallah",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Vikas Gupta",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Mahfouz Shehu",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Jorge Alvarez",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Disha Lodha",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "ChrisMGnify",
+        "github": "ChrisMGnify",
+        "githubUrl": "https://github.com/ChrisMGnify"
+      },
+      {
+        "name": "KateSakharova",
+        "github": "KateSakharova",
+        "githubUrl": "https://github.com/KateSakharova"
+      },
+      {
+        "name": "Santiago Fragoso",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Email",
+        "url": "mailto:helpdesk@ensembl.org",
+        "label": "helpdesk@ensembl.org"
+      }
+    ],
+    "tip": "Contact the EMBL-EBI GSoC helpdesk at helpdesk@ensembl.org; project teams also coordinate through Slack and mailing lists.",
+    "status": "ok",
+    "lastFetched": "2026-05-26T00:00:00.000Z"
   },
   "GeomScale": {
     "org": "GeomScale",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -931,7 +931,13 @@
   "Genome Assembly and Annotation": {
     "org": "Genome Assembly and Annotation",
     "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/genome-assembly-and-annotation",
-    "channels": [],
+    "channels": [
+      {
+        "type": "Email",
+        "url": "mailto:helpdesk@ensembl.org",
+        "label": "helpdesk@ensembl.org"
+      }
+    ],
     "mentors": [
       {
         "name": "Senthilnathan Vijayaraja",
@@ -1059,14 +1065,8 @@
         "githubUrl": ""
       }
     ],
-    "mailingLists": [
-      {
-        "type": "Email",
-        "url": "mailto:helpdesk@ensembl.org",
-        "label": "helpdesk@ensembl.org"
-      }
-    ],
-    "tip": "Contact the EMBL-EBI GSoC helpdesk at helpdesk@ensembl.org; project teams also coordinate through Slack and mailing lists.",
+    "mailingLists": [],
+    "tip": "Contact the EMBL-EBI GSoC helpdesk at helpdesk@ensembl.org for project questions.",
     "status": "ok",
     "lastFetched": "2026-05-26T00:00:00.000Z"
   },


### PR DESCRIPTION
program: gssoc

Fixes #298.

Verified the Genome Assembly and Annotation GSoC 2026 entry, updated the contact email, populated the mentor list from the ideas page, and marked the org as `ok`.