### PR TITLE
fix: clearAllFilters() leaves internal state and URL dirty (#1053)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3631,8 +3631,12 @@ if(org.ideas){
       chip.classList.add('bg-surface-container-highest');
     });
 
-    filteredOrgs = [...ORGS];
-    renderOrgs(true);
+    // Reset internal state
+    activeChip = null;
+    clearSelectedLanguagePills();
+
+    // Re-apply filters with clean state (handles URL and rendering)
+    applyFilters();
   };
 
   document.getElementById('searchInput').addEventListener('input', () => {


### PR DESCRIPTION
program: gssoc

## 🚀 Program
GSSoC

## 📝 Description
This PR fixes the clearAllFilters() ghost filtering bug reported in #1053.

### Changes:
- Modified window.clearAllFilters to reset activeChip to null.
- Integrated clearSelectedLanguagePills() into clearAllFilters() to properly clear the selectedLanguages Set and reset the language pill UI.
- Replaced manual rendering logic in clearAllFilters() with a call to applyFilters(). This ensures that the state, URL, and rendered results are always in sync.
- Updated applyFilters() to omit the cat=all parameter from the URL when the default category is selected, resulting in a cleaner URL after resetting filters.

## 🔗 Related Issue
Closes #1053

## 🔄 Type of Change
- [x] 🐛 Bug fix

## 🧪 How to Test
1. Open index.html in a browser
2. Select the **'Veterans Only'** chip
3. Select **Python** from the language pills
4. Observe the URL updates to ?chip=veterans&lang=Python
5. Click **'Clear All Filters'**
6. Observe: chips look inactive, pills look cleared, search is empty ✓
7. Type any single letter in the search box
8. Verify: results are now properly unfiltered (no ghost filtering) ✓
9. Verify URL shows no query params ✓

## ✅ Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format
