### PR TITLE
feat: enhance KDE Community entry in mentors.json

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1422,7 +1422,7 @@
     ],
     "mailingLists": [
       {
-        "type": "Mailing List",
+        "type": "Mailing list",
         "url": "mailto:kde-devel@kde.org",
         "label": "kde-devel@kde.org"
       }

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1390,12 +1390,41 @@
   },
   "KDE Community": {
     "org": "KDE Community",
-    "ideasUrl": "https://community.kde.org/GSoC/2026",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
+    "ideasUrl": "https://community.kde.org/GSoC/2026/Ideas",
+    "channels": [
+    {
+      "type": "Matrix",
+      "url": "https://matrix.to/#/#kde-new-contributors:kde.org",
+      "label": "KDE New Contributors"
+    },
+    {
+      "type": "Matrix",
+      "url": "https://matrix.to/#/#kde-devel:kde.org",
+      "label": "KDE Development"
+    }
+  ],
+    "mentors": [
+  {
+    "name": "Jean-Baptiste Mardelle",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "David Edmundson",
+    "github": "",
+    "githubUrl": ""
+  },
+  {
+    "name": "David Redondo",
+    "github": "",
+    "githubUrl": ""
+  }
+],
+    "mailingLists": [
+       "kde-devel@kde.org"
+    ],
+    "tip": "Join KDE Matrix rooms and interact with mentors before applying.",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Kiwix": {

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1392,36 +1392,40 @@
     "org": "KDE Community",
     "ideasUrl": "https://community.kde.org/GSoC/2026/Ideas",
     "channels": [
-    {
+      {
       "type": "Matrix",
       "url": "https://matrix.to/#/#kde-new-contributors:kde.org",
       "label": "KDE New Contributors"
-    },
-    {
+      },
+      {
       "type": "Matrix",
       "url": "https://matrix.to/#/#kde-devel:kde.org",
       "label": "KDE Development"
-    }
-  ],
+      }
+    ],
     "mentors": [
-  {
-    "name": "Jean-Baptiste Mardelle",
-    "github": "",
-    "githubUrl": ""
-  },
-  {
-    "name": "David Edmundson",
-    "github": "",
-    "githubUrl": ""
-  },
-  {
-    "name": "David Redondo",
-    "github": "",
-    "githubUrl": ""
-  }
-],
+      {
+        "name": "Jean-Baptiste Mardelle",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "David Edmundson",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "David Redondo",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
     "mailingLists": [
-       "kde-devel@kde.org"
+      {
+        "type": "Mailing List",
+        "url": "mailto:kde-devel@kde.org",
+        "label": "kde-devel@kde.org"
+      }
     ],
     "tip": "Join KDE Matrix rooms and interact with mentors before applying.",
     "status": "ok",


### PR DESCRIPTION
Summary:
Added verified KDE Community contact and mentorship information to mentors.json.
Changes Made:

1. Added KDE Matrix channels
2. Added mentor names from official KDE GSoC Ideas page
3. Added KDE development mailing list
4. Updated ideas URL
5. Updated status from "no-contact-found" to "ok"

Related Issue:
Closes #329

Type of Change:
1.Documentation Update
2.Data Update

Program:
program: GSSOC

Verification:
Verified details from official KDE community pages and ran "npm run lint" successfully.