### PR TITLE
fix: close keyboard shortcuts modal on outside click and disable background

### DIFF
--- a/index.html
+++ b/index.html
@@ -4156,14 +4156,22 @@ document.addEventListener('DOMContentLoaded', () => {
   function openHelpModal() {
     if (helpModal) {
       helpModal.classList.add('open');
+      document.body.style.overflow = 'hidden';
     }
   }
 
   function closeHelpModal() {
     if (helpModal) {
       helpModal.classList.remove('open');
+      document.body.style.overflow = '';
     }
   }
+
+  window.addEventListener('click', (e) => {
+  if (helpModal && helpModal.classList.contains('open') && e.target === helpModal) {
+    closeHelpModal();
+  }
+});
 
   if (helpBtn) {
     helpBtn.addEventListener('click', openHelpModal);


### PR DESCRIPTION
program: gssoc

## Description
This PR fixes the issue where the Keyboard Shortcuts Modal would not close when clicking outside, and the background remained interactive.

## Changes
- Added outside click handler to dismiss the modal.
- Disabled background interactions (scrolling/clicking) when the modal is open.

## How to Test
1. Open the Keyboard Shortcuts Modal.
2. Click anywhere outside the modal window.
3. Verify that the modal closes immediately.
4. Verify that you cannot scroll or interact with the page behind the modal while it is open.

## Related Issue
Closes #1276