### PR TITLE
fix: update Open Food Facts mentor contact info

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2148,12 +2148,21 @@
   },
   "Open Food Facts": {
     "org": "Open Food Facts",
-    "ideasUrl": "https://github.com/openfoodfacts/openfoodfacts-server/wiki/Google-Summer-Of-Code",
-    "channels": [],
-    "mentors": [],
+    "ideasUrl": "https://wiki.openfoodfacts.org/GSOC/2026_ideas_list",
+    "channels": [
+      {
+        "type": "Slack",
+        "label": "#off-explorer"
+      }
+  ],
+    "mentors": [
+      {
+        "name" : "VaiTon"
+      }
+    ],
     "mailingLists": [],
     "tip": "",
-    "status": "no-contact-found",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Open Genome Informatics": {

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2152,12 +2152,15 @@
     "channels": [
       {
         "type": "Slack",
+        "url": "https://slack.openfoodfacts.org/",
         "label": "#off-explorer"
       }
   ],
     "mentors": [
       {
-        "name" : "VaiTon"
+        "name" : "VaiTon",
+        "github" : "VaiTon",
+        "githubUrl": "https://github.com/VaiTon"
       }
     ],
     "mailingLists": [],


### PR DESCRIPTION
program: Gssoc

## Description
Updated Open Food Facts mentor contact information by:
- Updating the official ideas page URL
- Adding Slack channel information (#off-explorer)
- Adding mentor information (VaiTon)
- Verifying mailing list availability
- Updating status to "ok"

## Related Issue
Closes #365

## Type of Change
- [x] Data update
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist
- [x] Verified information from official Open Food Facts sources
- [x] Updated channels
- [x] Updated mentors
- [x] Verified mailing list information
- [x] Updated status field
- [x] Tested JSON formatting/structure