### PR TITLE
fix: update FreeCAD mentor contact information

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1160,10 +1160,26 @@
     "org": "Kiwix",
     "ideasUrl": "https://github.com/kiwix/kiwix-android/wiki/Google-Summer-of-Code-2026",
     "channels": [],
-    "mentors": [],
+    "mentors": [
+      {
+        "name":"Benoît BERAUD",
+        "github":"benoit74",
+        "githubUrl":"https://github.com/benoit74"
+      },
+      {
+        "name":"Travis Briggs",
+        "github":"audiodude",
+        "githubUrl":"https://github.com/audiodude"
+      },
+      {
+        "name":"Mohit Mali",
+        "github":"MohitMaliDeveloper",
+        "githubUrl":"https://github.com/MohitMaliDeveloper/"
+      }
+    ],
     "mailingLists": [],
     "tip": "",
-    "status": "no-contact-found",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "KolibriOS Project Team": {

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -726,7 +726,7 @@
       {
         "name":"Aik-Siong koh",
         "github":"ailsiongkoh",
-        "githuburl":"https://github.com/aiksiongkoh"
+        "githubUrl":"https://github.com/aiksiongkoh"
       },
       {
         "name":"Jackson Oursland",
@@ -1160,26 +1160,10 @@
     "org": "Kiwix",
     "ideasUrl": "https://github.com/kiwix/kiwix-android/wiki/Google-Summer-of-Code-2026",
     "channels": [],
-    "mentors": [
-      {
-        "name":"Benoît BERAUD",
-        "github":"benoit74",
-        "githubUrl":"https://github.com/benoit74"
-      },
-      {
-        "name":"Travis Briggs",
-        "github":"audiodude",
-        "githubUrl":"https://github.com/audiodude"
-      },
-      {
-        "name":"Mohit Mali",
-        "github":"MohitMaliDeveloper",
-        "githubUrl":"https://github.com/MohitMaliDeveloper/"
-      }
-    ],
+    "mentors": [],
     "mailingLists": [],
     "tip": "",
-    "status": "ok",
+    "status": "no-contact-found",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "KolibriOS Project Team": {

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -691,7 +691,7 @@
     "tip": "",
     "status": "no-contact-found",
     "lastFetched": "2026-05-09T16:09:12.548Z"
-  },
+  }, 
   "FreeCAD": {
     "org": "FreeCAD",
     "ideasUrl": "https://github.com/FreeCAD/FreeCAD/wiki/Google-Summer-of-Code-2026",
@@ -700,9 +700,70 @@
         "type": "Discord",
         "url": "https://discord.com/invite/w2cTKGzccC",
         "label": "Discord"
+      },
+      {
+        "type":"Forum",
+        "url":"https://forum.freecad.org/",
+        "label":"Forum"
+      },
+      {
+        "type":"Reddit",
+        "url":"https://www.reddit.com/r/FreeCAD",
+        "label":"reddit"
       }
     ],
-    "mentors": [],
+    "mentors": [
+      {
+        "name":"MarioAlexis",
+        "github":"marioalexis84",
+        "githubUrl":"https://github.com/marioalexis84"
+      },
+      {
+        "name":"Turan Furkan Topak",
+        "github":"Reqrefusion",
+        "githubUrl":"https://github.com/Reqrefusion"
+      },
+      {
+        "name":"Aik-Siong koh",
+        "github":"ailsiongkoh",
+        "githuburl":"https://github.com/aiksiongkoh"
+      },
+      {
+        "name":"Jackson Oursland",
+        "github":"oursland",
+        "githubUrl":"https://github.com/oursland"
+      },
+      {
+        "name":"Kacper Donat",
+        "github":"kadet1090",
+        "githubUrl":"https://github.com/kadet1090"
+      },
+      {
+        "name":"Obelisk",
+        "github":"obelisk79",
+        "githubUrl":"https://github.com/obelisk79"
+      },
+      {
+        "name":"Pieter Hijma",
+        "github":"pieterhijma",
+        "githubUrl":"https://github.com/pieterhijma"
+      },
+      {
+        "name":"Carlo D.",
+        "github":"onekk",
+        "githubUrl":"https://github.com/onekk"
+      },
+      {
+        "name":"David Planella",
+        "github":"dplanella",
+        "githubUrl":"https://github.com/dplanella"
+      },
+      {
+        "name":"Benjamin Nauck",
+        "github":"hyarion",
+        "githubUrl":"https://github.com/hyarion"
+      }
+    ], 
     "mailingLists": [],
     "tip": "Introduce yourself in the public channel before asking project-specific questions.",
     "status": "ok",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1099,10 +1099,26 @@
     "org": "Kiwix",
     "ideasUrl": "https://github.com/kiwix/kiwix-android/wiki/Google-Summer-of-Code-2026",
     "channels": [],
-    "mentors": [],
+    "mentors": [
+      {
+        "name":"Benoît BERAUD",
+        "github":"benoit74",
+        "githubUrl":"https://github.com/benoit74"
+      },
+      {
+        "name":"Travis Briggs",
+        "github":"audiodude",
+        "githubUrl":"https://github.com/audiodude"
+      },
+      {
+        "name":"Mohit Mali",
+        "github":"MohitMaliDeveloper",
+        "githubUrl":"https://github.com/MohitMaliDeveloper/"
+      }
+    ],
     "mailingLists": [],
     "tip": "",
-    "status": "no-contact-found",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "KolibriOS Project Team": {


### PR DESCRIPTION
closes #295  
# Summary  
Updated the FreeCAD entry in data/mentors.json by manually verifying mentor contact information  

# Changes Made  
- verified the ideas page URL  
- Added verified communication channels  
- Added verified mentor handle  
- Updated status to "ok"  

# Checklist  
- [x] issue assigned to me  
- [ x] PR links issue using Closes #295  
- [x] changes are focused  
- [ x] commit message follow conventional commits
- [x] DCO sign-off included  