### PR TITLE
fix(issues): replace substring match in filterIssues with exact LANGUAGE_MAP alias lookup

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2009,9 +2009,23 @@ function filterIssues() {
   const cat = document.getElementById('issueCatFilter')?.value || '';
   const lang = document.getElementById('issueLangFilter')?.value || '';
 
+  // Resolve the selected language value to the canonical LANGUAGE_MAP label and
+  // its known aliases (e.g. 'java' -> ['java']), exactly as applyFilters() does
+  // for the org grid. Using t.includes(lang) was a substring match that caused
+  // 'Java' to also return JavaScript issues because 'javascript'.includes('java')
+  // is true. normalizeTag() is used for both the key lookup and the alias mapping
+  // so the comparison is consistent with the rest of the codebase.
+  const langAliases = lang
+    ? (LANGUAGE_MAP[Object.keys(LANGUAGE_MAP).find(k => normalizeTag(k) === normalizeTag(lang)) || ''] || [lang])
+        .map(normalizeTag)
+    : [];
+
   filteredIssues = allIssues.filter(iss => {
     if (cat && iss.orgCat !== cat) return false;
-    if (lang && !iss.orgTags.some(t => t.includes(lang))) return false;
+    if (lang) {
+      const orgTagsNormalized = (iss.orgTags || []).map(normalizeTag);
+      if (!langAliases.some(alias => orgTagsNormalized.includes(alias))) return false;
+    }
     if (search && !iss.title.toLowerCase().includes(search) && !iss.org.toLowerCase().includes(search)) return false;
     return true;
   });

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2015,15 +2015,16 @@ function filterIssues() {
   // 'Java' to also return JavaScript issues because 'javascript'.includes('java')
   // is true. normalizeTag() is used for both the key lookup and the alias mapping
   // so the comparison is consistent with the rest of the codebase.
+  const normLang = lang.trim().toLowerCase();
   const langAliases = lang
-    ? (LANGUAGE_MAP[Object.keys(LANGUAGE_MAP).find(k => normalizeTag(k) === normalizeTag(lang)) || ''] || [lang])
-        .map(normalizeTag)
+    ? (LANGUAGE_MAP[Object.keys(LANGUAGE_MAP).find(k => k.trim().toLowerCase() === normLang) || ''] || [lang])
+        .map(t => t.trim().toLowerCase())
     : [];
 
   filteredIssues = allIssues.filter(iss => {
     if (cat && iss.orgCat !== cat) return false;
     if (lang) {
-      const orgTagsNormalized = (iss.orgTags || []).map(normalizeTag);
+      const orgTagsNormalized = (iss.orgTags || []).map(t => t.trim().toLowerCase());
       if (!langAliases.some(alias => orgTagsNormalized.includes(alias))) return false;
     }
     if (search && !iss.title.toLowerCase().includes(search) && !iss.org.toLowerCase().includes(search)) return false;


### PR DESCRIPTION
## 🚀 Program
program: gssoc

## 📝 Description
`filterIssues()` used `t.includes(lang)` (substring match) to filter issues by language. This caused false positives: selecting **Java** also returned JavaScript-tagged issues because `'javascript'.includes('java') === true`. The same problem exists for C vs C++/C#.

The fix resolves the dropdown value through `LANGUAGE_MAP` (the same alias table `applyFilters()` uses for the org card grid) and tests for exact tag equality, making both filters consistent:

```js
const langAliases = lang
  ? (LANGUAGE_MAP[Object.keys(LANGUAGE_MAP).find(k => k.toLowerCase() === lang) || ''] || [lang])
      .map(a => a.trim().toLowerCase())
  : [];

filteredIssues = allIssues.filter(iss => {
  if (cat && iss.orgCat !== cat) return false;
  if (lang) {
    const orgTagsNormalized = (iss.orgTags || []).map(t => t.trim().toLowerCase());
    if (!langAliases.some(alias => orgTagsNormalized.includes(alias))) return false;
  }
  if (search && !iss.title.toLowerCase().includes(search) && !iss.org.toLowerCase().includes(search)) return false;
  return true;
});
```

## 🔗 Related Issue
Closes #1345

## 🔄 Type of Change
- [x] 🐛 Bug fix

## 🧪 How to Test
1. Open `index.html` in a browser.
2. Open the Issues tab and select **Java** from the language filter.
3. Confirm no JavaScript-tagged issues appear in the results.
4. Select **C** and confirm C++/C# issues are excluded.
5. Select **JavaScript** and confirm all JS-tagged issues still appear.
6. Clear the filter and confirm all issues are shown again.

## 📸 Screenshots (if applicable)
N/A (filter logic; no visual layout change).

## ✅ Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)