### PR TITLE
fix: update mentor contact info for DeepChem

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -801,14 +801,36 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "DeepChem": {
-    "org": "DeepChem",
-    "ideasUrl": "https://github.com/deepchem/deepchem/wiki/GSoC-2026",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+      "org": "DeepChem",
+      "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/deepchem",
+      "channels": [
+        {
+          "type": "Discord",
+          "url": "https://discord.com/invite/RYTrUY8Ssn",
+          "label": "DeepChem Discord"
+        }
+      ],
+      "mentors": [
+        {
+          "name": "José A. Sigüenza",
+          "github": "JoseAntonioSiguenza",
+          "githubUrl": "https://github.com/JoseAntonioSiguenza"
+        },
+        {
+          "name": "Aryan Amit Barsainyan",
+          "github": "ARY2260",
+          "githubUrl": "https://github.com/ARY2260"
+        },
+        {
+          "name": "Harindhar",
+          "github": "Harindhar10",
+          "githubUrl": "https://github.com/Harindhar10"
+        }
+      ],
+      "mailingLists": [],
+      "tip": "",
+      "status": "ok",
+      "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Django Software Foundation": {
     "org": "Django Software Foundation",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -828,9 +828,9 @@
         }
       ],
       "mailingLists": [],
-      "tip": "",
+      "tip": "Join the DeepChem Discord server and introduce yourself before reaching out to mentors directly.",
       "status": "ok",
-      "lastFetched": "2026-05-09T16:09:12.548Z"
+      "lastFetched": "2026-05-28T00:00:00.000Z"
   },
   "Django Software Foundation": {
     "org": "Django Software Foundation",


### PR DESCRIPTION
program: gssoc

## Description

Verified and updated the mentor contact information for DeepChem for GSoC 2026.

### Changes Made

* Added the official GSoC 2026 ideas page URL
* Added the official DeepChem Discord communication channel
* Added verified mentor GitHub handles from official GSoC project listings
* Updated status from `no-contact-found` to `ok`

## Related Issue

Closes #283

## Type of Change

* [x] Documentation update
* [x] Data update

## Checklist

* [x] I have verified the information from official sources
* [x] I have checked that only relevant files were modified
* [x] I have tested the JSON formatting/validity
* [x] My commit includes DCO signoff
