### PR TITLE
fix(ui): close “Surprise Me!” modal on outside overlay click

### DIFF
--- a/index.html
+++ b/index.html
@@ -2615,7 +2615,16 @@
        timelineHtml += `<span class="${y===2026?'current-year':''} ${active?'opacity-100':'opacity-30'}">${y}</span>`;
     }
     document.getElementById('mTimeline').innerHTML = timelineHtml;
+    
+    const modalBg = document.querySelector('.modal-bg');
 
+    if (modalBg) {
+      modalBg.addEventListener('click', (e) => {
+        if (e.target === modalBg) {
+          modalBg.classList.remove('open');
+        }
+      });
+    }
     // Sanitize and set idea/repo links
     const ideasUrl = sanitizeHrefUrl(org.ideas);
     const repoUrl = sanitizeHrefUrl(githubUrlFromValue(org.github));


### PR DESCRIPTION
## Summary

Fixed the issue where the “Surprise Me!” modal did not close when clicking outside the modal overlay.

## Changes Made

* Added outside overlay click detection
* Improved modal close interaction
* Preserved existing modal functionality

## Testing

* Opened the “Surprise Me!” modal
* Clicked outside the modal on the dark overlay
* Verified that the modal closes correctly
* Verified that clicking inside the modal does not close it

Fixes #1280