### PR TITLE
Remove duplicate .sr-only CSS class to improve DRY principle

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,8 +362,7 @@
     .proposal-preview blockquote { border-left: 4px solid #ddd; padding-left: 1rem; color: #666; margin-bottom: 1rem; }
     .proposal-preview a { color: #f97316; text-decoration: underline; }
     .proposal-preview-error { color: #ba1a1a; font-size: 0.875rem; }
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
-
+    
     /* Custom Scrollbar for Modal */
     .modal::-webkit-scrollbar { width: 6px; }
     .modal::-webkit-scrollbar-track { background: transparent; }


### PR DESCRIPTION
## Description
Removed duplicate `.sr-only` CSS class to reduce redundancy and improve maintainability.

## Related Issue
Closes #1383

## Program
GSSOC 2026

## Checklist
 - Removed duplicate code
- Code is working properly
-No new errors introduced

