### PR TITLE
fix: Verify/add mentor contact info for UC OSPO

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -3866,15 +3866,38 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "UC OSPO": {
-    "org": "UC OSPO",
-    "ideasUrl": "https://ucsc-ospo.github.io/gsoc/",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "fetch-failed",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
-  },
+  "org": "UC OSPO",
+  "ideasUrl": "https://ucsc-ospo.github.io/osre26/",
+  "channels": [
+    {
+      "type": "Slack",
+      "url": "https://join.slack.com/t/uc-ospo-network/shared_invite/zt-3c6yw4l11-WU2PB4jUwAtXTDK09h8orQ",
+      "label": "UC OSPO Network Slack"
+    }
+  ],
+  "mentors": [
+    {
+      "name": "Carlos Maltzahn",
+      "github": "carlosmaltzahn",
+      "githubUrl": "https://github.com/carlosmaltzahn"
+    },
+    {
+      "name": "Stephanie Lieggi",
+      "github": "slieggi",
+      "githubUrl": "https://github.com/slieggi"
+    }
+  ],
+  "mailingLists": [
+    {
+      "type": "Email",
+      "url": "mailto:ospo-info-group@ucsc.edu",
+      "label": "ospo-info-group@ucsc.edu"
+    }
+  ],
+  "tip": "Join the UC OSPO Network Slack and email ospo-info-group@ucsc.edu for any eligibility questions.",
+  "status": "ok",
+  "lastFetched": "2026-05-28T00:00:00.000Z"
+},
   "Unikraft": {
     "org": "Unikraft",
     "ideasUrl": "https://github.com/unikraft/docs/tree/main/content/docs/contributing/gsoc",


### PR DESCRIPTION
Closes #427

## Changes
- Fixed broken `ideasUrl`: `https://ucsc-ospo.github.io/gsoc/` (404) → `https://ucsc-ospo.github.io/osre26/` (live ✅)
- Added Slack as communication channel (students must join before deadline; invite via ospo-info-group@ucsc.edu)
- Added org admin contact email: ospo-info-group@ucsc.edu
- Added known mentor GitHub handles: carlosmaltzahn, slieggi
- Changed `status` from `fetch-failed` → `ok`
- Updated `lastFetched` to today

## Research Sources
- Ideas page (verified live): https://ucsc-ospo.github.io/osre26/
- Student guidelines (Slack requirement): https://ucsc-ospo.github.io/osredocs/forstudents/
- Contact email: explicitly listed on the student guidelines page