### PR TITLE
Feature Enhancement: Adding responsive layout of website and avoid overflowing, or half text on main screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -890,6 +890,7 @@
   </nav>
 </div>
 
+
 <!-- ═══════════════════ HERO ═══════════════════ -->
 <section class="pt-20 sm:pt-28 pb-12 sm:pb-20 px-4 sm:px-6 max-w-4xl mx-auto fade-up">
   <div class="flex flex-col items-center text-center gap-8 lg:gap-12">

--- a/index.html
+++ b/index.html
@@ -891,66 +891,52 @@
 </div>
 
 <!-- ═══════════════════ HERO ═══════════════════ -->
-<section class="pt-20 sm:pt-28 pb-12 sm:pb-20 px-4 sm:px-6 max-w-7xl mx-auto fade-up">
-  <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-center"> 
-    <div class="lg:col-span-7">
-      <div class="inline-flex items-center gap-2 px-3 sm:px-4 py-1.5 rounded-full bg-orange-50 border border-orange-100 text-primary mb-6 sm:mb-8">
+<section class="pt-20 sm:pt-28 pb-12 sm:pb-20 px-4 sm:px-6 max-w-4xl mx-auto fade-up">
+  <div class="flex flex-col items-center text-center gap-8 lg:gap-12">
+    
+    <div class="flex flex-col items-center">
+      <div class="inline-flex items-center gap-2 px-3 sm:px-4 py-1.5 rounded-full bg-orange-50 border border-orange-100 text-primary mb-6">
         <span class="material-symbols-outlined text-sm icon-fill" style="color:#f97316">verified</span>
         <span class="font-label text-[10px] sm:text-xs uppercase font-bold tracking-widest">Google Summer of Code 2026</span>
       </div>
-      <h1 class="text-4xl sm:text-5xl md:text-7xl font-extrabold font-headline tracking-tighter text-zinc-900 mb-4 sm:mb-6 leading-[0.95]">
+      
+      <h1 class="text-4xl sm:text-5xl md:text-7xl font-extrabold font-headline tracking-tighter text-zinc-900 mb-6 leading-[0.95]">
         Find Your<br/><span class="text-primary italic">Perfect GSoC Org</span>
       </h1>
-      <p class="text-base sm:text-lg text-zinc-600 max-w-xl mb-8 sm:mb-10 leading-relaxed">
+      
+      <p class="text-base sm:text-lg text-zinc-600 max-w-xl leading-relaxed">
         Browse all <strong>184</strong> organizations. Filter by language, domain, competition, and live GitHub activity. Land your summer internship.
       </p>
-      <!-- Search Bar -->
-      <div class="relative max-w-xl mb-6 sm:mb-8">
+    </div>
+
+    <div class="w-full max-w-xl">
+      <div class="relative mb-6">
         <span class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400">search</span>
-        <input id="hero-search" type="text" placeholder="Search organization names..." aria-label="Search GSoC 2026 organizations" class="w-full bg-white border-2 border-zinc-100 rounded-2xl py-3 sm:py-4 pl-12 pr-4 text-sm font-medium focus:ring-2 focus:ring-primary/30 focus:border-primary/40 transition-all shadow-lg shadow-zinc-200/50" />
+        <input id="hero-search" type="text" placeholder="Search organization names..." class="w-full bg-white border-2 border-zinc-100 rounded-2xl py-4 pl-12 pr-4 shadow-lg shadow-zinc-200/50" />
       </div>
-      <!-- Surprise Button -->
-      <div class="mb-8 sm:mb-10">
-        <button id="surpriseBtn" class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-primary to-primary-container text-white rounded-full text-sm font-bold hover:shadow-lg hover:scale-105 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:ring-offset-2" aria-label="🎲 Surprise Me! - Open a random organization">
-          <span class="material-symbols-outlined text-sm">casino</span>
-          🎲 Surprise Me!
-        </button>
+      <button id="surpriseBtn" class="inline-flex items-center gap-2 px-8 py-3 bg-gradient-to-r from-primary to-primary-container text-white rounded-full font-bold hover:scale-105 transition-all">
+        <span class="material-symbols-outlined text-sm">casino</span> 🎲 Surprise Me!
+      </button>
+    </div>
+
+    <div class="flex flex-col items-center gap-8 w-full max-w-2xl">
+      <div class="flex flex-wrap justify-center gap-4">
+        <div class="flex items-center gap-2 px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm"><span class="material-symbols-outlined text-primary text-lg">groups</span><div><p class="text-[10px] text-zinc-500">Total Orgs</p><p class="font-bold text-sm">184</p></div></div>
+        <div class="flex items-center gap-2 px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm"><span class="material-symbols-outlined text-secondary text-lg">code</span><div><p class="text-[10px] text-zinc-500">Languages</p><p class="font-bold text-sm">30+</p></div></div>
+        <div class="flex items-center gap-2 px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm"><span class="material-symbols-outlined text-primary-container text-lg">category</span><div><p class="text-[10px] text-zinc-500">Domains</p><p class="font-bold text-sm">15+</p></div></div>
       </div>
-      <!-- Stat Badges -->
-      <div class="flex flex-wrap gap-3 sm:gap-4">
-        <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
-          <span class="material-symbols-outlined text-primary text-lg">groups</span>
-          <div><p class="text-[10px] sm:text-xs text-zinc-500">Total Orgs</p><p class="font-bold text-sm">184</p></div>
+      
+      <div id="timeline" class="w-full bg-white rounded-3xl p-8 shadow-2xl shadow-zinc-200/50 border border-zinc-100 text-left">
+        <div class="flex items-center justify-between mb-6">
+          <h3 class="font-headline font-extrabold text-lg">2026 Timeline</h3>
+          <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-[10px] font-bold uppercase">Live</span>
         </div>
-        <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
-          <span class="material-symbols-outlined text-secondary text-lg">code</span>
-          <div><p class="text-[10px] sm:text-xs text-zinc-500">Languages</p><p class="font-bold text-sm">30+</p></div>
-        </div>
-        <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
-          <span class="material-symbols-outlined text-primary-container text-lg">category</span>
-          <div><p class="text-[10px] sm:text-xs text-zinc-500">Domains</p><p class="font-bold text-sm">15+</p></div>
-        </div>
+        <div id="timeline-milestones" class="space-y-4"></div>
       </div>
     </div>
-    <!-- Timeline Card -->
-    <div id="timeline" class="lg:col-span-5 fade-up" style="animation-delay:.2s">
-      <div class="bg-white rounded-2xl sm:rounded-3xl p-6 sm:p-8 shadow-2xl shadow-zinc-200/50 border border-zinc-100">
-        <div class="flex items-center justify-between mb-6 sm:mb-8">
-          <h3 class="font-headline font-extrabold text-lg sm:text-xl">2026 Timeline</h3>
-          <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-[10px] font-bold uppercase tracking-wider">Live</span>
-        </div>
-        <div id="timeline-milestones" class="space-y-4 sm:space-y-5"></div>
-        <div class="mt-5 sm:mt-6 pt-5 sm:pt-6 border-t border-zinc-100">
-          <div class="flex items-center justify-between">
-            <span class="text-xs text-zinc-500" id="countdown-label">Next milestone</span>
-            <span id="countdown" class="font-mono text-sm font-bold text-primary">--d --h --m</span>
-          </div>
-        </div>
-      </div>
-    </div>
+
   </div>
 </section>
-
 <!-- ═══════════════════ FILTER CHIPS ═══════════════════ -->
 <section class="px-6 max-w-7xl mx-auto mb-6 fade-up" style="animation-delay:.3s">
   <div class="flex flex-wrap gap-2 mb-4">

--- a/index.html
+++ b/index.html
@@ -932,10 +932,17 @@
           <h3 class="font-headline font-extrabold text-lg">2026 Timeline</h3>
           <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-[10px] font-bold uppercase">Live</span>
         </div>
+        
         <div id="timeline-milestones" class="space-y-4"></div>
+
+        <div class="mt-6 pt-6 border-t border-zinc-100">
+           <div class="flex items-center justify-between">
+             <span id="countdown-label" class="text-xs text-zinc-500">Next milestone</span>
+             <span id="countdown" class="font-mono text-sm font-bold text-primary">--d --h --m</span>
+           </div>
+        </div>
       </div>
     </div>
-
   </div>
 </section>
 <!-- ═══════════════════ FILTER CHIPS ═══════════════════ -->

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -861,7 +861,7 @@ function updateStats(){
 // ══════════════════════════════════════════════
 // KEYBOARD NAVIGATION
 // ══════════════════════════════════════════════
-cconst GRID_COLS = () => {
+const GRID_COLS = () => {
   const g = document.getElementById('orgGrid');
   
   // 1. Safety check: ensure element exists

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -861,15 +861,32 @@ function updateStats(){
 // ══════════════════════════════════════════════
 // KEYBOARD NAVIGATION
 // ══════════════════════════════════════════════
-const GRID_COLS=()=>{
-  const g=document.getElementById('orgGrid');
-  if(!g||!g.children.length)return 3;
-  const firstRect=g.children[0].getBoundingClientRect();
-  let cols=1;
-  for(let i=1;i<g.children.length;i++){
-    if(Math.abs(g.children[i].getBoundingClientRect().top-firstRect.top)<5)cols++;
-    else break;
+cconst GRID_COLS = () => {
+  const g = document.getElementById('orgGrid');
+  
+  // 1. Safety check: ensure element exists
+  if (!g) return 3;
+
+  // 2. Target only the cards, ignore loading spinners or empty-state text
+  const cards = g.querySelectorAll('.org-card');
+  
+  // 3. If no cards exist, return default
+  if (cards.length === 0) return 3;
+
+  const firstRect = cards[0].getBoundingClientRect();
+  let cols = 1;
+
+  // 4. Loop through remaining cards and check if they are on the same "top" line
+  for (let i = 1; i < cards.length; i++) {
+    const currentRect = cards[i].getBoundingClientRect();
+    // Using a tolerance of 5px for sub-pixel rendering differences
+    if (Math.abs(currentRect.top - firstRect.top) < 5) {
+      cols++;
+    } else {
+      break;
+    }
   }
+  
   return cols;
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -161,7 +161,7 @@ body.modal-open{overflow:hidden;  height:100vh;}
 .sort-row select{background:var(--white);border:1.5px solid var(--border);border-radius:8px;padding:6px 26px 6px 9px;color:var(--ink);font-family:'Plus Jakarta Sans',sans-serif;font-size:12px;font-weight:600;outline:none;cursor:pointer;appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%23B07850' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 7px center;transition:background-color .3s,border-color .3s,color .3s}
 
 /* ── GRID ── */
-.grid {
+.org-card {
   display: grid;
   /* Use auto-fit to allow the grid to collapse empty tracks */
   grid-template-columns: repeat(auto-fit, 310px); 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,12 @@
+/* Add this to your stylesheet */
+.wrap, .container, main {
+  max-width: 1200px; /* Limits the width so it doesn't stretch too far */
+  margin: 0 auto;    /* This is the magic for centering */
+  padding: 0 15px;   /* Adds the "little space at the corner" on mobile */
+  box-sizing: border-box;
+}
+
+
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 :root,[data-theme="light"]{
   --bg:#FAFAFA;--white:#FFFFFF;
@@ -152,7 +161,20 @@ body.modal-open{overflow:hidden;  height:100vh;}
 .sort-row select{background:var(--white);border:1.5px solid var(--border);border-radius:8px;padding:6px 26px 6px 9px;color:var(--ink);font-family:'Plus Jakarta Sans',sans-serif;font-size:12px;font-weight:600;outline:none;cursor:pointer;appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%23B07850' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 7px center;transition:background-color .3s,border-color .3s,color .3s}
 
 /* ── GRID ── */
-.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(310px,1fr));gap:12px;margin-bottom:60px}
+.grid {
+  display: grid;
+  /* Use auto-fit to allow the grid to collapse empty tracks */
+  grid-template-columns: repeat(auto-fit, 310px); 
+  /* Center the cards within the container */
+  justify-content: center; 
+  gap: 12px;
+  
+  /* Make the container take full width but center its content */
+  width: 100%;
+  padding: 0 10px;
+  box-sizing: border-box;
+  margin-bottom: 60px;
+}
 
 /* ── CARD ── */
 .org-card{background:var(--card-bg);border:1.5px solid var(--border);border-radius:14px;padding:18px;cursor:pointer;position:relative;overflow:hidden;animation:fadeUp .25s ease forwards;transition:border-color .18s,box-shadow .18s,transform .15s,background .3s}


### PR DESCRIPTION
closes #1297 
program: gssoc
Initial Problem:
When we used to open the website, the screen was divided into two parts-1. Find Your Perfect GSoC org which was the heading only visible on main screen and on right side only half the timeline was visible making the overall home page of website visually incomplete. Also, in devices of different dimensions, the entire text and cards were left centered.
Th modified code:
1. Now this PR has replaced the grid container with flex flex-col items-center of section page in index.html page which resulted in centered block that expands/contracts naturally with the screen size.
2. So, as a result now when we will open the website, the whole website name, search bar and surprise me will be at centre of main page which is a very clean css rather than left-right incomplete text visuals. So, this is not making page crowded.
3. Also, the timeline feature will be there which is visible to user when that person clicks the required tab.
4. Now,the original code used grid grid-cols-1 lg:grid-cols-12. This effectively split the page into 12 "slots." Even with justify-items-center, the content was forced into a specific column span (lg:col-span-7), which inherently left the right side (the remaining 5 columns) empty. Now, withflex this problem is solved.And on every devices, text and cards are centre aligned.


This PR is trying to enhance the feature of responsiveness across devices of different dimensions and provide a clean visual to the website,
The images are attached to see the clear difference between earlier and modified code of this PR.
Thank you!
<img width="269" height="216" alt="Screenshot 2026-05-27 003907" src="https://github.com/user-attachments/assets/dc40bbbd-a225-4c38-baa9-3977710104b5" />
<img width="468" height="485" alt="Screenshot 2026-05-27 004639" src="https://github.com/user-attachments/assets/c2552ece-bd24-428c-9ef6-c50c359beba2" />
<img width="361" height="489" alt="Screenshot 2026-05-27 004843" src="https://github.com/user-attachments/assets/eb67080f-ebbe-42ba-8902-553c5573a1c3" />
<img width="768" height="443" alt="Screenshot 2026-05-27 004907" src="https://github.com/user-attachments/assets/54cb6b2a-0360-49d1-b913-d819a692adc8" />
<img width="767" height="438" alt="Screenshot 2026-05-27 004920" src="https://github.com/user-attachments/assets/c03314f7-a05b-4ea6-bbd3-ce1aa91597be" />
<img width="499" height="59" alt="Screenshot 2026-05-27 005000" src="https://github.com/user-attachments/assets/59612ca7-ae00-409d-a8f3-e23823034565" />
<img width="623" height="50" alt="Screenshot 2026-05-27 005232" src="https://github.com/user-attachments/assets/06bb84cd-d1f7-4040-b71a-a1739d6592ee" />
