### PR TITLE
feat: add share / copy to clipboard button to organization cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -2751,9 +2751,16 @@ btn.__orgListenerAttached = true;
     });
   }
 
-  function copyOrgToClipboard(e, name) {
-    if (e) e.stopPropagation();
-    const org = ORGS.find(o => o.name === name);
+  function copyOrgToClipboard(e, identifier, btnOverride) {
+    if (e) {
+      if (typeof e.stopPropagation === 'function') e.stopPropagation();
+    }
+    let org = null;
+    if (typeof identifier === 'number') {
+      org = ORGS[identifier];
+    } else if (typeof identifier === 'string') {
+      org = ORGS.find(o => o.name === identifier);
+    }
     if (!org) return;
 
     const techStack = (org.tags || []).join(', ');
@@ -2767,9 +2774,9 @@ btn.__orgListenerAttached = true;
       shareText += ` GitHub: ${repoHref}`;
     }
 
-    const btn = e.currentTarget;
-    const icon = btn.querySelector('.material-symbols-outlined');
-    const tooltip = btn.querySelector('.share-tooltip') || btn.nextElementSibling;
+    const btn = btnOverride || (e ? e.currentTarget : null);
+    const icon = btn ? btn.querySelector('.material-symbols-outlined') : null;
+    const tooltip = btn ? (btn.querySelector('.share-tooltip') || btn.nextElementSibling) : null;
 
     function showFeedback() {
       if (icon) {

--- a/index.html
+++ b/index.html
@@ -2664,6 +2664,14 @@ sections.forEach(sectionId => {
           <div class="flex items-center gap-2">
             <span class="bg-primary/10 text-primary text-[10px] font-label uppercase tracking-widest px-2 py-1 rounded-full font-bold">${escapeHtml(String(org.years))}y Veteran</span>
             <span class="complexity-badge ${escapeHtml(org.codebase)}">${escapeHtml(org.codebase)}</span>
+            <div class="relative flex items-center justify-center">
+              <button class="share-btn text-zinc-300 hover:text-primary transition-all duration-200 flex items-center justify-center p-1 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800" data-share-org="${escapeHtml(org.name)}" title="Copy details to clipboard" aria-label="Copy organization details for ${escapeHtml(org.name)}">
+                <span class="material-symbols-outlined text-lg">content_copy</span>
+              </button>
+              <div class="share-tooltip absolute bottom-full mb-2 hidden bg-zinc-900 dark:bg-zinc-800 text-white text-[10px] font-bold px-2 py-1 rounded shadow-lg whitespace-nowrap pointer-events-none transition-all duration-200 z-10">
+                Copied!
+              </div>
+            </div>
             <button class="bookmark-btn ${isBookmarked ? 'active' : 'text-zinc-300'}" data-bookmark-org="${escapeHtml(org.name)}" title="${isBookmarked ? 'Remove bookmark' : 'Add bookmark'}">
               <span class="material-symbols-outlined text-lg ${isBookmarked ? 'icon-fill' : ''}">star</span>
             </button>
@@ -2715,6 +2723,16 @@ sections.forEach(sectionId => {
       btn.__orgListenerAttached = true;
     });
 
+    // share buttons
+    (root.querySelectorAll ? root.querySelectorAll('.share-btn[data-share-org]') : []).forEach(btn => {
+      if (btn.__orgListenerAttached) return;
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        copyOrgToClipboard(e, btn.dataset.shareOrg);
+      });
+      btn.__orgListenerAttached = true;
+    });
+
     // compare buttons
     (root.querySelectorAll ? root.querySelectorAll('[data-compare-org]') : []).forEach(btn => {
       if (btn.__orgListenerAttached) return;
@@ -2732,6 +2750,72 @@ sections.forEach(sectionId => {
 btn.__orgListenerAttached = true;
     });
   }
+
+  function copyOrgToClipboard(e, name) {
+    if (e) e.stopPropagation();
+    const org = ORGS.find(o => o.name === name);
+    if (!org) return;
+
+    const techStack = (org.tags || []).join(', ');
+    const githubOwner = githubOwnerFromValue(org.github);
+    const repoHref = githubOwner ? `https://github.com/${githubOwner}` : '';
+    
+    let shareText = `Check out ${org.name} on GSoC! Tech Stack: ${techStack}.`;
+    if (org.ideas) {
+      shareText += ` Ideas List: ${org.ideas}`;
+    } else if (repoHref) {
+      shareText += ` GitHub: ${repoHref}`;
+    }
+
+    const btn = e.currentTarget;
+    const icon = btn.querySelector('.material-symbols-outlined');
+    const tooltip = btn.querySelector('.share-tooltip') || btn.nextElementSibling;
+
+    function showFeedback() {
+      if (icon) {
+        icon.textContent = 'check';
+        icon.classList.add('text-green-500');
+        icon.classList.remove('text-zinc-300');
+      }
+      if (tooltip) {
+        tooltip.classList.remove('hidden');
+      }
+      setTimeout(() => {
+        if (icon) {
+          icon.textContent = 'content_copy';
+          icon.classList.remove('text-green-500');
+          icon.classList.add('text-zinc-300');
+        }
+        if (tooltip) {
+          tooltip.classList.add('hidden');
+        }
+      }, 2000);
+    }
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(shareText).then(() => {
+        showFeedback();
+      }).catch(err => {
+        console.error('Failed to copy text: ', err);
+      });
+    } else {
+      const textArea = document.createElement("textarea");
+      textArea.value = shareText;
+      textArea.style.position = "fixed";
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+      try {
+        document.execCommand('copy');
+        showFeedback();
+      } catch (err) {
+        console.error('Fallback copy failed: ', err);
+      }
+      document.body.removeChild(textArea);
+    }
+  }
+
+  globalThis.copyOrgToClipboard = copyOrgToClipboard;
 
   function toggleCompare(e, name) {
     if (e) e.stopPropagation();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -771,6 +771,71 @@ function isBookmarked(orgName) {
   return saved.includes(orgName);
 }
 
+function copyOrgToClipboard(e, globalIdx) {
+  if (e) e.stopPropagation();
+  const org = ORGS[globalIdx];
+  if (!org) return;
+
+  const techStack = (org.tags || []).join(', ');
+  const repoHref = repoUrl(org);
+  
+  let shareText = `Check out ${org.name} on GSoC! Tech Stack: ${techStack}.`;
+  if (org.ideas) {
+    shareText += ` Ideas List: ${org.ideas}`;
+  } else if (repoHref) {
+    shareText += ` GitHub: ${repoHref}`;
+  }
+
+  const btn = e.currentTarget;
+  const icon = btn.querySelector('.material-symbols-outlined');
+  const tooltip = btn.querySelector('.share-tooltip') || btn.nextElementSibling;
+
+  function showFeedback() {
+    if (icon) {
+      icon.textContent = 'check';
+      icon.classList.add('text-green-500');
+      icon.classList.remove('text-zinc-300');
+    }
+    if (tooltip) {
+      tooltip.classList.remove('hidden');
+    }
+    setTimeout(() => {
+      if (icon) {
+        icon.textContent = 'content_copy';
+        icon.classList.remove('text-green-500');
+        icon.classList.add('text-zinc-300');
+      }
+      if (tooltip) {
+        tooltip.classList.add('hidden');
+      }
+    }, 2000);
+  }
+
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(shareText).then(() => {
+      showFeedback();
+    }).catch(err => {
+      console.error('Failed to copy text: ', err);
+    });
+  } else {
+    const textArea = document.createElement("textarea");
+    textArea.value = shareText;
+    textArea.style.position = "fixed";
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    try {
+      document.execCommand('copy');
+      showFeedback();
+    } catch (err) {
+      console.error('Fallback copy failed: ', err);
+    }
+    document.body.removeChild(textArea);
+  }
+}
+
+globalThis.copyOrgToClipboard = copyOrgToClipboard;
+
 function renderGfiBadge(gh){
   if(gh?.gfi===null||gh?.gfi===undefined)return '';
   return `<span class="gh-s">🟢 <b>${escapeHtml(fmt(gh.gfi))} GFI</b></span>`;
@@ -826,6 +891,14 @@ function renderGrid(orgs){
             <div class="card-actions">
               <button class="btn-card-compare${inCompare?' active':''}" onclick="toggleCompare(${globalIdx},event)" title="${inCompare?'Remove from compare':'Add to compare'}">⚖</button>
               <span class="cat-pill ${catBdg(o.cat)}">${catLabel(o.cat)}</span>
+              <div class="relative flex items-center justify-center">
+                <button type="button" onclick="copyOrgToClipboard(event, ${globalIdx})" class="share-btn text-zinc-300 hover:text-primary transition-all duration-200 flex items-center justify-center p-1 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800" title="Copy details to clipboard" aria-label="Copy organization details for ${escapeHtml(o.name)}">
+                  <span class="material-symbols-outlined text-lg">content_copy</span>
+                </button>
+                <div class="share-tooltip absolute bottom-full mb-2 hidden bg-zinc-900 dark:bg-zinc-800 text-white text-[10px] font-bold px-2 py-1 rounded shadow-lg whitespace-nowrap pointer-events-none transition-all duration-200 z-10">
+                  Copied!
+                </div>
+              </div>
               <button type="button" onclick="toggleBookmark(event, ${globalIdx})" class="bookmark-btn" title="${isBookmarked(o.name) ? 'Remove bookmark' : 'Add bookmark'}" aria-label="${isBookmarked(o.name) ? 'Remove bookmark from ' : 'Add bookmark to '}${escapeHtml(o.name)}">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-label="star" role="img">
                   <path

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -771,9 +771,16 @@ function isBookmarked(orgName) {
   return saved.includes(orgName);
 }
 
-function copyOrgToClipboard(e, globalIdx) {
-  if (e) e.stopPropagation();
-  const org = ORGS[globalIdx];
+function copyOrgToClipboard(e, identifier, btnOverride) {
+  if (e) {
+    if (typeof e.stopPropagation === 'function') e.stopPropagation();
+  }
+  let org = null;
+  if (typeof identifier === 'number') {
+    org = ORGS[identifier];
+  } else if (typeof identifier === 'string') {
+    org = ORGS.find(o => o.name === identifier);
+  }
   if (!org) return;
 
   const techStack = (org.tags || []).join(', ');
@@ -786,9 +793,9 @@ function copyOrgToClipboard(e, globalIdx) {
     shareText += ` GitHub: ${repoHref}`;
   }
 
-  const btn = e.currentTarget;
-  const icon = btn.querySelector('.material-symbols-outlined');
-  const tooltip = btn.querySelector('.share-tooltip') || btn.nextElementSibling;
+  const btn = btnOverride || (e ? e.currentTarget : null);
+  const icon = btn ? btn.querySelector('.material-symbols-outlined') : null;
+  const tooltip = btn ? (btn.querySelector('.share-tooltip') || btn.nextElementSibling) : null;
 
   function showFeedback() {
     if (icon) {

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -59,7 +59,7 @@ function handleShareAction(e, btn) {
   e.stopPropagation();
   const name = btn.dataset.shareOrg;
   if (typeof copyOrgToClipboard === 'function') {
-    copyOrgToClipboard(e, name);
+    copyOrgToClipboard(e, name, btn);
   }
 }
 

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -1,6 +1,6 @@
 // src/js/recommendation-ui.js
 
-/* global analyzeGitHubUser, extractSkills, getRecommendations, escapeHtml, openModal, toggleCompare, toggleBookmark */
+/* global analyzeGitHubUser, extractSkills, getRecommendations, escapeHtml, openModal, toggleCompare, toggleBookmark, copyOrgToClipboard */
 
 /**
  * Encapsulates the heavy analytical logic into a single async pipe.
@@ -54,6 +54,14 @@ const safeEscapeHtml = (str) => {
     .replaceAll("'", '&#039;');
 };
 
+
+function handleShareAction(e, btn) {
+  e.stopPropagation();
+  const name = btn.dataset.shareOrg;
+  if (typeof copyOrgToClipboard === 'function') {
+    copyOrgToClipboard(e, name);
+  }
+}
 
 function handleBookmarkAction(e, btn) {
   e.stopPropagation();
@@ -182,6 +190,12 @@ document.addEventListener('DOMContentLoaded', () => {
     resultsContainer.addEventListener('click', (e) => {
       const target = e.target;
       
+      const shareBtn = target.closest('[data-share-org]');
+      if (shareBtn) {
+        e.stopPropagation();
+        return handleShareAction(e, shareBtn);
+      }
+      
       const bookmarkBtn = target.closest('[data-bookmark-org]');
       if (bookmarkBtn) {
         return handleBookmarkAction(e, bookmarkBtn);
@@ -250,6 +264,17 @@ document.addEventListener('DOMContentLoaded', () => {
           </div>
           
           <div class="flex items-center gap-2 mt-2">
+             <div class="relative flex items-center justify-center">
+               <button class="share-btn text-zinc-300 hover:text-primary transition-all duration-200 flex items-center justify-center p-1 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800" 
+                       data-share-org="${safeEscapeHtml(o.name)}" 
+                       title="Copy details to clipboard"
+                       aria-label="Copy organization details for ${safeEscapeHtml(o.name)}">
+                  <span class="material-symbols-outlined text-lg">content_copy</span>
+               </button>
+               <div class="share-tooltip absolute bottom-full mb-2 hidden bg-zinc-900 dark:bg-zinc-800 text-white text-[10px] font-bold px-2 py-1 rounded shadow-lg whitespace-nowrap pointer-events-none transition-all duration-200 z-10">
+                 Copied!
+               </div>
+             </div>
              <button class="bookmark-btn ${isBookmarked ? 'active text-orange-500' : 'text-zinc-300'}" 
                      data-bookmark-org="${safeEscapeHtml(o.name)}" 
                      title="${isBookmarked ? 'Remove bookmark' : 'Add bookmark'}">


### PR DESCRIPTION
program: gssoc

## 🚀 Program
GSSoC

## 📝 Description
This PR adds a highly responsive and interactive **"Copy to Clipboard" / "Share"** button next to the star bookmark button on each organization card. It helps GSoC aspirants easily share specific open-source opportunities with their mentors, partners, or friends.

* **Core Logic:** Uses the Vanilla JS `navigator.clipboard.writeText()` API, with an automatic off-screen `textarea` fallback for legacy browsers or restricted permission scopes.
* **Micro-interactions:** Clicking the button temporarily changes the copy icon (`content_copy`) into a green success checkmark (`check`) and displays a premium absolute-positioned **"Copied!"** tooltip above it for 2 seconds.
* **Event Safety:** Captures and stops event propagation (`e.stopPropagation()`) so that copying details does not open the details modal.
* **Consistency:** Applied symmetrically to main grid cards, personalize recommendation cards (`recommendation-ui.js`), and static offline mirrors (`app.js`).
* **Design & Compatibility:** Standard Tailwind CSS-based, fully aligned for all light/dark mode variations, and thoroughly lint-tested.

## 🔗 Related Issue
Closes #1558 

## 🔄 Type of Change
- [x] ✨ New feature
- [x] 🎨 Style / UI improvement
- [x] ♿ Accessibility improvement

## 🧪 How to Test
1. Run the project locally (or visit the active static server at `http://localhost:3000`).
2. Go to any organization card on the main dashboard grid or the AI recommendation panel.
3. Click the `content_copy` document-copy icon next to the bookmark star.
4. Verify the micro-interaction feedback (icon turns to a green checkmark and "Copied!" tooltip slides up above the button).
5. Paste the clipboard contents to verify the clean formatted string:
   * *Example:* `Check out AboutCode on GSoC! Tech Stack: python, javascript, c, shell script. Ideas List: https://github.com/aboutcode-org/aboutcode/wiki/GSOC-2026-project-ideas`
6. Verify that clicking the copy button does not open the details modal.

## 📸 Screenshots 
<img width="519" height="442" alt="image" src="https://github.com/user-attachments/assets/fa605be9-ac73-4193-94c5-288e088874ea" />

## ✅ Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)