### PR TITLE
fix: restore Privacy Policy link in footer (#444)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,2407 +1,4474 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-  <title>Live GSoC 2026 Org Finder & Good First Issue Tracker | FindMyGSoC</title>
-  <meta name="description" content="Live GSoC 2026 Org Finder & Good First Issue Tracker. Discover organizations, compare project fit, and track beginner-friendly GitHub issues in real time." />
-  <link rel="canonical" href="https://findmygsoc.vercel.app/" />
-  <meta property="og:type" content="website" />
-  <meta property="og:site_name" content="FindMyGSoC" />
-  <meta property="og:title" content="Live GSoC 2026 Org Finder & Good First Issue Tracker" />
-  <meta property="og:description" content="Discover Google Summer of Code 2026 organizations and track live good first issues across GitHub." />
-  <meta property="og:url" content="https://findmygsoc.vercel.app/" />
-  <meta property="og:image" content="https://findmygsoc.vercel.app/src/assets/og-image.jpeg" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Live GSoC 2026 Org Finder & Good First Issue Tracker" />
-  <meta name="twitter:description" content="Find your best-fit GSoC 2026 org and track beginner-friendly GitHub issues." />
-  <meta name="twitter:image" content="https://findmygsoc.vercel.app/src/assets/og-image.jpeg" />
-  <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebApplication",
-      "name": "FindMyGSoC — GSoC 2026 Org Finder",
-      "url": "https://findmygsoc.vercel.app/",
-      "description": "Find your perfect GSoC 2026 organization filtered by tech stack, domain, and competition level.",
-      "applicationCategory": "DeveloperApplication",
-      "operatingSystem": "Any",
-      "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "USD"
-      },
-      "author": {
-        "@type": "Person",
-        "name": "S3DFX-CYBER"
-      }
-    }
-  </script>
-  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-  <script src="https://cdn.jsdelivr.net/npm/marked@9.1.6/marked.min.js" integrity="sha384-odPBjvtXVM/5hOYIr3A1dB+flh0c3wAT3bSesIOqEGmyUA4JoKf/YTWy0XKOYAY7" crossorigin="anonymous"></script>
-  <script>
-    if (typeof marked === 'undefined') {
-      const s = document.createElement('script');
-      s.src = "https://unpkg.com/marked@9.1.6/marked.min.js";
-      s.integrity = "sha384-odPBjvtXVM/5hOYIr3A1dB+flh0c3wAT3bSesIOqEGmyUA4JoKf/YTWy0XKOYAY7";
-      s.crossOrigin = "anonymous";
-      document.head.appendChild(s);
-    }
-  </script>
-  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js" integrity="sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7" crossorigin="anonymous"></script>
-  <script>
-    if (typeof DOMPurify === 'undefined') {
-      const s = document.createElement('script');
-      s.src = "https://unpkg.com/dompurify@3.4.0/dist/purify.min.js";
-      s.integrity = "sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7";
-      s.crossOrigin = "anonymous";
-      document.head.appendChild(s);
-    }
-  </script>
-  <script src="https://cdn.jsdelivr.net/npm/html2pdf.js@0.14.0/dist/html2pdf.bundle.min.js" integrity="sha384-EaWTV/aVUkLz3tfwg3+5ycX7Q/d9ET9ruOKUgUuFIRUCfzHO1eo2J62a844iWPmY" crossorigin="anonymous"></script>
-  <script>
-    if (typeof html2pdf === 'undefined') {
-      const s = document.createElement('script');
-      s.src = "https://unpkg.com/html2pdf.js@0.14.0/dist/html2pdf.bundle.min.js";
-      s.integrity = "sha384-EaWTV/aVUkLz3tfwg3+5ycX7Q/d9ET9ruOKUgUuFIRUCfzHO1eo2J62a844iWPmY";
-      s.crossOrigin = "anonymous";
-      document.head.appendChild(s);
-    }
-  </script>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
-  <script>
-    // Theme restoration - runs early to prevent FOUC
-    (function(){
-      try {
-        if (localStorage.getItem('theme') === 'dark') {
-          document.documentElement.classList.add('dark');
-        }
-      } catch(e) {
-        // localStorage might be unavailable in some browsers/modes
-        console.warn('Theme restoration failed:', e);
-      }
-    })();
-  </script>
-  <script>
-    tailwind.config = {
-      darkMode: "class",
-      theme: {
-        extend: {
-          screens: {
-            'xs': '480px',
-            'sm': '640px',
-            'md': '768px',
-            'lg': '1024px',
-            'xl': '1280px',
-            '2xl': '1536px',
-          },
-          colors: {
-            "surface-container-highest":"#e2e2e2","background":"#f9f9f9",
-            "surface-container":"#eeeeee","primary-container":"#f97316",
-            "surface":"#f9f9f9","surface-variant":"#e2e2e2",
-            "on-background":"#1a1c1c","on-primary":"#ffffff",
-            "on-surface":"#1a1c1c","error":"#ba1a1a",
-            "primary":"#9d4300","on-surface-variant":"#584237",
-            "outline":"#8c7164","surface-container-lowest":"#ffffff",
-            "secondary":"#006c47","secondary-container":"#8af5be",
-            "on-secondary-container":"#00714b","on-secondary":"#ffffff",
-            "surface-container-low":"#f3f3f3","surface-container-high":"#e8e8e8",
-            "surface-dim":"#dadada","primary-fixed":"#ffdbca",
-            "primary-fixed-dim":"#ffb690","error-container":"#ffdad6",
-            "on-error-container":"#93000a","on-secondary-fixed":"#002113",
-            "secondary-fixed-dim":"#71dba6","tertiary":"#5f5e5e",
-            "on-primary-container":"#582200","surface-tint":"#9d4300",
-          },
-          fontFamily: {
-            "headline":["Plus Jakarta Sans"],"body":["Plus Jakarta Sans"],
-            "label":["Space Grotesk"],"mono":["Fira Code"]
-          },
-          borderRadius:{"DEFAULT":"0.25rem","lg":"0.5rem","xl":"0.75rem","full":"9999px"},
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>
+      Live GSoC 2026 Org Finder & Good First Issue Tracker | FindMyGSoC
+    </title>
+    <meta
+      name="description"
+      content="Live GSoC 2026 Org Finder & Good First Issue Tracker. Discover organizations, compare project fit, and track beginner-friendly GitHub issues in real time."
+    />
+    <link rel="canonical" href="https://findmygsoc.vercel.app/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="FindMyGSoC" />
+    <meta
+      property="og:title"
+      content="Live GSoC 2026 Org Finder & Good First Issue Tracker"
+    />
+    <meta
+      property="og:description"
+      content="Discover Google Summer of Code 2026 organizations and track live good first issues across GitHub."
+    />
+    <meta property="og:url" content="https://findmygsoc.vercel.app/" />
+    <meta
+      property="og:image"
+      content="https://findmygsoc.vercel.app/src/assets/og-image.jpeg"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Live GSoC 2026 Org Finder & Good First Issue Tracker"
+    />
+    <meta
+      name="twitter:description"
+      content="Find your best-fit GSoC 2026 org and track beginner-friendly GitHub issues."
+    />
+    <meta
+      name="twitter:image"
+      content="https://findmygsoc.vercel.app/src/assets/og-image.jpeg"
+    />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "FindMyGSoC — GSoC 2026 Org Finder",
+        "url": "https://findmygsoc.vercel.app/",
+        "description": "Find your perfect GSoC 2026 organization filtered by tech stack, domain, and competition level.",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
         },
-      },
-    }
-  </script>
-  <style>
-    .material-symbols-outlined{font-variation-settings:'FILL' 0,'wght' 400,'GRAD' 0,'opsz' 24;vertical-align:middle}
-    .icon-fill{font-variation-settings:'FILL' 1,'wght' 400,'GRAD' 0,'opsz' 24}
-    .glass{backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px)}
-    .no-scrollbar::-webkit-scrollbar{display:none}.no-scrollbar{-ms-overflow-style:none;scrollbar-width:none}
-    @keyframes fadeUp{from{opacity:0;transform:translateY(20px)}to{opacity:1;transform:translateY(0)}}
-    .fade-up{animation:fadeUp .6s ease-out both}
-    @keyframes pulse-dot{0%,100%{opacity:.4}50%{opacity:1}}
-    .pulse-dot{animation:pulse-dot 2s infinite}
-    @keyframes gradient-shift{0%{background-position:0% 50%}50%{background-position:100% 50%}100%{background-position:0% 50%}}
-    .gradient-animate{background-size:200% 200%;animation:gradient-shift 8s ease infinite}
-    .hero-gradient{background:linear-gradient(135deg,#9d4300 0%,#f97316 50%,#f59e0b 100%)}
+        "author": {
+          "@type": "Person",
+          "name": "S3DFX-CYBER"
+        }
+      }
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/marked@9.1.6/marked.min.js"
+      integrity="sha384-odPBjvtXVM/5hOYIr3A1dB+flh0c3wAT3bSesIOqEGmyUA4JoKf/YTWy0XKOYAY7"
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      if (typeof marked === "undefined") {
+        const s = document.createElement("script");
+        s.src = "https://unpkg.com/marked@9.1.6/marked.min.js";
+        s.integrity =
+          "sha384-odPBjvtXVM/5hOYIr3A1dB+flh0c3wAT3bSesIOqEGmyUA4JoKf/YTWy0XKOYAY7";
+        s.crossOrigin = "anonymous";
+        document.head.appendChild(s);
+      }
+    </script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js"
+      integrity="sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7"
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      if (typeof DOMPurify === "undefined") {
+        const s = document.createElement("script");
+        s.src = "https://unpkg.com/dompurify@3.4.0/dist/purify.min.js";
+        s.integrity =
+          "sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7";
+        s.crossOrigin = "anonymous";
+        document.head.appendChild(s);
+      }
+    </script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/html2pdf.js@0.14.0/dist/html2pdf.bundle.min.js"
+      integrity="sha384-EaWTV/aVUkLz3tfwg3+5ycX7Q/d9ET9ruOKUgUuFIRUCfzHO1eo2J62a844iWPmY"
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      if (typeof html2pdf === "undefined") {
+        const s = document.createElement("script");
+        s.src =
+          "https://unpkg.com/html2pdf.js@0.14.0/dist/html2pdf.bundle.min.js";
+        s.integrity =
+          "sha384-EaWTV/aVUkLz3tfwg3+5ycX7Q/d9ET9ruOKUgUuFIRUCfzHO1eo2J62a844iWPmY";
+        s.crossOrigin = "anonymous";
+        document.head.appendChild(s);
+      }
+    </script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <script>
+      // Theme restoration - runs early to prevent FOUC
+      (function () {
+        try {
+          if (localStorage.getItem("theme") === "dark") {
+            document.documentElement.classList.add("dark");
+          }
+        } catch (e) {
+          // localStorage might be unavailable in some browsers/modes
+          console.warn("Theme restoration failed:", e);
+        }
+      })();
+    </script>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            screens: {
+              xs: "480px",
+              sm: "640px",
+              md: "768px",
+              lg: "1024px",
+              xl: "1280px",
+              "2xl": "1536px",
+            },
+            colors: {
+              "surface-container-highest": "#e2e2e2",
+              background: "#f9f9f9",
+              "surface-container": "#eeeeee",
+              "primary-container": "#f97316",
+              surface: "#f9f9f9",
+              "surface-variant": "#e2e2e2",
+              "on-background": "#1a1c1c",
+              "on-primary": "#ffffff",
+              "on-surface": "#1a1c1c",
+              error: "#ba1a1a",
+              primary: "#9d4300",
+              "on-surface-variant": "#584237",
+              outline: "#8c7164",
+              "surface-container-lowest": "#ffffff",
+              secondary: "#006c47",
+              "secondary-container": "#8af5be",
+              "on-secondary-container": "#00714b",
+              "on-secondary": "#ffffff",
+              "surface-container-low": "#f3f3f3",
+              "surface-container-high": "#e8e8e8",
+              "surface-dim": "#dadada",
+              "primary-fixed": "#ffdbca",
+              "primary-fixed-dim": "#ffb690",
+              "error-container": "#ffdad6",
+              "on-error-container": "#93000a",
+              "on-secondary-fixed": "#002113",
+              "secondary-fixed-dim": "#71dba6",
+              tertiary: "#5f5e5e",
+              "on-primary-container": "#582200",
+              "surface-tint": "#9d4300",
+            },
+            fontFamily: {
+              headline: ["Plus Jakarta Sans"],
+              body: ["Plus Jakarta Sans"],
+              label: ["Space Grotesk"],
+              mono: ["Fira Code"],
+            },
+            borderRadius: {
+              DEFAULT: "0.25rem",
+              lg: "0.5rem",
+              xl: "0.75rem",
+              full: "9999px",
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      .material-symbols-outlined {
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 400,
+          "GRAD" 0,
+          "opsz" 24;
+        vertical-align: middle;
+      }
+      .icon-fill {
+        font-variation-settings:
+          "FILL" 1,
+          "wght" 400,
+          "GRAD" 0,
+          "opsz" 24;
+      }
+      .glass {
+        backdrop-filter: blur(20px);
+        -webkit-backdrop-filter: blur(20px);
+      }
+      .no-scrollbar::-webkit-scrollbar {
+        display: none;
+      }
+      .no-scrollbar {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+      }
+      @keyframes fadeUp {
+        from {
+          opacity: 0;
+          transform: translateY(20px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+      .fade-up {
+        animation: fadeUp 0.6s ease-out both;
+      }
+      @keyframes pulse-dot {
+        0%,
+        100% {
+          opacity: 0.4;
+        }
+        50% {
+          opacity: 1;
+        }
+      }
+      .pulse-dot {
+        animation: pulse-dot 2s infinite;
+      }
+      @keyframes gradient-shift {
+        0% {
+          background-position: 0% 50%;
+        }
+        50% {
+          background-position: 100% 50%;
+        }
+        100% {
+          background-position: 0% 50%;
+        }
+      }
+      .gradient-animate {
+        background-size: 200% 200%;
+        animation: gradient-shift 8s ease infinite;
+      }
+      .hero-gradient {
+        background: linear-gradient(
+          135deg,
+          #9d4300 0%,
+          #f97316 50%,
+          #f59e0b 100%
+        );
+      }
 
-    /* Screen reader only - for accessibility */
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border-width: 0;
-    }
+      /* Screen reader only - for accessibility */
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border-width: 0;
+      }
 
-    /* Modal Styles */
-    .modal-bg {
-      position: fixed;
-      inset: 0;
-      background: rgba(0, 0, 0, 0.6);
-      backdrop-filter: blur(4px);
-      z-index: 100;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      opacity: 0;
-      pointer-events: none;
-      transition: all 0.3s ease;
-      overflow: hidden;
-    }
-    .modal-bg.open {
-      opacity: 1;
-      pointer-events: auto;
-    }
-    .modal {
-     background: white;
-     width: 90%;
-     max-width: 700px;
-     max-height: 90vh;
-     border-radius: 2rem;
-     position: relative;
-     overflow: hidden;
+      /* Modal Styles */
+      .modal-bg {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.6);
+        backdrop-filter: blur(4px);
+        z-index: 100;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        opacity: 0;
+        pointer-events: none;
+        transition: all 0.3s ease;
+        overflow: hidden;
+      }
+      .modal-bg.open {
+        opacity: 1;
+        pointer-events: auto;
+      }
+      .modal {
+        background: white;
+        width: 90%;
+        max-width: 700px;
+        max-height: 90vh;
+        border-radius: 2rem;
+        position: relative;
+        overflow: hidden;
 
-     display: flex;
-     flex-direction: column;
-     padding-top: 1px;
-     box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-     transform: scale(0.9);
-    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-    }
-    .modal-bg.open .modal {
-      transform: scale(1);
-    }
-    .close-btn {
-     position: absolute;
-     top: 1.5rem;
-     right: 1.5rem;
-     z-index: 1000;
-     width: 2.5rem;
-     height: 2.5rem;
-     border-radius: 99px;
-     background: #f3f3f3;
-     display: flex;
-     align-items: center;
-     justify-content: center;
-     color: #555;
-     font-size: 1.2rem;
-    transition: all 0.2s;
-    }
-    .close-btn:hover { background: #e8e8e8; color: #1a1c1c; }
-    
-    .modal-header { padding: 3rem 3rem 1.5rem; }
-    .category-tag {
-      background: rgba(157, 67, 0, 0.1);
-      color: #9d4300;
-      font-size: 0.7rem;
-      font-weight: 800;
-      padding: 0.3rem 0.8rem;
-      border-radius: 99px;
-      letter-spacing: 0.1em;
-      display: inline-block;
-      margin-bottom: 1rem;
-    }
-    .modal-header h2 { font-size: 2.5rem; font-weight: 800; line-height: 1.1; margin-bottom: 0.5rem; }
-    .modal-header p { color: #584237; font-size: 1rem; line-height: 1.5; }
+        display: flex;
+        flex-direction: column;
+        padding-top: 1px;
+        box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+        transform: scale(0.9);
+        transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+      }
+      .modal-bg.open .modal {
+        transform: scale(1);
+      }
+      .close-btn {
+        position: absolute;
+        top: 1.5rem;
+        right: 1.5rem;
+        z-index: 1000;
+        width: 2.5rem;
+        height: 2.5rem;
+        border-radius: 99px;
+        background: #f3f3f3;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #555;
+        font-size: 1.2rem;
+        transition: all 0.2s;
+      }
+      .close-btn:hover {
+        background: #e8e8e8;
+        color: #1a1c1c;
+      }
 
-    .modal-body {padding: 0 3rem 3rem; overflow-y: auto; flex: 1;}
-    .section-title { font-size: 0.75rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.15em; color: #aaa; margin-bottom: 1rem; margin-top: 2rem; border-bottom: 1px solid #f3f3f3; padding-bottom: 0.5rem; }
-    
-    .metrics-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 1rem; }
-    .metric-card { background: #f9f9f9; padding: 1.2rem; border-radius: 1.2rem; border: 1px solid #eee; text-align: center; }
-    .metric-value { font-size: 1.25rem; font-weight: 800; color: #1a1c1c; margin-bottom: 0.2rem; }
-    .metric-label { font-size: 0.65rem; font-weight: 700; text-transform: uppercase; color: #888; }
+      .modal-header {
+        padding: 3rem 3rem 1.5rem;
+      }
+      .category-tag {
+        background: rgba(157, 67, 0, 0.1);
+        color: #9d4300;
+        font-size: 0.7rem;
+        font-weight: 800;
+        padding: 0.3rem 0.8rem;
+        border-radius: 99px;
+        letter-spacing: 0.1em;
+        display: inline-block;
+        margin-bottom: 1rem;
+      }
+      .modal-header h2 {
+        font-size: 2.5rem;
+        font-weight: 800;
+        line-height: 1.1;
+        margin-bottom: 0.5rem;
+      }
+      .modal-header p {
+        color: #584237;
+        font-size: 1rem;
+        line-height: 1.5;
+      }
 
-    .github-stats-container { background: #1a1a1a; border-radius: 1.5rem; padding: 1.5rem; color: #fff; display: flex; flex-wrap: wrap; gap: 1.5rem; align-items: center; position: relative; overflow: hidden; }
-    .gh-fetch { position: absolute; top: 1rem; right: 1rem; background: #333; color: #aaa; border: none; padding: 0.3rem 0.8rem; border-radius: 99px; font-size: 0.65rem; font-weight: 700; cursor: pointer; transition: all 0.2s; }
-    .gh-fetch:hover { background: #444; color: #fff; }
-    .gh-stat-item { font-family: 'Fira Code', monospace; font-size: 0.75rem; color: #4ade80; display: flex; align-items: center; gap: 0.5rem; }
+      .modal-body {
+        padding: 0 3rem 3rem;
+        overflow-y: auto;
+        flex: 1;
+      }
+      .section-title {
+        font-size: 0.75rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.15em;
+        color: #aaa;
+        margin-bottom: 1rem;
+        margin-top: 2rem;
+        border-bottom: 1px solid #f3f3f3;
+        padding-bottom: 0.5rem;
+      }
 
-    .tech-tags, .fit-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-    .tech-tag { background: #f3f4f6; color: #4b5563; font-size: 0.7rem; font-weight: 600; padding: 0.4rem 0.8rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; }
-    .fit-tag { background: #eff6ff; color: #2563eb; font-size: 0.7rem; font-weight: 600; padding: 0.4rem 0.8rem; border-radius: 0.5rem; border: 1px solid #dbeafe; }
-    .mentor-link-chip { display:inline-flex; align-items:center; gap:.45rem; background:#fff7ed; color:#9d4300; border:1px solid #fed7aa; border-radius:999px; padding:.45rem .75rem; font-size:.75rem; font-weight:700; }
-    .mentor-handle-chip { display:inline-flex; align-items:center; gap:.35rem; background:#f3f4f6; color:#374151; border:1px solid #e5e7eb; border-radius:999px; padding:.4rem .7rem; font-size:.75rem; font-weight:600; }
-    .mentor-card { background:#ffffff; border:1px solid #e5e7eb; border-radius:1rem; padding:1.25rem; box-shadow:0 1px 2px rgba(15,23,42,.04); }
-    .mentor-empty { background:#ffffff; border:1px solid #e5e7eb; border-radius:1rem; padding:2rem; text-align:center; }
+      .metrics-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 1rem;
+      }
+      .metric-card {
+        background: #f9f9f9;
+        padding: 1.2rem;
+        border-radius: 1.2rem;
+        border: 1px solid #eee;
+        text-align: center;
+      }
+      .metric-value {
+        font-size: 1.25rem;
+        font-weight: 800;
+        color: #1a1c1c;
+        margin-bottom: 0.2rem;
+      }
+      .metric-label {
+        font-size: 0.65rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        color: #888;
+      }
 
-    .timeline-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-    .timeline-grid span { font-size: 0.75rem; font-weight: 500; color: #666; background: #fff; border: 1px solid #eee; padding: 0.3rem 0.7rem; border-radius: 0.5rem; }
-    .timeline-grid span.current-year { background: #fffbeb; color: #d97706; border-color: #fef3c7; font-weight: 700; }
+      .github-stats-container {
+        background: #1a1a1a;
+        border-radius: 1.5rem;
+        padding: 1.5rem;
+        color: #fff;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        align-items: center;
+        position: relative;
+        overflow: hidden;
+      }
+      .gh-fetch {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+        background: #333;
+        color: #aaa;
+        border: none;
+        padding: 0.3rem 0.8rem;
+        border-radius: 99px;
+        font-size: 0.65rem;
+        font-weight: 700;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .gh-fetch:hover {
+        background: #444;
+        color: #fff;
+      }
+      .gh-stat-item {
+        font-family: "Fira Code", monospace;
+        font-size: 0.75rem;
+        color: #4ade80;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
 
-    .modal-footer { padding: 2rem 3rem 3rem; background: #f9f9f9; display: flex; gap: 1rem; border-top: 1px solid #eee; }
-    .modal-cta { flex: 1; padding: 1rem; border-radius: 1rem; font-size: 0.8rem; font-weight: 800; text-align: center; text-transform: uppercase; letter-spacing: 0.05em; transition: all 0.2s; }
-    .modal-ideas-link { background: #9d4300; color: white; }
-    .modal-ideas-link:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(157, 67, 0, 0.3); }
-    .modal-repo-link { background: white; color: #1a1c1c; border: 1px solid #ddd; }
-    .modal-repo-link:hover { background: #f0f0f0; }
-    .modal-proposal-link { background: linear-gradient(135deg, #c2410c, #9a3412); color: white; border: none; cursor: pointer; }
-    .modal-proposal-link:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(154, 52, 18, 0.45); }
+      .tech-tags,
+      .fit-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+      .tech-tag {
+        background: #f3f4f6;
+        color: #4b5563;
+        font-size: 0.7rem;
+        font-weight: 600;
+        padding: 0.4rem 0.8rem;
+        border-radius: 0.5rem;
+        border: 1px solid #e5e7eb;
+      }
+      .fit-tag {
+        background: #eff6ff;
+        color: #2563eb;
+        font-size: 0.7rem;
+        font-weight: 600;
+        padding: 0.4rem 0.8rem;
+        border-radius: 0.5rem;
+        border: 1px solid #dbeafe;
+      }
+      .mentor-link-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        background: #fff7ed;
+        color: #9d4300;
+        border: 1px solid #fed7aa;
+        border-radius: 999px;
+        padding: 0.45rem 0.75rem;
+        font-size: 0.75rem;
+        font-weight: 700;
+      }
+      .mentor-handle-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        background: #f3f4f6;
+        color: #374151;
+        border: 1px solid #e5e7eb;
+        border-radius: 999px;
+        padding: 0.4rem 0.7rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+      .mentor-card {
+        background: #ffffff;
+        border: 1px solid #e5e7eb;
+        border-radius: 1rem;
+        padding: 1.25rem;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+      }
+      .mentor-empty {
+        background: #ffffff;
+        border: 1px solid #e5e7eb;
+        border-radius: 1rem;
+        padding: 2rem;
+        text-align: center;
+      }
 
-    /* Proposal workspace */
-    dialog.proposal-bg {
-      position: fixed;
-      inset: 0;
-      background: rgba(0, 0, 0, 0.8);
-      backdrop-filter: blur(8px);
-      z-index: 200;
-      display: flex;
-      opacity: 0;
-      pointer-events: none;
-      transition: opacity 0.3s ease;
-      border: none;
-      margin: 0;
-      padding: 0;
-      width: 100%;
-      height: 100%;
-      max-width: 100%;
-      max-height: 100%;
-      color: inherit;
-    }
-    dialog.proposal-bg.open {
-      opacity: 1;
-      pointer-events: auto;
-    }
-    .proposal-workspace {
-      background: white;
-      width: 100%;
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-      transform: translateY(20px);
-      transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-    }
-    .proposal-bg.open .proposal-workspace {
-      transform: translateY(0);
-    }
-    .proposal-header {
-      padding: 1rem 1.5rem;
-      border-bottom: 1px solid #eee;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 1rem;
-      justify-content: space-between;
-      align-items: center;
-      background: #f9f9f9;
-    }
-    .proposal-header-title { flex: 1; min-width: 200px; }
-    .proposal-header-title h2 { font-size: 1.25rem; font-weight: 800; margin: 0; }
-    .proposal-header-title p { font-size: 0.75rem; color: #888; margin: 0.25rem 0 0; }
-    .proposal-toolbar { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; }
-    .proposal-btn {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.35rem;
-      padding: 0.5rem 0.85rem;
-      border-radius: 0.75rem;
-      font-size: 0.7rem;
-      font-weight: 800;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-      border: 1px solid #ddd;
-      background: white;
-      color: #1a1c1c;
-      cursor: pointer;
-      transition: all 0.2s;
-    }
-    .proposal-btn:hover { background: #f3f3f3; }
-    .proposal-btn-primary { background: #9d4300; color: white; border-color: #9d4300; }
-    .proposal-btn-primary:hover { background: #7a3500; }
-    .proposal-btn-danger { color: #ba1a1a; border-color: #fecaca; }
-    .proposal-btn-danger:hover { background: #fef2f2; }
-    .proposal-autosave { display: flex; align-items: center; gap: 0.4rem; font-size: 0.75rem; color: #666; cursor: pointer; user-select: none; }
-    .proposal-body { display: flex; flex: 1; overflow: hidden; flex-direction: column; }
-    @media (min-width: 768px) { .proposal-body { flex-direction: row; } }
-    .proposal-editor, .proposal-preview {
-      flex: 1;
-      overflow-y: auto;
-      padding: 1.5rem;
-      min-height: 200px;
-    }
-    .proposal-editor { border-bottom: 1px solid #eee; background: #fff; }
-    @media (min-width: 768px) { .proposal-editor { border-bottom: none; border-right: 1px solid #eee; } }
-    .proposal-textarea {
-      width: 100%;
-      min-height: 280px;
-      height: 100%;
-      border: none;
-      resize: none;
-      outline: none;
-      font-family: 'Fira Code', monospace;
-      font-size: 0.9rem;
-      line-height: 1.6;
-      color: #333;
-      background: transparent;
-    }
-    .proposal-preview {
-      background: #fafafa;
-      color: #333;
-    }
-    .proposal-preview h1 { font-size: 2rem; font-weight: 800; margin-bottom: 1rem; }
-    .proposal-preview h2 { font-size: 1.5rem; font-weight: 700; margin-top: 1.5rem; margin-bottom: 0.75rem; }
-    .proposal-preview h3 { font-size: 1.25rem; font-weight: 600; margin-top: 1.25rem; margin-bottom: 0.5rem; }
-    .proposal-preview p { margin-bottom: 1rem; line-height: 1.6; }
-    .proposal-preview ul { list-style-type: disc; margin-left: 1.5rem; margin-bottom: 1rem; }
-    .proposal-preview ol { list-style-type: decimal; margin-left: 1.5rem; margin-bottom: 1rem; }
-    .proposal-preview code { background: #eee; padding: 0.2rem 0.4rem; border-radius: 4px; font-family: 'Fira Code', monospace; font-size: 0.85em; }
-    .proposal-preview pre { background: #f4f4f4; padding: 1rem; border-radius: 8px; overflow-x: auto; margin-bottom: 1rem; }
-    .proposal-preview blockquote { border-left: 4px solid #ddd; padding-left: 1rem; color: #666; margin-bottom: 1rem; }
-    .proposal-preview a { color: #f97316; text-decoration: underline; }
-    .proposal-preview-error { color: #ba1a1a; font-size: 0.875rem; }
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+      .timeline-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+      .timeline-grid span {
+        font-size: 0.75rem;
+        font-weight: 500;
+        color: #666;
+        background: #fff;
+        border: 1px solid #eee;
+        padding: 0.3rem 0.7rem;
+        border-radius: 0.5rem;
+      }
+      .timeline-grid span.current-year {
+        background: #fffbeb;
+        color: #d97706;
+        border-color: #fef3c7;
+        font-weight: 700;
+      }
 
-    /* Custom Scrollbar for Modal */
-    .modal::-webkit-scrollbar { width: 6px; }
-    .modal::-webkit-scrollbar-track { background: transparent; }
-    .modal::-webkit-scrollbar-thumb { background: #ddd; border-radius: 3px; }
-    .modal::-webkit-scrollbar-thumb:hover { background: #ccc; }
+      .modal-footer {
+        padding: 2rem 3rem 3rem;
+        background: #f9f9f9;
+        display: flex;
+        gap: 1rem;
+        border-top: 1px solid #eee;
+      }
+      .modal-cta {
+        flex: 1;
+        padding: 1rem;
+        border-radius: 1rem;
+        font-size: 0.8rem;
+        font-weight: 800;
+        text-align: center;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        transition: all 0.2s;
+      }
+      .modal-ideas-link {
+        background: #9d4300;
+        color: white;
+      }
+      .modal-ideas-link:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(157, 67, 0, 0.3);
+      }
+      .modal-repo-link {
+        background: white;
+        color: #1a1c1c;
+        border: 1px solid #ddd;
+      }
+      .modal-repo-link:hover {
+        background: #f0f0f0;
+      }
+      .modal-proposal-link {
+        background: linear-gradient(135deg, #c2410c, #9a3412);
+        color: white;
+        border: none;
+        cursor: pointer;
+      }
+      .modal-proposal-link:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(154, 52, 18, 0.45);
+      }
 
-    /* Complexity Badges */
-    .complexity-badge { font-size: 0.65rem; font-weight: 800; padding: 0.2rem 0.6rem; border-radius: 99px; text-transform: uppercase; }
-    .complexity-badge.beginner { background: #dcfce7; color: #166534; }
-    .complexity-badge.intermediate { background: #fef9c3; color: #854d0e; }
-    .complexity-badge.advanced { background: #fee2e2; color: #991b1b; }
+      /* Proposal workspace */
+      dialog.proposal-bg {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.8);
+        backdrop-filter: blur(8px);
+        z-index: 200;
+        display: flex;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        border: none;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        max-width: 100%;
+        max-height: 100%;
+        color: inherit;
+      }
+      dialog.proposal-bg.open {
+        opacity: 1;
+        pointer-events: auto;
+      }
+      .proposal-workspace {
+        background: white;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        transform: translateY(20px);
+        transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+      }
+      .proposal-bg.open .proposal-workspace {
+        transform: translateY(0);
+      }
+      .proposal-header {
+        padding: 1rem 1.5rem;
+        border-bottom: 1px solid #eee;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        justify-content: space-between;
+        align-items: center;
+        background: #f9f9f9;
+      }
+      .proposal-header-title {
+        flex: 1;
+        min-width: 200px;
+      }
+      .proposal-header-title h2 {
+        font-size: 1.25rem;
+        font-weight: 800;
+        margin: 0;
+      }
+      .proposal-header-title p {
+        font-size: 0.75rem;
+        color: #888;
+        margin: 0.25rem 0 0;
+      }
+      .proposal-toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        align-items: center;
+      }
+      .proposal-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.5rem 0.85rem;
+        border-radius: 0.75rem;
+        font-size: 0.7rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        border: 1px solid #ddd;
+        background: white;
+        color: #1a1c1c;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .proposal-btn:hover {
+        background: #f3f3f3;
+      }
+      .proposal-btn-primary {
+        background: #9d4300;
+        color: white;
+        border-color: #9d4300;
+      }
+      .proposal-btn-primary:hover {
+        background: #7a3500;
+      }
+      .proposal-btn-danger {
+        color: #ba1a1a;
+        border-color: #fecaca;
+      }
+      .proposal-btn-danger:hover {
+        background: #fef2f2;
+      }
+      .proposal-autosave {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.75rem;
+        color: #666;
+        cursor: pointer;
+        user-select: none;
+      }
+      .proposal-body {
+        display: flex;
+        flex: 1;
+        overflow: hidden;
+        flex-direction: column;
+      }
+      @media (min-width: 768px) {
+        .proposal-body {
+          flex-direction: row;
+        }
+      }
+      .proposal-editor,
+      .proposal-preview {
+        flex: 1;
+        overflow-y: auto;
+        padding: 1.5rem;
+        min-height: 200px;
+      }
+      .proposal-editor {
+        border-bottom: 1px solid #eee;
+        background: #fff;
+      }
+      @media (min-width: 768px) {
+        .proposal-editor {
+          border-bottom: none;
+          border-right: 1px solid #eee;
+        }
+      }
+      .proposal-textarea {
+        width: 100%;
+        min-height: 280px;
+        height: 100%;
+        border: none;
+        resize: none;
+        outline: none;
+        font-family: "Fira Code", monospace;
+        font-size: 0.9rem;
+        line-height: 1.6;
+        color: #333;
+        background: transparent;
+      }
+      .proposal-preview {
+        background: #fafafa;
+        color: #333;
+      }
+      .proposal-preview h1 {
+        font-size: 2rem;
+        font-weight: 800;
+        margin-bottom: 1rem;
+      }
+      .proposal-preview h2 {
+        font-size: 1.5rem;
+        font-weight: 700;
+        margin-top: 1.5rem;
+        margin-bottom: 0.75rem;
+      }
+      .proposal-preview h3 {
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin-top: 1.25rem;
+        margin-bottom: 0.5rem;
+      }
+      .proposal-preview p {
+        margin-bottom: 1rem;
+        line-height: 1.6;
+      }
+      .proposal-preview ul {
+        list-style-type: disc;
+        margin-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .proposal-preview ol {
+        list-style-type: decimal;
+        margin-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .proposal-preview code {
+        background: #eee;
+        padding: 0.2rem 0.4rem;
+        border-radius: 4px;
+        font-family: "Fira Code", monospace;
+        font-size: 0.85em;
+      }
+      .proposal-preview pre {
+        background: #f4f4f4;
+        padding: 1rem;
+        border-radius: 8px;
+        overflow-x: auto;
+        margin-bottom: 1rem;
+      }
+      .proposal-preview blockquote {
+        border-left: 4px solid #ddd;
+        padding-left: 1rem;
+        color: #666;
+        margin-bottom: 1rem;
+      }
+      .proposal-preview a {
+        color: #f97316;
+        text-decoration: underline;
+      }
+      .proposal-preview-error {
+        color: #ba1a1a;
+        font-size: 0.875rem;
+      }
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
 
-    /* Bookmark Button */
-    .bookmark-btn { transition: all 0.2s; font-size: 1.25rem; }
-    .bookmark-btn.active { color: #f59e0b; }
-    .bookmark-btn:hover { transform: scale(1.2); }
+      /* Custom Scrollbar for Modal */
+      .modal::-webkit-scrollbar {
+        width: 6px;
+      }
+      .modal::-webkit-scrollbar-track {
+        background: transparent;
+      }
+      .modal::-webkit-scrollbar-thumb {
+        background: #ddd;
+        border-radius: 3px;
+      }
+      .modal::-webkit-scrollbar-thumb:hover {
+        background: #ccc;
+      }
 
-    /* Base mobile-first styles */
-    body { width: 100%; overflow-x: hidden; }
-    html { width: 100%; scroll-behavior: smooth; }
-    
-    /* Scroll offset for fixed header */
-    #timeline, #orgs, #guide, #watchlist, #issues, #mentors, #contact {
-      scroll-margin-top: 80px;
-    }
+      /* Complexity Badges */
+      .complexity-badge {
+        font-size: 0.65rem;
+        font-weight: 800;
+        padding: 0.2rem 0.6rem;
+        border-radius: 99px;
+        text-transform: uppercase;
+      }
+      .complexity-badge.beginner {
+        background: #dcfce7;
+        color: #166534;
+      }
+      .complexity-badge.intermediate {
+        background: #fef9c3;
+        color: #854d0e;
+      }
+      .complexity-badge.advanced {
+        background: #fee2e2;
+        color: #991b1b;
+      }
 
-    /* Minimal dark-mode support */
-    .dark body { background: #0f0f10; color: #e5e7eb; }
-    .dark .glass { background: rgba(24, 24, 27, 0.85); }
-    .dark .bg-white { background: #18181b !important; }
-    .dark .bg-surface-container-low { background: #27272a !important; color: #d4d4d8 !important; }
-    .dark .text-zinc-900 { color: #f4f4f5 !important; }
-    .dark .text-zinc-600, .dark .text-zinc-500, .dark .text-zinc-400 { color: #a1a1aa !important; }
-    .dark .text-zinc-300 { color: #a1a1aa !important; }
-    .dark .text-on-surface { color: #f4f4f5 !important; }
-    .dark .text-on-surface-variant { color: #a1a1aa !important; }
-    .dark .border-zinc-100 { border-color: #3f3f46 !important; }
-    .dark .border-zinc-200 { border-color: #3f3f46 !important; }
-    .dark #timeline-milestones .bg-zinc-200 { background-color: #3f3f46 !important; }
-    .dark .hover\:bg-zinc-100\/50:hover { background: rgba(63, 63, 70, 0.45) !important; }
-    .dark .proposal-workspace { background: #18181b; }
-    .dark .proposal-header { background: #0f0f10; border-color: #27272a; }
-    .dark .proposal-editor { background: #18181b; border-color: #27272a; }
-    .dark .proposal-preview { background: #1f1f23; color: #d4d4d8; }
-    .dark .proposal-textarea { color: #d4d4d8; }
-    .dark .proposal-preview code { background: #3f3f46; color: #f4f4f5; }
-    .dark .proposal-preview pre { background: #27272a; }
-    .dark .proposal-preview blockquote { border-color: #3f3f46; color: #a1a1aa; }
-    .dark .proposal-btn { background: #27272a; color: #e5e7eb; border-color: #3f3f46; }
-    .dark .proposal-btn:hover { background: #3f3f46; }
-    .dark .proposal-autosave { color: #a1a1aa; }
+      /* Bookmark Button */
+      .bookmark-btn {
+        transition: all 0.2s;
+        font-size: 1.25rem;
+      }
+      .bookmark-btn.active {
+        color: #f59e0b;
+      }
+      .bookmark-btn:hover {
+        transform: scale(1.2);
+      }
 
-    /* Light mode - Language pills active state */
-    .pill.active {
-      background: rgba(157, 67, 0, 0.1) !important;
-      border-color: #9d4300 !important;
-      color: #9d4300 !important;
-      font-weight: 600;
-    }
+      /* Base mobile-first styles */
+      body {
+        width: 100%;
+        overflow-x: hidden;
+      }
+      html {
+        width: 100%;
+        scroll-behavior: smooth;
+      }
 
-    /* Dark mode - Filter chips & language pills */
-    .dark .bg-surface-container-highest { background: #27272a !important; color: #d4d4d8 !important; }
-    .dark .filter-chip:not(.bg-orange-600) { background: #27272a !important; color: #d4d4d8 !important; border: 1px solid #3f3f46 !important; }
-    .dark .filter-chip:not(.bg-orange-600):hover { background: #fb923c !important; color: #ffffff !important; border-color: #fb923c !important; }
+      /* Scroll offset for fixed header */
+      #timeline,
+      #orgs,
+      #guide,
+      #watchlist,
+      #issues,
+      #mentors,
+      #contact {
+        scroll-margin-top: 80px;
+      }
 
-    /* Dark mode - Language tag pills */
-    .dark section .flex.flex-wrap.gap-2 > button:not(.filter-chip) { 
-      background: #27272a !important; 
-      color: #d4d4d8 !important; 
-      border-color: #3f3f46 !important; 
-    }
-    .dark section .flex.flex-wrap.gap-2 > button:not(.filter-chip):hover { 
-      border-color: #f97316 !important; 
-      color: #f97316 !important; 
-    }
-    /* Higher-specificity rule beats .dark section .flex.flex-wrap.gap-2 > button:not(.filter-chip) (0,5,2) */
-    .dark .pill.active,
-    .dark section .flex.flex-wrap.gap-2 > button.pill.active {
-      background: rgba(251, 146, 60, 0.2) !important;
-      border-color: #fb923c !important;
-      color: #fb923c !important;
-    }
-    
-    /* Dark mode - Issue card badges */
-    .dark .bg-green-100 { background: #14532d !important; }
-    .dark .bg-zinc-100 { background: #27272a !important; }
-    .dark .text-green-700 { color: #4ade80 !important; }
-    .dark .text-green-800 { color: #86efac !important; }
-    .dark .text-green-600 { color: #4ade80 !important; }
-    .dark .text-zinc-600 { color: #a1a1aa !important; }
-    
-    /* Dark mode - Card hover effects */
-    .dark .group:hover { background: #1f1f23 !important; border-color: rgba(249, 115, 22, 0.3) !important; box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.4) !important; }
-    .dark .group:hover .text-on-surface { color: #f97316 !important; }
-    .dark .group-hover\:text-primary:hover, .dark .group:hover .group-hover\:text-primary { color: #f97316 !important; }
-    
-    /* Dark mode - Tech tags */
-    .dark .tech-tag { background: #27272a; color: #d4d4d8; border-color: #3f3f46; }
-    .dark .fit-tag { background: #1e293b; color: #93c5fd; border-color: #334155; }
-    .dark .mentor-link-chip { background: rgba(124,45,18,0.72); color: #fff7ed; border-color: rgba(251,146,60,0.45); }
-    .dark .mentor-handle-chip { background: #27272a; color: #d4d4d8; border-color: #3f3f46; }
-    .dark .mentor-card, .dark .mentor-empty { background:#18181b; border-color:#3f3f46; }
+      /* Minimal dark-mode support */
+      .dark body {
+        background: #0f0f10;
+        color: #e5e7eb;
+      }
+      .dark .glass {
+        background: rgba(24, 24, 27, 0.85);
+      }
+      .dark .bg-white {
+        background: #18181b !important;
+      }
+      .dark .bg-surface-container-low {
+        background: #27272a !important;
+        color: #d4d4d8 !important;
+      }
+      .dark .text-zinc-900 {
+        color: #f4f4f5 !important;
+      }
+      .dark .text-zinc-600,
+      .dark .text-zinc-500,
+      .dark .text-zinc-400 {
+        color: #a1a1aa !important;
+      }
+      .dark .text-zinc-300 {
+        color: #a1a1aa !important;
+      }
+      .dark .text-on-surface {
+        color: #f4f4f5 !important;
+      }
+      .dark .text-on-surface-variant {
+        color: #a1a1aa !important;
+      }
+      .dark .border-zinc-100 {
+        border-color: #3f3f46 !important;
+      }
+      .dark .border-zinc-200 {
+        border-color: #3f3f46 !important;
+      }
+      .dark #timeline-milestones .bg-zinc-200 {
+        background-color: #3f3f46 !important;
+      }
+      .dark .hover\:bg-zinc-100\/50:hover {
+        background: rgba(63, 63, 70, 0.45) !important;
+      }
+      .dark .proposal-workspace {
+        background: #18181b;
+      }
+      .dark .proposal-header {
+        background: #0f0f10;
+        border-color: #27272a;
+      }
+      .dark .proposal-editor {
+        background: #18181b;
+        border-color: #27272a;
+      }
+      .dark .proposal-preview {
+        background: #1f1f23;
+        color: #d4d4d8;
+      }
+      .dark .proposal-textarea {
+        color: #d4d4d8;
+      }
+      .dark .proposal-preview code {
+        background: #3f3f46;
+        color: #f4f4f5;
+      }
+      .dark .proposal-preview pre {
+        background: #27272a;
+      }
+      .dark .proposal-preview blockquote {
+        border-color: #3f3f46;
+        color: #a1a1aa;
+      }
+      .dark .proposal-btn {
+        background: #27272a;
+        color: #e5e7eb;
+        border-color: #3f3f46;
+      }
+      .dark .proposal-btn:hover {
+        background: #3f3f46;
+      }
+      .dark .proposal-autosave {
+        color: #a1a1aa;
+      }
 
-    @media (max-width: 640px) {
-      .modal-header { padding: 2rem 1.5rem 1rem; }
-      .modal-body { padding: 0 1.5rem 2rem; }
-      .modal-footer { padding: 1.5rem; flex-direction: column; }
-      .modal-cta { width: 100%; }
-    }
-    
-    /* Dark mode - Modal */
-    .dark .modal { background: #18181b; }
-    .dark .modal-header h2 { color: #f4f4f5; }
-    .dark .modal-header p { color: #a1a1aa; }
-    .dark .section-title { color: #a1a1aa; border-color: #27272a; }
-    .dark .metric-card { background: #27272a; border-color: #3f3f46; }
-    .dark .metric-value { color: #f4f4f5; }
-    .dark .metric-label { color: #a1a1aa; }
-    .dark .close-btn { background: #27272a; color: #a1a1aa; }
-    .dark .close-btn:hover { background: #3f3f46; color: #f4f4f5; }
-    .dark .modal-footer { background: #0f0f10; border-color: #27272a; }
-    .dark .modal-repo-link { background: #27272a; color: #e5e7eb; border-color: #3f3f46; }
-    .dark .modal-repo-link:hover { background: #3f3f46; }
-    .dark #compareModalBody { color: #e5e7eb; }
-    .dark #compareModalBody .text-zinc-700 { color: #e5e7eb !important; }
-    .dark #compareModalBody .text-zinc-500 { color: #a1a1aa !important; }
-    .dark #compareModalBody .text-zinc-400 { color: #d4d4d8 !important; }
+      /* Light mode - Language pills active state */
+      .pill.active {
+        background: rgba(157, 67, 0, 0.1) !important;
+        border-color: #9d4300 !important;
+        color: #9d4300 !important;
+        font-weight: 600;
+      }
 
-    /* Dark mode - Guide section cards */
-    .dark #guide article { background: #18181b !important; border-color: #3f3f46 !important; }
-    .dark #guide article h3 { color: #f4f4f5 !important; }
-    .dark #guide article p, .dark #guide article li { color: #a1a1aa !important; }
-    .dark #guide details { border-color: #3f3f46 !important; }
-    .dark #guide details summary { color: #f4f4f5 !important; }
-    .dark #guide a.block { border-color: #3f3f46 !important; }
-    .dark #guide a.block:hover { background: rgba(249, 115, 22, 0.1) !important; }
-    .dark #guide .font-mono { background: #27272a !important; color: #d4d4d8 !important; }
+      /* Dark mode - Filter chips & language pills */
+      .dark .bg-surface-container-highest {
+        background: #27272a !important;
+        color: #d4d4d8 !important;
+      }
+      .dark .filter-chip:not(.bg-orange-600) {
+        background: #27272a !important;
+        color: #d4d4d8 !important;
+        border: 1px solid #3f3f46 !important;
+      }
+      .dark .filter-chip:not(.bg-orange-600):hover {
+        background: #fb923c !important;
+        color: #ffffff !important;
+        border-color: #fb923c !important;
+      }
 
-    /* Dark mode - Mobile menu */
-    .dark #mobileMenu #menuPanel { background: #18181b !important; border-right: 1px solid #3f3f46; }
-    .dark #mobileMenu .border-zinc-100 { border-color: #3f3f46 !important; }
-    .dark #mobileMenu .text-zinc-900 { color: #f4f4f5 !important; }
-    .dark #mobileMenu .text-zinc-700 { color: #e5e7eb !important; }
-    .dark #mobileMenu .hover\:bg-zinc-100:hover { background: #27272a !important; }
-    .dark #mobileMenu .bg-orange-50 { background: rgba(249, 115, 22, 0.15) !important; }
+      /* Dark mode - Language tag pills */
+      .dark section .flex.flex-wrap.gap-2 > button:not(.filter-chip) {
+        background: #27272a !important;
+        color: #d4d4d8 !important;
+        border-color: #3f3f46 !important;
+      }
+      .dark section .flex.flex-wrap.gap-2 > button:not(.filter-chip):hover {
+        border-color: #f97316 !important;
+        color: #f97316 !important;
+      }
+      /* Higher-specificity rule beats .dark section .flex.flex-wrap.gap-2 > button:not(.filter-chip) (0,5,2) */
+      .dark .pill.active,
+      .dark section .flex.flex-wrap.gap-2 > button.pill.active {
+        background: rgba(251, 146, 60, 0.2) !important;
+        border-color: #fb923c !important;
+        color: #fb923c !important;
+      }
 
-    /* Badge Notification Toast */
-    .badge-notification {
-      position: fixed;
-      bottom: 24px;
-      right: 24px;
-      background: linear-gradient(135deg, #f97316 0%, #fb923c 100%);
-      color: white;
-      padding: 16px 20px;
-      border-radius: 16px;
-      box-shadow: 0 10px 40px rgba(249, 115, 22, 0.4);
-      z-index: 9999;
-      transform: translateX(400px);
-      opacity: 0;
-      transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
-      max-width: 320px;
-    }
-    .badge-notification.show {
-      transform: translateX(0);
-      opacity: 1;
-    }
-    .badge-notification-content {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-    }
-    .badge-notification-icon {
-      font-size: 32px;
-      animation: badgePulse 0.6s ease-out;
-    }
-    @keyframes badgePulse {
-      0%, 100% { transform: scale(1); }
-      50% { transform: scale(1.2); }
-    }
-    .badge-notification-text {
-      flex: 1;
-    }
-    .badge-notification-title {
-      font-size: 14px;
-      font-weight: 800;
-      margin-bottom: 2px;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-    }
-    .badge-notification-desc {
-      font-size: 13px;
-      font-weight: 600;
-      margin-bottom: 2px;
-    }
-    .badge-notification-progress {
-      font-size: 11px;
-      opacity: 0.9;
-    }
+      /* Dark mode - Issue card badges */
+      .dark .bg-green-100 {
+        background: #14532d !important;
+      }
+      .dark .bg-zinc-100 {
+        background: #27272a !important;
+      }
+      .dark .text-green-700 {
+        color: #4ade80 !important;
+      }
+      .dark .text-green-800 {
+        color: #86efac !important;
+      }
+      .dark .text-green-600 {
+        color: #4ade80 !important;
+      }
+      .dark .text-zinc-600 {
+        color: #a1a1aa !important;
+      }
 
-    /* Badge Display in Analytics Panel */
-    .badge-card {
-      background: linear-gradient(135deg, #fff7ed 0%, #ffedd5 100%);
-      border: 2px solid #fed7aa;
-      border-radius: 12px;
-      padding: 12px;
-      text-align: center;
-      transition: all 0.2s;
-    }
-    .badge-card:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 4px 12px rgba(249, 115, 22, 0.2);
-    }
-    .badge-icon {
-      font-size: 32px;
-      margin-bottom: 6px;
-      display: block;
-    }
-    .badge-name {
-      font-size: 12px;
-      font-weight: 700;
-      color: #9d4300;
-      margin-bottom: 4px;
-    }
-    .badge-level {
-      font-size: 10px;
-      font-weight: 600;
-      color: #c2410c;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-    }
-    .badge-progress {
-      margin-top: 6px;
-      height: 4px;
-      background: rgba(157, 67, 0, 0.2);
-      border-radius: 2px;
-      overflow: hidden;
-    }
-    .badge-progress-fill {
-      height: 100%;
-      background: linear-gradient(90deg, #f97316, #fb923c);
-      transition: width 0.3s ease;
-    }
-    .badge-count {
-      font-size: 11px;
-      color: #92600A;
-      margin-top: 4px;
-    }
-    .badge-locked {
-      opacity: 0.5;
-      filter: grayscale(1);
-    }
-    .badge-indicator {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 4px 12px;
-      background: linear-gradient(135deg, #fff7ed, #ffedd5);
-      border: 1.5px solid #fed7aa;
-      border-radius: 100px;
-      font-size: 12px;
-      font-weight: 700;
-      color: #9d4300;
-    }
+      /* Dark mode - Card hover effects */
+      .dark .group:hover {
+        background: #1f1f23 !important;
+        border-color: rgba(249, 115, 22, 0.3) !important;
+        box-shadow:
+          0 20px 25px -5px rgba(0, 0, 0, 0.4),
+          0 8px 10px -6px rgba(0, 0, 0, 0.4) !important;
+      }
+      .dark .group:hover .text-on-surface {
+        color: #f97316 !important;
+      }
+      .dark .group-hover\:text-primary:hover,
+      .dark .group:hover .group-hover\:text-primary {
+        color: #f97316 !important;
+      }
 
-    /* Dark mode - Badges */
-    .dark .badge-notification {
-      background: linear-gradient(135deg, #c2410c 0%, #ea580c 100%);
-    }
-    .dark .badge-card {
-      background: linear-gradient(135deg, #1c0f05 0%, #2a1508 100%);
-      border-color: #3a1f0a;
-    }
-    .dark .badge-name {
-      color: #fb923c;
-    }
-    .dark .badge-level {
-      color: #fdba74;
-    }
-    .dark .badge-count {
-      color: #fb923c;
-    }
-    .dark .badge-progress {
-      background: rgba(251, 146, 60, 0.2);
-    }
-    .dark .badge-indicator {
-      background: linear-gradient(135deg, #1c0f05, #2a1508);
-      border-color: #3a1f0a;
-      color: #fb923c;
-    }
+      /* Dark mode - Tech tags */
+      .dark .tech-tag {
+        background: #27272a;
+        color: #d4d4d8;
+        border-color: #3f3f46;
+      }
+      .dark .fit-tag {
+        background: #1e293b;
+        color: #93c5fd;
+        border-color: #334155;
+      }
+      .dark .mentor-link-chip {
+        background: rgba(124, 45, 18, 0.72);
+        color: #fff7ed;
+        border-color: rgba(251, 146, 60, 0.45);
+      }
+      .dark .mentor-handle-chip {
+        background: #27272a;
+        color: #d4d4d8;
+        border-color: #3f3f46;
+      }
+      .dark .mentor-card,
+      .dark .mentor-empty {
+        background: #18181b;
+        border-color: #3f3f46;
+      }
 
-    /* Header dark mode */
-    .dark header { background: rgba(24, 24, 27, 0.85) !important; border-bottom: 1px solid #3f3f46; }
-    .dark header .text-zinc-900 { color: #f4f4f5 !important; }
-    .dark header .text-zinc-600 { color: #a1a1aa !important; }
-    .dark header .hover\:text-zinc-900:hover { color: #f4f4f5 !important; }
-    .dark header .hover\:bg-zinc-100\/50:hover { background: rgba(39, 39, 42, 0.5) !important; }
+      @media (max-width: 640px) {
+        .modal-header {
+          padding: 2rem 1.5rem 1rem;
+        }
+        .modal-body {
+          padding: 0 1.5rem 2rem;
+        }
+        .modal-footer {
+          padding: 1.5rem;
+          flex-direction: column;
+        }
+        .modal-cta {
+          width: 100%;
+        }
+      }
 
-    /* Selected Languages Strip */
-    #selectedLangsStrip {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: 8px;
-      min-height: 32px;
-    }
-    #selectedLangsStrip .empty-state {
-      color: #888;
-      font-style: italic;
-      font-size: 12px;
-    }
-    .selected-lang-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 4px 10px 4px 12px;
-      background: #fff4ec;
-      border: 1.5px solid #ffe0c8;
-      border-radius: 100px;
-      font-size: 12px;
-      font-weight: 600;
-      color: #d45800;
-    }
-    .unselect-lang-btn {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 16px;
-      height: 16px;
-      border-radius: 50%;
-      border: none;
-      background: #ffe0c8;
-      color: #d45800;
-      font-size: 14px;
-      font-weight: 700;
-      cursor: pointer;
-      padding: 0;
-      margin-left: 2px;
-    }
-    .unselect-lang-btn:hover {
-      background: #f46b0e;
-      color: white;
-    }
-    .clear-all-langs-btn {
-      display: inline-flex;
-      align-items: center;
-      padding: 4px 12px;
-      background: transparent;
-      border: 1.5px dashed #ddd;
-      border-radius: 100px;
-      font-size: 11px;
-      font-weight: 600;
-      color: #888;
-      cursor: pointer;
-    }
-    .clear-all-langs-btn:hover {
-      border-color: #f46b0e;
-      color: #f46b0e;
-      background: #fff4ec;
-    }
-    /* Dark mode */
-    .dark #selectedLangsStrip .empty-state { color: #8a6a45; }
-    .dark .selected-lang-badge {
-      background: #1c0f05;
-      border-color: #2a1508;
-      color: #f97316;
-    }
-    .dark .unselect-lang-btn {
-      background: #2a1508;
-      color: #f97316;
-    }
-    .dark .unselect-lang-btn:hover {
-      background: #fb923c;
-      color: white;
-    }
-    .dark .clear-all-langs-btn {
-      border-color: #2e1e0a;
-      color: #8a6a45;
-    }
-    .dark .clear-all-langs-btn:hover {
-      border-color: #f97316;
-      color: #fb923c;
-      background: #1c0f05;
-    }
-  </style>
-  <link rel="manifest" href="manifest.json" />
-  <meta name="theme-color" content="#F46B0E" />
-  <link rel="apple-touch-icon" href="src/assets/icon-512.png" />
-  <meta name="mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-title" content="FindMyGSoC" />
-</head>
-<body class="bg-background text-on-surface font-body antialiased">
+      /* Dark mode - Modal */
+      .dark .modal {
+        background: #18181b;
+      }
+      .dark .modal-header h2 {
+        color: #f4f4f5;
+      }
+      .dark .modal-header p {
+        color: #a1a1aa;
+      }
+      .dark .section-title {
+        color: #a1a1aa;
+        border-color: #27272a;
+      }
+      .dark .metric-card {
+        background: #27272a;
+        border-color: #3f3f46;
+      }
+      .dark .metric-value {
+        color: #f4f4f5;
+      }
+      .dark .metric-label {
+        color: #a1a1aa;
+      }
+      .dark .close-btn {
+        background: #27272a;
+        color: #a1a1aa;
+      }
+      .dark .close-btn:hover {
+        background: #3f3f46;
+        color: #f4f4f5;
+      }
+      .dark .modal-footer {
+        background: #0f0f10;
+        border-color: #27272a;
+      }
+      .dark .modal-repo-link {
+        background: #27272a;
+        color: #e5e7eb;
+        border-color: #3f3f46;
+      }
+      .dark .modal-repo-link:hover {
+        background: #3f3f46;
+      }
+      .dark #compareModalBody {
+        color: #e5e7eb;
+      }
+      .dark #compareModalBody .text-zinc-700 {
+        color: #e5e7eb !important;
+      }
+      .dark #compareModalBody .text-zinc-500 {
+        color: #a1a1aa !important;
+      }
+      .dark #compareModalBody .text-zinc-400 {
+        color: #d4d4d8 !important;
+      }
 
-<!-- ═══════════════════ NAVBAR ═══════════════════ -->
-<header class="fixed top-0 w-full z-50 bg-white/80 glass shadow-sm">
-  <div class="flex items-center justify-between px-4 sm:px-6 py-3 max-w-7xl mx-auto w-full">
-    <div class="flex items-center gap-3 sm:gap-4 md:gap-8">
-      <!-- Hamburger menu button (mobile only) -->
-      <button id="menuBtn" onclick="toggleMenu()" class="inline-flex md:hidden shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
-        <span class="material-symbols-outlined text-zinc-600">menu</span>
-      </button>
-      
-      <a href="#timeline" class="flex items-center gap-2" id="logoLink">
-        <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center flex-shrink-0">
-          <span class="text-white font-bold text-sm">G</span>
-        </div>
-      <span class="text-base sm:text-lg font-extrabold tracking-tight text-zinc-900 font-headline whitespace-nowrap">
-        <span class="hidden sm:inline">GSoC 2026 </span>
-        <span class="text-primary italic">Org Finder</span>
-      </span>
-      </a>
-      <nav class="hidden md:flex items-center gap-6 text-sm font-medium">
-        <a class="desktop-nav-link text-orange-600 font-bold border-b-2 border-orange-600 transition-colors" href="#timeline" data-section="timeline">Timeline</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#orgs" data-section="orgs">Organizations</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#ai-recommender" data-section="ai-recommender">AI Recommender</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#watchlist" data-section="watchlist">Watchlist</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#issues" data-section="issues">Issues</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#mentors" data-section="mentors">Mentors</a>
-      </nav>
-    </div>
-    
-    <!-- Right side: Toggle visible on all screens, GitHub button hidden on mobile -->
-    <div class="flex items-center gap-2 sm:gap-3">
-    
-      <button id="themeToggleBtn" onclick="toggleTheme()"
-        class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-full transition-colors"
-        aria-label="Switch to dark theme" aria-pressed="false" title="Switch to dark theme">
-    
-        <span class="material-symbols-outlined text-zinc-600">
-          dark_mode
-        </span>
-      </button>
-    
-      <!-- ANALYTICS BUTTON -->
-      <button id="analyticsBtn" onclick="openAnalytics()"
-        class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-full transition-colors"
-        title="View Analytics & Badges"
-        aria-label="View Analytics and Badges">
-    
-        <span class="material-symbols-outlined text-zinc-600">
-          analytics
-        </span>
-      </button>
-    
-      <!-- HELP BUTTON -->
-      <button id="helpBtn"
-        class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-full transition-colors"
-        title="Keyboard shortcuts (?)">
-    
-        <span class="material-symbols-outlined text-zinc-600">
-          help
-        </span>
-      </button>
-    
-      <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer"
-        class="hidden sm:flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-900 text-white text-xs font-bold hover:bg-zinc-700 transition-colors">
-    
-        <span class="material-symbols-outlined text-sm">
-          star
-        </span>
-    
-        Star & Contribute
-      </a>
-    
-    </div>
-  </div>
-</header>
+      /* Dark mode - Guide section cards */
+      .dark #guide article {
+        background: #18181b !important;
+        border-color: #3f3f46 !important;
+      }
+      .dark #guide article h3 {
+        color: #f4f4f5 !important;
+      }
+      .dark #guide article p,
+      .dark #guide article li {
+        color: #a1a1aa !important;
+      }
+      .dark #guide details {
+        border-color: #3f3f46 !important;
+      }
+      .dark #guide details summary {
+        color: #f4f4f5 !important;
+      }
+      .dark #guide a.block {
+        border-color: #3f3f46 !important;
+      }
+      .dark #guide a.block:hover {
+        background: rgba(249, 115, 22, 0.1) !important;
+      }
+      .dark #guide .font-mono {
+        background: #27272a !important;
+        color: #d4d4d8 !important;
+      }
 
-<!-- Mobile Menu Overlay -->
-<div id="mobileMenu" class="fixed inset-0 z-40 hidden" role="dialog" aria-modal="true" aria-label="Navigation menu">
-  <!-- Backdrop -->
-  <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" onclick="toggleMenu()" onkeydown="if(event.key==='Enter'||event.key===' ')toggleMenu()" tabindex="0" role="button" aria-label="Close menu"></div>
-  
-  <!-- Menu Panel -->
-  <nav class="absolute top-0 left-0 bottom-0 w-72 bg-white shadow-2xl transform transition-transform duration-300 ease-out -translate-x-full" id="menuPanel" aria-label="Main navigation">
-    <div class="flex items-center justify-between p-6 border-b border-zinc-100">
-      <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center">
-          <span class="text-white font-bold text-sm">G</span>
-        </div>
-        <span class="font-extrabold tracking-tight text-zinc-900">Menu</span>
-      </div>
-      <button onclick="toggleMenu()" class="p-2 hover:bg-zinc-100 rounded-lg transition-colors">
-        <span class="material-symbols-outlined text-zinc-600">close</span>
-      </button>
-    </div>
-    
-    <div class="p-4 space-y-1">
-      <a href="#timeline" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="timeline">
-        <span class="material-symbols-outlined text-lg">schedule</span>
-        Timeline
-      </a>
-      <a href="#orgs" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="orgs">
-        <span class="material-symbols-outlined text-lg">business</span>
-        Organizations
-      </a>
-      <a href="#ai-recommender" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="ai-recommender">
-        <span class="material-symbols-outlined text-lg">auto_awesome</span>
-        AI Recommender
-      </a>
-      <a href="#watchlist" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="watchlist">
-        <span class="material-symbols-outlined text-lg">bookmark</span>
-        Watchlist
-      </a>
-      <a href="#issues" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="issues">
-        <span class="material-symbols-outlined text-lg">bug_report</span>
-        Issues
-      </a>
-      <a href="#mentors" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="mentors">
-        <span class="material-symbols-outlined text-lg">group</span>
-        Mentors
-      </a>
-      <a href="#guide" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="guide">
-        <span class="material-symbols-outlined text-lg">menu_book</span>
-        Guide
-      </a>
-    </div>
-    
-    <div class="absolute bottom-0 left-0 right-0 p-4 border-t border-zinc-100">
-      <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer" class="flex items-center justify-center gap-2 w-full px-4 py-3 rounded-lg bg-zinc-900 text-white text-sm font-bold hover:bg-zinc-700 transition-colors">
-        <span class="material-symbols-outlined text-base">star</span> Star & Contribute
-      </a>
-    </div>
-  </nav>
-</div>
+      /* Dark mode - Mobile menu */
+      .dark #mobileMenu #menuPanel {
+        background: #18181b !important;
+        border-right: 1px solid #3f3f46;
+      }
+      .dark #mobileMenu .border-zinc-100 {
+        border-color: #3f3f46 !important;
+      }
+      .dark #mobileMenu .text-zinc-900 {
+        color: #f4f4f5 !important;
+      }
+      .dark #mobileMenu .text-zinc-700 {
+        color: #e5e7eb !important;
+      }
+      .dark #mobileMenu .hover\:bg-zinc-100:hover {
+        background: #27272a !important;
+      }
+      .dark #mobileMenu .bg-orange-50 {
+        background: rgba(249, 115, 22, 0.15) !important;
+      }
 
-<!-- ═══════════════════ HERO ═══════════════════ -->
-<section class="pt-20 sm:pt-28 pb-12 sm:pb-20 px-4 sm:px-6 max-w-7xl mx-auto fade-up">
-  <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-center"> 
-    <div class="lg:col-span-7">
-      <div class="inline-flex items-center gap-2 px-3 sm:px-4 py-1.5 rounded-full bg-orange-50 border border-orange-100 text-primary mb-6 sm:mb-8">
-        <span class="material-symbols-outlined text-sm icon-fill" style="color:#f97316">verified</span>
-        <span class="font-label text-[10px] sm:text-xs uppercase font-bold tracking-widest">Google Summer of Code 2026</span>
-      </div>
-      <h1 class="text-4xl sm:text-5xl md:text-7xl font-extrabold font-headline tracking-tighter text-zinc-900 mb-4 sm:mb-6 leading-[0.95]">
-        Find Your<br/><span class="text-primary italic">Perfect GSoC Org</span>
-      </h1>
-      <p class="text-base sm:text-lg text-zinc-600 max-w-xl mb-8 sm:mb-10 leading-relaxed">
-        Browse all <strong>184</strong> organizations. Filter by language, domain, competition, and live GitHub activity. Land your summer internship.
-      </p>
-      <!-- Search Bar -->
-      <div class="relative max-w-xl mb-6 sm:mb-8">
-        <span class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400">search</span>
-        <input id="hero-search" type="text" placeholder="Search organization names..." aria-label="Search GSoC 2026 organizations" class="w-full bg-white border-2 border-zinc-100 rounded-2xl py-3 sm:py-4 pl-12 pr-4 text-sm font-medium focus:ring-2 focus:ring-primary/30 focus:border-primary/40 transition-all shadow-lg shadow-zinc-200/50" />
-      </div>
-      <!-- Surprise Button -->
-      <div class="mb-8 sm:mb-10">
-        <button id="surpriseBtn" class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-primary to-primary-container text-white rounded-full text-sm font-bold hover:shadow-lg hover:scale-105 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:ring-offset-2" aria-label="🎲 Surprise Me! - Open a random organization">
-          <span class="material-symbols-outlined text-sm">casino</span>
-          🎲 Surprise Me!
-        </button>
-      </div>
-      <!-- Stat Badges -->
-      <div class="flex flex-wrap gap-3 sm:gap-4">
-        <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
-          <span class="material-symbols-outlined text-primary text-lg">groups</span>
-          <div><p class="text-[10px] sm:text-xs text-zinc-500">Total Orgs</p><p class="font-bold text-sm">184</p></div>
-        </div>
-        <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
-          <span class="material-symbols-outlined text-secondary text-lg">code</span>
-          <div><p class="text-[10px] sm:text-xs text-zinc-500">Languages</p><p class="font-bold text-sm">30+</p></div>
-        </div>
-        <div class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm">
-          <span class="material-symbols-outlined text-primary-container text-lg">category</span>
-          <div><p class="text-[10px] sm:text-xs text-zinc-500">Domains</p><p class="font-bold text-sm">15+</p></div>
-        </div>
-      </div>
-    </div>
-    <!-- Timeline Card -->
-    <div id="timeline" class="lg:col-span-5 fade-up" style="animation-delay:.2s">
-      <div class="bg-white rounded-2xl sm:rounded-3xl p-6 sm:p-8 shadow-2xl shadow-zinc-200/50 border border-zinc-100">
-        <div class="flex items-center justify-between mb-6 sm:mb-8">
-          <h3 class="font-headline font-extrabold text-lg sm:text-xl">2026 Timeline</h3>
-          <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-[10px] font-bold uppercase tracking-wider">Live</span>
-        </div>
-        <div id="timeline-milestones" class="space-y-4 sm:space-y-5"></div>
-        <div class="mt-5 sm:mt-6 pt-5 sm:pt-6 border-t border-zinc-100">
-          <div class="flex items-center justify-between">
-            <span class="text-xs text-zinc-500" id="countdown-label">Next milestone</span>
-            <span id="countdown" class="font-mono text-sm font-bold text-primary">--d --h --m</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
+      /* Badge Notification Toast */
+      .badge-notification {
+        position: fixed;
+        bottom: 24px;
+        right: 24px;
+        background: linear-gradient(135deg, #f97316 0%, #fb923c 100%);
+        color: white;
+        padding: 16px 20px;
+        border-radius: 16px;
+        box-shadow: 0 10px 40px rgba(249, 115, 22, 0.4);
+        z-index: 9999;
+        transform: translateX(400px);
+        opacity: 0;
+        transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+        max-width: 320px;
+      }
+      .badge-notification.show {
+        transform: translateX(0);
+        opacity: 1;
+      }
+      .badge-notification-content {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .badge-notification-icon {
+        font-size: 32px;
+        animation: badgePulse 0.6s ease-out;
+      }
+      @keyframes badgePulse {
+        0%,
+        100% {
+          transform: scale(1);
+        }
+        50% {
+          transform: scale(1.2);
+        }
+      }
+      .badge-notification-text {
+        flex: 1;
+      }
+      .badge-notification-title {
+        font-size: 14px;
+        font-weight: 800;
+        margin-bottom: 2px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .badge-notification-desc {
+        font-size: 13px;
+        font-weight: 600;
+        margin-bottom: 2px;
+      }
+      .badge-notification-progress {
+        font-size: 11px;
+        opacity: 0.9;
+      }
 
+      /* Badge Display in Analytics Panel */
+      .badge-card {
+        background: linear-gradient(135deg, #fff7ed 0%, #ffedd5 100%);
+        border: 2px solid #fed7aa;
+        border-radius: 12px;
+        padding: 12px;
+        text-align: center;
+        transition: all 0.2s;
+      }
+      .badge-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(249, 115, 22, 0.2);
+      }
+      .badge-icon {
+        font-size: 32px;
+        margin-bottom: 6px;
+        display: block;
+      }
+      .badge-name {
+        font-size: 12px;
+        font-weight: 700;
+        color: #9d4300;
+        margin-bottom: 4px;
+      }
+      .badge-level {
+        font-size: 10px;
+        font-weight: 600;
+        color: #c2410c;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .badge-progress {
+        margin-top: 6px;
+        height: 4px;
+        background: rgba(157, 67, 0, 0.2);
+        border-radius: 2px;
+        overflow: hidden;
+      }
+      .badge-progress-fill {
+        height: 100%;
+        background: linear-gradient(90deg, #f97316, #fb923c);
+        transition: width 0.3s ease;
+      }
+      .badge-count {
+        font-size: 11px;
+        color: #92600a;
+        margin-top: 4px;
+      }
+      .badge-locked {
+        opacity: 0.5;
+        filter: grayscale(1);
+      }
+      .badge-indicator {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 12px;
+        background: linear-gradient(135deg, #fff7ed, #ffedd5);
+        border: 1.5px solid #fed7aa;
+        border-radius: 100px;
+        font-size: 12px;
+        font-weight: 700;
+        color: #9d4300;
+      }
 
-<!-- ═══════════════════ ORG DIRECTORY ═══════════════════ -->
-<section id="orgs" class="px-6 max-w-7xl mx-auto pb-20">
-  <div class="mb-12">
-    <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Find projects that fit you</span>
-    <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Organizations</h2>
-    <p class="text-zinc-600 dark:text-zinc-400 mt-4 max-w-2xl">Browse and filter GSoC 2026 organizations by tech stack, difficulty level, and interests to discover projects that match your skills and goals.</p>
-  </div>
-  <!-- ═══════════════════ FILTER CHIPS ═══════════════════ -->
-  <div class="mb-6 fade-up" style="animation-delay:.3s">
-    <div class="flex flex-wrap gap-2 mb-4">
-      <button id="chip-veteran" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm">military_tech</span> Veterans Only</button>
-      <button id="chip-newcomer" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm">fiber_new</span> Newcomers</button>
-      <button id="chip-hot" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm">local_fire_department</span> High Competition</button>
-      <button id="chip-chill" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm">sentiment_satisfied</span> Low Competition</button>
-      <button id="chip-active" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm">bolt</span> Actively Maintained</button>
-      <button id="chip-bookmarked" class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"><span class="material-symbols-outlined text-sm icon-fill" style="color:#f59e0b">star</span> Bookmarked</button>
-    </div>
-    <div class="flex flex-wrap gap-2">
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Python" aria-pressed="false" onclick="togglePill(this)">Python</button>
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="JavaScript" aria-pressed="false" onclick="togglePill(this)">JavaScript</button>
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="TypeScript" aria-pressed="false" onclick="togglePill(this)">TypeScript</button>
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="C/C++" aria-pressed="false" onclick="togglePill(this)">C/C++</button>
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Java" aria-pressed="false" onclick="togglePill(this)">Java</button>
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Rust" aria-pressed="false" onclick="togglePill(this)">Rust</button>
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Go" aria-pressed="false" onclick="togglePill(this)">Go</button>
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Ruby" aria-pressed="false" onclick="togglePill(this)">Ruby</button>
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Haskell" aria-pressed="false" onclick="togglePill(this)">Haskell</button>
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Scala" aria-pressed="false" onclick="togglePill(this)">Scala</button>
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="ML/AI" aria-pressed="false" onclick="togglePill(this)">ML/AI</button>
-      <button class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors" data-lang="Robotics" aria-pressed="false" onclick="togglePill(this)">Robotics</button>
-    </div>
-    <div id="selectedLangsStrip" class="mt-3 flex flex-wrap items-center gap-2 min-h-[32px]">
-      <span class="empty-state">No languages selected</span>
-    </div>
-    <div class="mt-2 flex items-center gap-2">
-      <label class="inline-flex items-center gap-2 cursor-pointer select-none">
-        <input id="matchAllLanguagesToggle" type="checkbox" class="rounded border-zinc-300 text-primary focus:ring-primary" aria-describedby="languageLogicHint"/>
-        <span class="text-xs text-zinc-600 font-medium">Match all selected languages </span>
-      </label>
-      <span id="languageLogicHint" 
-        class="text-xs text-primary font-medium italic">
-      </span>
-    </div>
-  </div>
+      /* Dark mode - Badges */
+      .dark .badge-notification {
+        background: linear-gradient(135deg, #c2410c 0%, #ea580c 100%);
+      }
+      .dark .badge-card {
+        background: linear-gradient(135deg, #1c0f05 0%, #2a1508 100%);
+        border-color: #3a1f0a;
+      }
+      .dark .badge-name {
+        color: #fb923c;
+      }
+      .dark .badge-level {
+        color: #fdba74;
+      }
+      .dark .badge-count {
+        color: #fb923c;
+      }
+      .dark .badge-progress {
+        background: rgba(251, 146, 60, 0.2);
+      }
+      .dark .badge-indicator {
+        background: linear-gradient(135deg, #1c0f05, #2a1508);
+        border-color: #3a1f0a;
+        color: #fb923c;
+      }
 
-  <div class="flex flex-wrap items-center justify-between gap-4 mb-8">
-    <p class="font-label text-xs uppercase tracking-widest text-zinc-500">Showing <strong id="orgCount">184</strong> of 184 organizations</p>
-    <div class="flex flex-wrap items-center gap-4">
-      <select id="categoryFilter" aria-label="Filter by category" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-2 focus:ring-zinc-500 focus:outline-none cursor-pointer text-zinc-600">
-        <option value="all">Categories: All</option>
-        <option value="web">Web</option>
-        <option value="programming">Programming</option>
-        <option value="science">Science</option>
-        <option value="os">OS</option>
-        <option value="infra">Infra</option>
-        <option value="security">Security</option>
-        <option value="data">Data</option>
-        <option value="media">Media</option>
-        <option value="other">Other</option>
-      </select>
-      <select id="complexityFilter" aria-label="Filter by complexity" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-2 focus:ring-zinc-500 focus:outline-none cursor-pointer text-zinc-600">
-        <option value="all">Complexity: All</option>
-        <option value="beginner">Beginner</option>
-        <option value="intermediate">Intermediate</option>
-        <option value="advanced">Advanced</option>
-      </select>
-      <select id="sortSelect" aria-label="Sort organizations" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-2 focus:ring-zinc-500 focus:outline-none cursor-pointer text-zinc-600">
-        <option value="alpha">Sort: A-Z</option>
-        <option value="years-desc">Years (High-Low)</option>
-        <option value="years-asc">Years (Low-High)</option>
-        <option value="comp-low">Competition (Chill First)</option>
-        <option value="stars">GitHub Stars</option>
-        <option value="gfi">Good First Issues</option>
-      </select>
-    </div>
-  </div>
-  
-  <!-- Hidden search input for JavaScript compatibility -->
-  <input type="hidden" id="searchInput" />
-  
-  <div class="org-grid grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6" id="orgGrid">
-    <!-- Organizations will be rendered here dynamically -->
-    <div class="col-span-full py-20 text-center animate-pulse">
-      <p class="text-zinc-400 font-headline italic">Loading organization directory...</p>
-    </div>
-  </div>
+      /* Header dark mode */
+      .dark header {
+        background: rgba(24, 24, 27, 0.85) !important;
+        border-bottom: 1px solid #3f3f46;
+      }
+      .dark header .text-zinc-900 {
+        color: #f4f4f5 !important;
+      }
+      .dark header .text-zinc-600 {
+        color: #a1a1aa !important;
+      }
+      .dark header .hover\:text-zinc-900:hover {
+        color: #f4f4f5 !important;
+      }
+      .dark header .hover\:bg-zinc-100\/50:hover {
+        background: rgba(39, 39, 42, 0.5) !important;
+      }
 
-  <!-- Empty State -->
-  <div id="emptyState" class="hidden py-20 text-center animate-fade-up">
-    <div class="text-6xl mb-4">🔍</div>
-    <h3 class="text-2xl font-bold text-zinc-900 dark:text-white mb-2">No organizations match your current filters.</h3>
-    <p class="text-zinc-500 dark:text-zinc-400 mb-8">Try adjusting your search or clearing some filters.</p>
-    <button onclick="clearAllFilters()" class="px-8 py-3 bg-primary text-white rounded-xl font-bold hover:bg-orange-600 transition-colors shadow-lg shadow-primary/20">
-      Clear All Filters
-    </button>
-  </div>
+      /* Selected Languages Strip */
+      #selectedLangsStrip {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px;
+        min-height: 32px;
+      }
+      #selectedLangsStrip .empty-state {
+        color: #888;
+        font-style: italic;
+        font-size: 12px;
+      }
+      .selected-lang-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px 4px 12px;
+        background: #fff4ec;
+        border: 1.5px solid #ffe0c8;
+        border-radius: 100px;
+        font-size: 12px;
+        font-weight: 600;
+        color: #d45800;
+      }
+      .unselect-lang-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        border: none;
+        background: #ffe0c8;
+        color: #d45800;
+        font-size: 14px;
+        font-weight: 700;
+        cursor: pointer;
+        padding: 0;
+        margin-left: 2px;
+      }
+      .unselect-lang-btn:hover {
+        background: #f46b0e;
+        color: white;
+      }
+      .clear-all-langs-btn {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 12px;
+        background: transparent;
+        border: 1.5px dashed #ddd;
+        border-radius: 100px;
+        font-size: 11px;
+        font-weight: 600;
+        color: #888;
+        cursor: pointer;
+      }
+      .clear-all-langs-btn:hover {
+        border-color: #f46b0e;
+        color: #f46b0e;
+        background: #fff4ec;
+      }
+      /* Dark mode */
+      .dark #selectedLangsStrip .empty-state {
+        color: #8a6a45;
+      }
+      .dark .selected-lang-badge {
+        background: #1c0f05;
+        border-color: #2a1508;
+        color: #f97316;
+      }
+      .dark .unselect-lang-btn {
+        background: #2a1508;
+        color: #f97316;
+      }
+      .dark .unselect-lang-btn:hover {
+        background: #fb923c;
+        color: white;
+      }
+      .dark .clear-all-langs-btn {
+        border-color: #2e1e0a;
+        color: #8a6a45;
+      }
+      .dark .clear-all-langs-btn:hover {
+        border-color: #f97316;
+        color: #fb923c;
+        background: #1c0f05;
+      }
+    </style>
+    <link rel="manifest" href="manifest.json" />
+    <meta name="theme-color" content="#F46B0E" />
+    <link rel="apple-touch-icon" href="src/assets/icon-512.png" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-title" content="FindMyGSoC" />
+  </head>
+  <body class="bg-background text-on-surface font-body antialiased">
+    <!-- ═══════════════════ NAVBAR ═══════════════════ -->
+    <header class="fixed top-0 w-full z-50 bg-white/80 glass shadow-sm">
+      <div
+        class="flex items-center justify-between px-4 sm:px-6 py-3 max-w-7xl mx-auto w-full"
+      >
+        <div class="flex items-center gap-3 sm:gap-4 md:gap-8">
+          <!-- Hamburger menu button (mobile only) -->
+          <button
+            id="menuBtn"
+            onclick="toggleMenu()"
+            class="inline-flex md:hidden shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors"
+            aria-label="Open menu"
+            aria-expanded="false"
+            aria-controls="mobileMenu"
+          >
+            <span class="material-symbols-outlined text-zinc-600">menu</span>
+          </button>
 
-  <div class="mt-12 flex justify-center" id="loadMoreContainer" style="display:none">
-    <button id="loadMoreBtn" class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2">
-      View More Organizations <span class="material-symbols-outlined text-lg">expand_more</span>
-    </button>
-  </div>
-</section>
-
-<!-- ═══════════════════ AI RECOMMENDER ═══════════════════ -->
-<section id="ai-recommender" class="px-6 max-w-7xl mx-auto py-20 border-t border-zinc-100 dark:border-zinc-800">
-  <div class="mb-12">
-    <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">AI-Powered</span>
-    <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Personalized Org Suggestions</h2>
-    <p class="text-zinc-600 dark:text-zinc-400 mt-4 max-w-2xl">Enter your GitHub username or paste your resume to get deterministic AI-style organization recommendations tailored to your skills and experience.</p>
-  </div>
-
-  <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
-    <!-- Input Form -->
-    <div class="lg:col-span-4 bg-white dark:bg-[#18181b] p-6 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm h-fit">
-      <div class="space-y-5">
-        <div>
-          <label for="aiGhUsername" class="block text-sm font-bold text-zinc-900 dark:text-zinc-100 mb-1">GitHub Username</label>
-          <div class="relative">
-            <span class="material-symbols-outlined absolute left-3 top-2.5 text-zinc-400 text-sm">person</span>
-            <input type="text" id="aiGhUsername" placeholder="e.g. torvalds" class="w-full pl-9 pr-4 py-2 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm focus:ring-2 focus:ring-primary dark:text-white transition-all">
-          </div>
-          <p class="text-[10px] text-zinc-500 mt-1 ml-1">Used to analyze your repo languages and activity.</p>
-        </div>
-
-        <div>
-          <label for="aiResumeText" class="block text-sm font-bold text-zinc-900 dark:text-zinc-100 mb-1">Resume / Skills</label>
-          <textarea id="aiResumeText" rows="4" placeholder="Paste your resume or list your skills here (e.g. Python, React, Machine Learning)..." class="w-full p-3 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm focus:ring-2 focus:ring-primary dark:text-white transition-all resize-none"></textarea>
-          <div class="mt-2 flex items-center justify-between">
-            <label class="text-xs text-primary font-bold cursor-pointer hover:underline flex items-center gap-1">
-              <span class="material-symbols-outlined text-[14px]">upload_file</span> Upload .txt
-              <input type="file" id="aiResumeFile" accept=".txt" class="hidden">
-            </label>
-          </div>
-        </div>
-
-        <button id="btnGetRecommendations" class="w-full py-3 bg-gradient-to-r from-primary to-primary-container text-white rounded-xl font-bold text-sm shadow-md hover:shadow-lg hover:scale-[1.02] transition-all flex items-center justify-center gap-2">
-          <span class="material-symbols-outlined text-sm">auto_awesome</span> Get Recommendations
-        </button>
-      </div>
-    </div>
-
-    <!-- Results Area -->
-    <div class="lg:col-span-8">
-      <!-- Initial State -->
-      <div id="aiLoadingState" aria-live="polite" class="hidden flex flex-col items-center justify-center py-16 bg-zinc-50 dark:bg-zinc-900/50 rounded-2xl border border-dashed border-zinc-300 dark:border-zinc-700">
-        <div class="w-10 h-10 border-4 border-primary border-t-transparent rounded-full animate-spin mb-4"></div>
-        <p class="text-zinc-600 dark:text-zinc-400 font-bold animate-pulse">Analyzing profile & calculating matches...</p>
-      </div>
-      
-      <!-- Error State -->
-      <div id="aiErrorState" aria-live="assertive" class="hidden bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-2xl p-6 text-center block">
-        <span class="material-symbols-outlined text-red-500 text-4xl mb-2">error</span>
-        <h3 class="text-red-800 dark:text-red-400 font-bold mb-1">Analysis Failed</h3>
-        <p id="aiErrorMsg" class="text-red-600 dark:text-red-300 text-sm"></p>
-      </div>
-
-      <!-- Results Container -->
-      <div id="aiResultsContainer" class="org-grid w-full">
-        <div class="flex flex-col items-center justify-center py-20 text-center text-zinc-400 dark:text-zinc-500">
-          <span class="material-symbols-outlined text-6xl mb-4 opacity-50">magic_button</span>
-          <p class="font-bold">Provide your details to see personalized matches.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════ WATCHLIST ═══════════════════ -->
-<section id="watchlist" class="bg-surface-container-low py-20 px-6">
-  <div class="max-w-7xl mx-auto">
-    <div class="mb-12 flex items-start justify-between gap-4 flex-wrap">
-      <div>
-        <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Scholarly Sandbox</span>
-        <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Watchlist.</h2>
-        <p class="text-zinc-600 mt-4 max-w-2xl">Curate your open-source journey. Track organizations, monitor deadlines, and prepare your proposals for GSoC 2026.</p>
-      </div>
-      <button id="clearAllBookmarksBtn"
-        class="hidden mt-8 flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-red-500 border border-red-200 rounded-full px-4 py-2 hover:bg-red-50 transition-colors"
-        title="Remove all bookmarks">
-        <span class="material-symbols-outlined text-sm">delete_sweep</span>
-        Clear All
-      </button>
-    </div>
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-      <div class="lg:col-span-2 space-y-6">
-        <div id="recentlyViewedSection" class="space-y-4">
-          <div class="flex items-center justify-between gap-3">
-            <div class="flex items-center gap-3 flex-wrap">
-              <h3 class="text-lg font-bold text-zinc-900">Recently Viewed Organizations</h3>
-              <span id="recentlyViewedOverflowBadge" class="hidden rounded-full bg-zinc-100 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-zinc-500">+0</span>
+          <a href="#timeline" class="flex items-center gap-2" id="logoLink">
+            <div
+              class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center flex-shrink-0"
+            >
+              <span class="text-white font-bold text-sm">G</span>
             </div>
-            <button id="clearRecentlyViewedBtn" class="text-xs font-bold uppercase tracking-wider text-zinc-500 hover:text-red-500 transition-colors" aria-label="Clear All recently viewed organizations">Clear All</button>
-          </div>
-          <div id="recentlyViewedContainer" class="space-y-3">
-            <!-- Recently viewed items will be rendered here -->
-          </div>
+            <span
+              class="text-base sm:text-lg font-extrabold tracking-tight text-zinc-900 font-headline whitespace-nowrap"
+            >
+              <span class="hidden sm:inline">GSoC 2026 </span>
+              <span class="text-primary italic">Org Finder</span>
+            </span>
+          </a>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium">
+            <a
+              class="desktop-nav-link text-orange-600 font-bold border-b-2 border-orange-600 transition-colors"
+              href="#timeline"
+              data-section="timeline"
+              >Timeline</a
+            >
+            <a
+              class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors"
+              href="#orgs"
+              data-section="orgs"
+              >Organizations</a
+            >
+            <a
+              class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors"
+              href="#ai-recommender"
+              data-section="ai-recommender"
+              >AI Recommender</a
+            >
+            <a
+              class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors"
+              href="#watchlist"
+              data-section="watchlist"
+              >Watchlist</a
+            >
+            <a
+              class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors"
+              href="#issues"
+              data-section="issues"
+              >Issues</a
+            >
+            <a
+              class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors"
+              href="#mentors"
+              data-section="mentors"
+              >Mentors</a
+            >
+          </nav>
         </div>
 
-        <div class="space-y-4" id="watchlistContainer">
-          <!-- Watchlist items will be rendered here -->
+        <!-- Right side: Toggle visible on all screens, GitHub button hidden on mobile -->
+        <div class="flex items-center gap-2 sm:gap-3">
+          <button
+            id="themeToggleBtn"
+            onclick="toggleTheme()"
+            class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-full transition-colors"
+            aria-label="Switch to dark theme"
+            aria-pressed="false"
+            title="Switch to dark theme"
+          >
+            <span class="material-symbols-outlined text-zinc-600">
+              dark_mode
+            </span>
+          </button>
+
+          <!-- ANALYTICS BUTTON -->
+          <button
+            id="analyticsBtn"
+            onclick="openAnalytics()"
+            class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-full transition-colors"
+            title="View Analytics & Badges"
+            aria-label="View Analytics and Badges"
+          >
+            <span class="material-symbols-outlined text-zinc-600">
+              analytics
+            </span>
+          </button>
+
+          <!-- HELP BUTTON -->
+          <button
+            id="helpBtn"
+            class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-full transition-colors"
+            title="Keyboard shortcuts (?)"
+          >
+            <span class="material-symbols-outlined text-zinc-600"> help </span>
+          </button>
+
+          <a
+            href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="hidden sm:flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-900 text-white text-xs font-bold hover:bg-zinc-700 transition-colors"
+          >
+            <span class="material-symbols-outlined text-sm"> star </span>
+
+            Star & Contribute
+          </a>
         </div>
-      </div>
-      <!-- Sidebar -->
-      <div class="space-y-6">
-        <div class="bg-white rounded-2xl p-6 border border-zinc-100">
-          <h4 class="font-bold mb-4 flex items-center gap-2"><span class="material-symbols-outlined text-primary text-lg">event</span> Upcoming Deadlines</h4>
-          <div class="space-y-4">
-            <div><p class="text-[10px] font-label uppercase tracking-wider text-zinc-400">MAR 31, 2026</p><p class="text-sm font-bold">Proposal Submission Deadline</p><p class="text-xs text-zinc-500">Ensure your final proposals are submitted by 18:00 UTC.</p></div>
-            <div><p class="text-[10px] font-label uppercase tracking-wider text-zinc-400">APR 21, 2026</p><p class="text-sm font-bold">Review Period Starts</p><p class="text-xs text-zinc-500">Mentors begin ranking of proposals.</p></div>
-          </div>
-        </div>
-        <div class="bg-gradient-to-br from-primary to-primary-container text-white rounded-2xl p-6 relative overflow-hidden">
-          <div class="absolute top-0 right-0 p-4 opacity-20"><span class="material-symbols-outlined text-5xl">auto_awesome</span></div>
-          <h4 class="font-bold mb-3">AI Application Insight</h4>
-          <p id="aiInsightText" class="text-sm text-orange-100 leading-relaxed mb-4">Select organizations to get personalized contribution advice.</p>
-          <span class="text-[10px] font-label uppercase tracking-widest text-orange-200">Automated System Advice</span>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════ GOOD FIRST ISSUES ═══════════════════ -->
-<section id="issues" class="py-20 px-6 max-w-7xl mx-auto">
-  <div class="mb-12">
-    <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">First Contributions</span>
-    <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Good First Issues</h2>
-    <p class="text-zinc-600 mt-4 max-w-2xl">Pre-fetched from all GSoC 2026 orgs every 6 hours — no rate limits, no token required, instant results.</p>
-  </div>
-  <!-- Status Banner -->
-  <div id="issuesBanner" class="bg-green-50 border border-green-200 rounded-2xl p-6 mb-8 flex flex-col sm:flex-row items-start sm:items-center gap-4">
-    <div class="flex items-center gap-3">
-      <div class="w-3 h-3 rounded-full bg-green-500 pulse-dot" id="issuesBannerDot"></div>
-      <div>
-        <p class="font-bold text-green-800 text-sm" id="issuesBannerTitle">Pre-fetched Issues Ready</p>
-        <p class="text-xs text-green-600" id="issuesBannerSubtitle">Updated every 6 hours via GitHub Actions — no API rate limits for visitors.</p>
-      </div>
-    </div>
-    <div class="ml-auto text-right">
-      <span id="issuesLastUpdated" class="text-xs font-mono text-green-600">Last updated: pending refresh</span>
-      <span id="issuesStaleNote" class="hidden ml-2 text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2 py-0.5">⏸ GSoC selection complete. Data won't update frequently.</span>
-    </div>
-  </div>
-  <!-- Issue Cards -->
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/rust-lang/rust/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
-      <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
-        <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
-      </div>
-      <p class="text-xs text-zinc-500 mb-3 font-mono">rust-lang/rust</p>
-      <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
-      </div>
-    </div>
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/django/django/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
-      <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
-        <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
-      </div>
-      <p class="text-xs text-zinc-500 mb-3 font-mono">django/django</p>
-      <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
-      </div>
-    </div>
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/tensorflow/tensorflow/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
-      <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
-        <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
-      </div>
-      <p class="text-xs text-zinc-500 mb-3 font-mono">tensorflow/tensorflow</p>
-      <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
-      </div>
-    </div>
-    <div class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card" data-url="https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
-      <div class="flex items-start justify-between mb-3">
-        <h4 class="font-bold text-sm group-hover:text-primary transition-colors">Browse open Good First Issues</h4>
-        <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
-      </div>
-      <p class="text-xs text-zinc-500 mb-3 font-mono">kubernetes/kubernetes</p>
-      <div class="flex flex-wrap gap-1.5">
-        <span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">GitHub search</span>
-        <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════ MENTOR FINDER ═══════════════════ -->
-<section id="mentors" class="py-20 px-6 bg-surface-container-low">
-  <div class="max-w-7xl mx-auto">
-    <div class="mb-12">
-      <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Mentor Outreach</span>
-      <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Mentor Finder</h2>
-      <p class="text-zinc-600 mt-4 max-w-3xl">Pre-fetched contact channels and conservative mentor handles from org ideas pages, so you can find where to introduce yourself before proposal season gets busy.</p>
-    </div>
-
-    <div class="bg-white border border-zinc-100 rounded-2xl p-6 mb-8 flex flex-col sm:flex-row items-start sm:items-center gap-4">
-      <div class="flex items-center gap-3">
-        <div class="w-3 h-3 rounded-full pulse-dot" id="mentorBannerDot" style="background-color:#f97316"></div>
-        <div>
-          <p class="font-bold text-zinc-900 text-sm">Cached mentor contact data</p>
-          <p class="text-xs text-zinc-600">Generated offline by the project workflow to keep scraping out of the browser.</p>
-        </div>
-      </div>
-      <div class="ml-auto text-right">
-        <span id="mentorLastUpdated" class="text-xs font-mono text-zinc-500">Last updated: pending refresh</span>
-        <span id="mentorStaleNote" class="hidden ml-2 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-full px-2 py-0.5">ℹ GSoC selection complete. Data won't update frequently.</span>
-      </div>
-    </div>
-
-    <div class="bg-white rounded-2xl border border-zinc-100 p-6 mb-8">
-      <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_220px] gap-4">
-        <label class="relative block">
-          <span class="material-symbols-outlined absolute left-3 top-3 text-zinc-400 text-sm">search</span>
-          <input id="mentorSearchInput" type="text" placeholder="Search org name or mentor GitHub handle..." class="w-full pl-10 pr-4 py-3 bg-surface-container-low border-none rounded-xl text-sm focus:ring-2 focus:ring-primary" />
-        </label>
-        <select id="mentorChannelFilter" class="bg-surface-container-low border-none rounded-xl text-sm font-medium focus:ring-2 focus:ring-primary text-zinc-700 px-4">
-          <option value="all">All channels</option>
-          <option value="Slack">Slack</option>
-          <option value="Zulip">Zulip</option>
-          <option value="Discord">Discord</option>
-          <option value="Matrix">Matrix</option>
-          <option value="IRC">IRC</option>
-          <option value="Mailing list">Mailing list</option>
-        </select>
-      </div>
-    </div>
-
-    <div id="mentorGrid" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
-      <div class="col-span-full bg-white rounded-2xl border border-zinc-100 p-8 text-center">
-        <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
-      </div>
-    </div>
-
-    <div class="mt-12 flex justify-center" id="loadMoreMentorContainer" style="display:none">
-      <button type="button" id="loadMoreMentorBtn" aria-label="View More Mentors" class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2">
-        View More Mentors <span class="material-symbols-outlined text-lg">expand_more</span>
-      </button>
-    </div>
-  </div>
-</section>
- 
-<!-- ═══════════════════ CONTRIBUTOR GUIDE ═══════════════════ -->
-<section id="guide" class="py-20 px-6 max-w-7xl mx-auto">
-  <div class="mb-12">
-    <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Contributor Guide</span>
-    <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Start Contributing with Confidence</h2>
-    <p class="text-zinc-600 mt-4 max-w-3xl">New to open source or this project? Follow this quick path: learn the basics, set up locally, find a good first issue, and open your first PR.</p>
-  </div>
-
-  <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-    <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm">
-      <h3 class="text-xl font-bold mb-3">1) Open Source Basics</h3>
-      <p class="text-sm text-zinc-600 mb-4 leading-relaxed">Open source projects publish source code publicly so anyone can inspect, improve, and share it. Contribution usually starts with reading contribution guidelines and making small, focused changes.</p>
-      <ul class="space-y-2 text-sm text-zinc-700 list-disc pl-5">
-        <li>Understand how licensing and collaboration work.</li>
-        <li>Start with documentation or beginner-friendly issues.</li>
-        <li>Communicate early through issues and PR comments.</li>
-      </ul>
-    </article>
-
-    <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm">
-      <h3 class="text-xl font-bold mb-3">2) Contribute to a GSoC Organization</h3>
-      <ol class="space-y-2 text-sm text-zinc-700 list-decimal pl-5">
-        <li>Pick 2–3 organizations that match your skills and interests.</li>
-        <li>Read their ideas page, contribution guide, and communication channels.</li>
-        <li>Set up the project locally and start with a small issue or documentation task.</li>
-        <li>Open a focused pull request and respond to mentor feedback quickly.</li>
-        <li>Document your contributions and turn them into a stronger GSoC proposal.</li>
-      </ol>
-      <p class="text-xs text-zinc-500 mt-4">Tip: quality communication and small, consistent contributions usually matter more than a single large PR.</p>
-    </article>
-
-    <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm lg:col-span-2">
-      <h3 class="text-xl font-bold mb-5">3) Useful Resources</h3>
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm">
-        <a href="https://opensource.guide/how-to-contribute/" target="_blank" rel="noopener noreferrer" class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
-          <p class="font-bold mb-1">Open Source Guide</p>
-          <p class="text-zinc-600">Practical guide for first-time and returning contributors.</p>
-        </a>
-        <a href="https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project" target="_blank" rel="noopener noreferrer" class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
-          <p class="font-bold mb-1">GitHub Contribution Flow</p>
-          <p class="text-zinc-600">Official docs for forking, cloning, and opening pull requests.</p>
-        </a>
-        <a href="https://developers.google.com/open-source/gsoc/resources/guide" target="_blank" rel="noopener noreferrer" class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
-          <p class="font-bold mb-1">GSoC Contributor/Student Guide</p>
-          <p class="text-zinc-600">Official program timeline and best practices for applicants.</p>
-        </a>
-        <a href="https://developers.google.com/open-source/gsoc/help/student-advice" target="_blank" rel="noopener noreferrer" class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
-          <p class="font-bold mb-1">Student Advice</p>
-          <p class="text-zinc-600">Official guidance for choosing orgs, communicating well, and writing proposals.</p>
-        </a>
-        <a href="https://firstcontributions.github.io/" target="_blank" rel="noopener noreferrer" class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors">
-          <p class="font-bold mb-1">First Contributions</p>
-          <p class="text-zinc-600">Hands-on tutorial to practice your first fork, commit, and pull request.</p>
-        </a>
-      </div>
-    </article>
-
-    <article class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm lg:col-span-2">
-      <h3 class="text-xl font-bold mb-4">4) FAQ</h3>
-      <div class="space-y-3 text-sm">
-        <details class="group border border-zinc-200 rounded-xl p-4">
-          <summary class="font-semibold cursor-pointer">Do I need prior GSoC experience to contribute?</summary>
-          <p class="text-zinc-600 mt-2">No. Start with small docs or UI fixes, then move to larger tasks as you learn the codebase.</p>
-        </details>
-        <details class="group border border-zinc-200 rounded-xl p-4">
-          <summary class="font-semibold cursor-pointer">What should my first pull request look like?</summary>
-          <p class="text-zinc-600 mt-2">Keep it focused on one change, reference the issue number, and include a short explanation of what you tested.</p>
-        </details>
-        <details class="group border border-zinc-200 rounded-xl p-4">
-          <summary class="font-semibold cursor-pointer">How do I find tasks I can start quickly?</summary>
-          <p class="text-zinc-600 mt-2">Look for issues labeled <span class="font-mono text-xs bg-zinc-100 px-1 py-0.5 rounded">good first issue</span> and comment before starting work.</p>
-        </details>
-      </div>
-    </article>
-  </div>
-</section>
-
-<!-- ═══════════════════ HOW IT WORKS ═══════════════════ -->
-<section class="bg-zinc-900 py-20 px-6">
-  <div class="max-w-7xl mx-auto">
-    <div class="text-center mb-16">
-      <h2 class="text-4xl font-extrabold font-headline tracking-tight text-white mb-4">New to GSoC? Start here.</h2>
-      <p class="text-zinc-400 max-w-2xl mx-auto">Google Summer of Code is a global, online program focused on bringing new contributors into open source software development.</p>
-    </div>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-      <div class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all">
-        <div class="w-14 h-14 rounded-2xl bg-orange-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-primary group-hover:scale-110 transition-transform">1</div>
-        <h3 class="text-xl font-bold text-white mb-3">Explore Organizations</h3>
-        <p class="text-zinc-400 text-sm leading-relaxed">Browse 185+ open source organizations. Filter by language, domain, and competition level to find your match.</p>
-      </div>
-      <div class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all">
-        <div class="w-14 h-14 rounded-2xl bg-blue-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-blue-400 group-hover:scale-110 transition-transform">2</div>
-        <h3 class="text-xl font-bold text-white mb-3">Submit a Proposal</h3>
-        <p class="text-zinc-400 text-sm leading-relaxed">Reach out to mentors and write a detailed proposal outlining how you'll contribute to your chosen project.</p>
-      </div>
-      <div class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all">
-        <div class="w-14 h-14 rounded-2xl bg-green-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-green-400 group-hover:scale-110 transition-transform">3</div>
-        <h3 class="text-xl font-bold text-white mb-3">Start Coding</h3>
-        <p class="text-zinc-400 text-sm leading-relaxed">If accepted, spend your summer coding under the guidance of experienced mentors and earn a stipend of $1,500–$6,600.</p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════ COMPARE ═══════════════════ -->
-<section class="py-20 px-6 max-w-7xl mx-auto">
-  <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-    <div>
-      <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Decision Tool</span>
-      <h2 class="text-4xl font-extrabold font-headline tracking-tighter mt-2 mb-6">Compare Organizations</h2>
-      <p class="text-zinc-600 leading-relaxed mb-8">Select up to 3 orgs to compare side-by-side. See history, mentor count, tech stack, competition level, and active GFIs at a glance.</p>
-      <button onclick="openCompareModal()" class="inline-flex items-center gap-2 px-8 py-4 bg-primary text-white font-bold rounded-xl hover:scale-95 transition-all shadow-lg">
-        <span class="material-symbols-outlined">compare</span> Open Comparison Tool
-      </button>
-    </div>
-    <div id="compare" class="bg-surface-container-low rounded-3xl p-8 border border-zinc-100">
-      <div class="grid grid-cols-3 gap-4 text-center">
-        <div class="bg-white rounded-xl p-4 border border-zinc-100">
-          <div class="w-10 h-10 rounded-lg bg-orange-100 flex items-center justify-center mx-auto mb-3"><span class="material-symbols-outlined text-orange-600">psychology</span></div>
-          <p class="font-bold text-sm">TensorFlow</p><p class="text-[10px] text-zinc-500 font-label uppercase mt-1">15y · 42 mentors</p>
-        </div>
-        <div class="bg-white rounded-xl p-4 border border-zinc-100">
-          <div class="w-10 h-10 rounded-lg bg-amber-100 flex items-center justify-center mx-auto mb-3"><span class="material-symbols-outlined text-amber-600">developer_board</span></div>
-          <p class="font-bold text-sm">Apache</p><p class="text-[10px] text-zinc-500 font-label uppercase mt-1">19y · 64 mentors</p>
-        </div>
-        <div class="bg-white rounded-xl p-4 border border-zinc-100 border-dashed border-zinc-300">
-          <div class="w-10 h-10 rounded-lg bg-zinc-100 flex items-center justify-center mx-auto mb-3"><span class="material-symbols-outlined text-zinc-400">add</span></div>
-          <p class="font-bold text-sm text-zinc-400">Add org</p><p class="text-[10px] text-zinc-400 font-label uppercase mt-1">slot 3</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ═══════════════════ CONTACT ═══════════════════ -->
-<section id="contact" class="py-20 px-6 max-w-7xl mx-auto">
-  <div class="text-center mb-12">
-    <h2 class="text-4xl font-extrabold font-headline tracking-tight mb-4">Get in Touch</h2>
-    <p class="text-zinc-600 max-w-2xl mx-auto">Have questions, feedback, or need help? We'd love to hear from you.</p>
-  </div>
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
-    <a href="https://github.com/S3DFX-CYBER" target="_blank" rel="noopener noreferrer" class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
-      <div class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
-        <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">person</span>
-      </div>
-      <h3 class="font-bold mb-2">GitHub Profile</h3>
-      <p class="text-sm text-zinc-600">Follow the maintainer and check out other projects.</p>
-    </a>
-    <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/issues" target="_blank" rel="noopener noreferrer" class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
-      <div class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
-        <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">bug_report</span>
-      </div>
-      <h3 class="font-bold mb-2">Report Issues</h3>
-      <p class="text-sm text-zinc-600">Found a bug or have a feature request? Open an issue.</p>
-    </a>
-    <a href="https://discord.gg/mgWV3xSV7" target="_blank" rel="noopener noreferrer" class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group">
-      <div class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors">
-        <span class="material-symbols-outlined text-zinc-600 group-hover:text-primary">forum</span>
-      </div>
-      <h3 class="font-bold mb-2">Join Discord</h3>
-      <p class="text-sm text-zinc-600">Connect with the community for discussions and support.</p>
-    </a>
-  </div>
-</section>
-
-<!-- ═══════════════════ FOOTER ═══════════════════ -->
-<footer class="w-full border-t border-zinc-200 bg-zinc-100 pb-48">
-  <div class="flex flex-col md:flex-row justify-between items-center px-8 py-12 gap-6 max-w-7xl mx-auto">
-    <div class="flex flex-col gap-2">
-      <div class="flex items-center gap-2">
-        <div class="w-6 h-6 rounded bg-gradient-to-br from-primary to-primary-container flex items-center justify-center"><span class="text-white font-bold text-[10px]">G</span></div>
-        <span class="text-lg font-bold text-zinc-900">FindMyGSoC</span>
-      </div>
-      <p class="text-[10px] font-bold uppercase tracking-widest text-zinc-400">© 2026 S3DFX-CYBER · Built for the Open Source Community</p>
-    </div>
-    <nav class="flex flex-wrap gap-6" aria-label="Footer navigation">
-          <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://discord.gg/mgWV3xSV7" target="_blank" rel="noopener noreferrer">Community</a>
-          <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://summerofcode.withgoogle.com/programs/2026/organizations" target="_blank" rel="noopener noreferrer">GSoC 2026</a>
-          <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer">GitHub</a>
-          <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="privacy.html">Privacy</a>
-          <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#contact">Contact</a>
-    </nav>
-  </div>
-</footer>
-
-<!-- ═══════════════════ MODAL ═══════════════════ -->
-<div class="modal-bg" id="orgModal">
-  <div class="modal">
-    <button class="close-btn" onclick="closeOrgModal()"><span class="material-symbols-outlined">close</span></button>
-    <div class="modal-header" id="mHeader">
-      <!-- Injected: Category, Name, Tagline -->
-    </div>
-    <div class="modal-body">
-      <div class="metrics-grid mb-8" id="mMetrics">
-        <!-- Injected: Years, Competition, First Year, etc. -->
-      </div>
-      
-      <div class="github-stats-container mb-8">
-        <button class="gh-fetch" id="mFetchBtn">Fetch Live Stats</button>
-        <div class="gh-stat-item"><span class="material-symbols-outlined text-sm">star</span> <span id="mStars">---</span></div>
-        <div class="gh-stat-item"><span class="material-symbols-outlined text-sm">fork_right</span> <span id="mForks">---</span></div>
-        <div class="gh-stat-item"><span class="material-symbols-outlined text-sm">bug_report</span> <span id="mIssues">---</span></div>
-        <div class="gh-stat-item text-blue-400"><span class="material-symbols-outlined text-sm">history</span> <span id="mActivity">Moderate</span></div>
-      </div>
-
-      <div class="section-title">Description</div>
-      <p id="mDesc" class="text-sm text-zinc-600 leading-relaxed mb-6"></p>
-
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-        <div>
-          <div class="section-title">Technologies</div>
-          <div class="tech-tags" id="mTech"></div>
-        </div>
-        <div>
-          <div class="section-title">Ideal Fit</div>
-          <div class="fit-tags" id="mFit"></div>
-        </div>
-      </div>
-
-      <div class="section-title">Participation Timeline</div>
-      <div class="timeline-grid" id="mTimeline"></div>
-
-      <div class="section-title">Mentors &amp; Contact</div>
-      <div id="mMentorSection" class="space-y-4">
-        <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
-      </div>
-    </div>
-    <div class="modal-footer">
-      <button type="button" id="mDraftBtn" class="modal-cta modal-proposal-link flex items-center justify-center gap-2">
-        <span class="material-symbols-outlined text-lg">edit_document</span> Open Proposal Builder
-      </button>
-      <a href="#" target="_blank" rel="noopener noreferrer" id="mIdeasBtn" class="modal-cta modal-ideas-link flex items-center justify-center gap-2">
-        <span class="material-symbols-outlined text-lg">lightbulb</span> Project Ideas
-      </a>
-      <a href="#" target="_blank" rel="noopener noreferrer" id="mRepoBtn" class="modal-cta modal-repo-link flex items-center justify-center gap-2">
-        <span class="material-symbols-outlined text-lg">code</span> Repository
-      </a>
-    </div>
-  </div>
-</div>
-
-<!-- ═══════════════════ PROPOSAL BUILDER ═══════════════════ -->
-<dialog class="proposal-bg" id="proposalModal" aria-labelledby="pwOrgName">
-  <div class="proposal-workspace">
-    <header class="proposal-header">
-      <div class="proposal-header-title">
-        <h2 id="pwOrgName">Organization Proposal</h2>
-        <p id="pwPrivacyNote">Drafts are stored only on this device when autosave is enabled.</p>
-      </div>
-      <label class="proposal-autosave">
-        <input type="checkbox" id="pwAutosaveToggle" aria-describedby="pwPrivacyNote" />
-        Enable autosave
-      </label>
-      <div class="proposal-toolbar">
-        <button type="button" id="pwClearBtn" class="proposal-btn proposal-btn-danger" aria-label="Clear proposal draft">
-          <span class="material-symbols-outlined text-sm">delete</span> Clear
-        </button>
-        <button type="button" id="pwExportMDBtn" class="proposal-btn" aria-label="Export proposal as Markdown">
-          <span class="material-symbols-outlined text-sm">download</span> Markdown
-        </button>
-        <button type="button" id="pwExportPDFBtn" class="proposal-btn proposal-btn-primary" aria-label="Download proposal as PDF">
-          <span class="material-symbols-outlined text-sm">picture_as_pdf</span> PDF
-        </button>
-        <button type="button" id="pwCloseBtn" class="proposal-btn" aria-label="Close proposal builder">
-          <span class="material-symbols-outlined text-sm">close</span> Close
-        </button>
       </div>
     </header>
-    <div class="proposal-body">
-      <div class="proposal-editor">
-        <label for="pwEditor" class="sr-only">Proposal markdown editor</label>
-        <textarea id="pwEditor" class="proposal-textarea" spellcheck="true" aria-label="Proposal markdown editor"></textarea>
-      </div>
-      <div id="pwPreview" class="proposal-preview" aria-live="polite" aria-label="Proposal preview"></div>
-    </div>
-  </div>
-</dialog>
 
-<!-- ═══════════════════ COMPARE MODAL ═══════════════════ -->
-<div class="modal-bg compare-bg" id="compareModal">
-  <div class="modal w-full max-w-5xl">
-    <button class="close-btn" onclick="closeCompareModal()"><span class="material-symbols-outlined">close</span></button>
-    <div class="modal-header pb-4 border-b border-zinc-100">
-      <h2 class="text-3xl font-extrabold font-headline">Compare Organizations</h2>
-      <p class="text-zinc-500 text-sm mt-1">Side-by-side comparison of your selected projects</p>
-    </div>
-    <div class="modal-body p-6 overflow-x-auto" id="compareModalBody">
-      <!-- Injected table -->
-    </div>
-  </div>
-</div>
+    <!-- Mobile Menu Overlay -->
+    <div
+      id="mobileMenu"
+      class="fixed inset-0 z-40 hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Navigation menu"
+    >
+      <!-- Backdrop -->
+      <div
+        class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onclick="toggleMenu()"
+        onkeydown="
+          if (event.key === 'Enter' || event.key === ' ') toggleMenu();
+        "
+        tabindex="0"
+        role="button"
+        aria-label="Close menu"
+      ></div>
 
-<!-- ═══════════════════ ANALYTICS PANEL ═══════════════════ -->
-
-<div class="modal-bg" id="anBg" onclick="closeAnEvent(event)" onkeydown="if(event.key==='Enter'||event.key===' ')closeAn()" tabindex="-1" role="dialog" aria-modal="true" aria-label="Analytics & Achievements">
-  <div class="modal w-full max-w-4xl">
-    <button class="close-btn" onclick="closeAn()"><span class="material-symbols-outlined">close</span></button>
-    <div class="modal-header pb-4 border-b border-zinc-100">
-      <div class="flex items-center justify-between">
-        <div>
-          <h2 class="text-3xl font-extrabold font-headline">Analytics & Achievements</h2>
-          <p class="text-zinc-500 text-sm mt-1">Your activity stats and unlocked badges</p>
-          <p class="text-zinc-400 text-xs mt-1 flex items-center gap-1">
-            <span class="material-symbols-outlined" style="font-size:14px">info</span>
-            Badges are stored locally in your browser (per-device, cleared with browser data)
-          </p>
-        </div>
-        <span class="badge-indicator" id="badgeIndicator">
-          <span class="material-symbols-outlined" style="font-size:16px">emoji_events</span> 0/16
-        </span>
-      </div>
-    </div>
-    <div class="modal-body p-6">
-      <!-- Stats Grid -->
-      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-bottom:24px">
-        <div style="background:var(--bg);border:1.5px solid var(--border2);border-radius:11px;padding:11px;text-align:center">
-          <div style="font-family:'Playfair Display',serif;font-size:19px;font-weight:900;margin-bottom:2px" id="aTot">0</div>
-          <div style="font-size:9px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em">Total Visits</div>
-        </div>
-        <div style="background:var(--bg);border:1.5px solid var(--border2);border-radius:11px;padding:11px;text-align:center">
-          <div style="font-family:'Playfair Display',serif;font-size:19px;font-weight:900;margin-bottom:2px" id="aToday">0</div>
-          <div style="font-size:9px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em">Today</div>
-        </div>
-        <div style="background:var(--bg);border:1.5px solid var(--border2);border-radius:11px;padding:11px;text-align:center">
-          <div style="font-family:'Playfair Display',serif;font-size:19px;font-weight:900;margin-bottom:2px" id="aSearches">0</div>
-          <div style="font-size:9px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em">Searches</div>
-        </div>
-        <div style="background:var(--bg);border:1.5px solid var(--border2);border-radius:11px;padding:11px;text-align:center">
-          <div style="font-family:'Playfair Display',serif;font-size:19px;font-weight:900;margin-bottom:2px" id="aViews">0</div>
-          <div style="font-size:9px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em">Org Views</div>
-        </div>
-        <div style="background:var(--bg);border:1.5px solid var(--border2);border-radius:11px;padding:11px;text-align:center">
-          <div style="font-family:'Playfair Display',serif;font-size:19px;font-weight:900;margin-bottom:2px" id="aFilters">0</div>
-          <div style="font-size:9px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em">Filters Used</div>
-        </div>
-        <div style="background:var(--bg);border:1.5px solid var(--border2);border-radius:11px;padding:11px;text-align:center">
-          <div style="font-family:'Playfair Display',serif;font-size:19px;font-weight:900;margin-bottom:2px" id="aTime">—</div>
-          <div style="font-size:9px;color:var(--muted);text-transform:uppercase;letter-spacing:.07em">Session Time</div>
-        </div>
-      </div>
-
-      <!-- Badges Section -->
-      <div style="margin-bottom:24px">
-        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
-          <h3 style="font-size:10px;font-weight:700;color:var(--muted);letter-spacing:.1em;text-transform:uppercase">🏆 Achievement Badges</h3>
-          <button onclick="if(typeof BadgeSystem !== 'undefined') { BadgeSystem.resetProgress(); renderBadges(); }" style="font-size:10px;font-weight:700;color:var(--red);background:transparent;border:1.5px solid var(--border);border-radius:8px;padding:4px 10px;cursor:pointer;transition:all .18s" onmouseover="this.style.borderColor='var(--red)';this.style.background='rgba(197,48,48,.06)'" onmouseout="this.style.borderColor='var(--border)';this.style.background='transparent'">
-            Reset Progress
+      <!-- Menu Panel -->
+      <nav
+        class="absolute top-0 left-0 bottom-0 w-72 bg-white shadow-2xl transform transition-transform duration-300 ease-out -translate-x-full"
+        id="menuPanel"
+        aria-label="Main navigation"
+      >
+        <div
+          class="flex items-center justify-between p-6 border-b border-zinc-100"
+        >
+          <div class="flex items-center gap-2">
+            <div
+              class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center"
+            >
+              <span class="text-white font-bold text-sm">G</span>
+            </div>
+            <span class="font-extrabold tracking-tight text-zinc-900"
+              >Menu</span
+            >
+          </div>
+          <button
+            onclick="toggleMenu()"
+            class="p-2 hover:bg-zinc-100 rounded-lg transition-colors"
+          >
+            <span class="material-symbols-outlined text-zinc-600">close</span>
           </button>
         </div>
-        <div id="badgesContainer">
-          <!-- Badges will be rendered here -->
+
+        <div class="p-4 space-y-1">
+          <a
+            href="#timeline"
+            onclick="setActiveMenu(this)"
+            class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+            data-section="timeline"
+          >
+            <span class="material-symbols-outlined text-lg">schedule</span>
+            Timeline
+          </a>
+          <a
+            href="#orgs"
+            onclick="setActiveMenu(this)"
+            class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+            data-section="orgs"
+          >
+            <span class="material-symbols-outlined text-lg">business</span>
+            Organizations
+          </a>
+          <a
+            href="#ai-recommender"
+            onclick="setActiveMenu(this)"
+            class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+            data-section="ai-recommender"
+          >
+            <span class="material-symbols-outlined text-lg">auto_awesome</span>
+            AI Recommender
+          </a>
+          <a
+            href="#watchlist"
+            onclick="setActiveMenu(this)"
+            class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+            data-section="watchlist"
+          >
+            <span class="material-symbols-outlined text-lg">bookmark</span>
+            Watchlist
+          </a>
+          <a
+            href="#issues"
+            onclick="setActiveMenu(this)"
+            class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+            data-section="issues"
+          >
+            <span class="material-symbols-outlined text-lg">bug_report</span>
+            Issues
+          </a>
+          <a
+            href="#mentors"
+            onclick="setActiveMenu(this)"
+            class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+            data-section="mentors"
+          >
+            <span class="material-symbols-outlined text-lg">group</span>
+            Mentors
+          </a>
+          <a
+            href="#guide"
+            onclick="setActiveMenu(this)"
+            class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors"
+            data-section="guide"
+          >
+            <span class="material-symbols-outlined text-lg">menu_book</span>
+            Guide
+          </a>
+        </div>
+
+        <div
+          class="absolute bottom-0 left-0 right-0 p-4 border-t border-zinc-100"
+        >
+          <a
+            href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex items-center justify-center gap-2 w-full px-4 py-3 rounded-lg bg-zinc-900 text-white text-sm font-bold hover:bg-zinc-700 transition-colors"
+          >
+            <span class="material-symbols-outlined text-base">star</span> Star &
+            Contribute
+          </a>
+        </div>
+      </nav>
+    </div>
+
+    <!-- ═══════════════════ HERO ═══════════════════ -->
+    <section
+      class="pt-20 sm:pt-28 pb-12 sm:pb-20 px-4 sm:px-6 max-w-7xl mx-auto fade-up"
+    >
+      <div
+        class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-center"
+      >
+        <div class="lg:col-span-7">
+          <div
+            class="inline-flex items-center gap-2 px-3 sm:px-4 py-1.5 rounded-full bg-orange-50 border border-orange-100 text-primary mb-6 sm:mb-8"
+          >
+            <span
+              class="material-symbols-outlined text-sm icon-fill"
+              style="color: #f97316"
+              >verified</span
+            >
+            <span
+              class="font-label text-[10px] sm:text-xs uppercase font-bold tracking-widest"
+              >Google Summer of Code 2026</span
+            >
+          </div>
+          <h1
+            class="text-4xl sm:text-5xl md:text-7xl font-extrabold font-headline tracking-tighter text-zinc-900 mb-4 sm:mb-6 leading-[0.95]"
+          >
+            Find Your<br /><span class="text-primary italic"
+              >Perfect GSoC Org</span
+            >
+          </h1>
+          <p
+            class="text-base sm:text-lg text-zinc-600 max-w-xl mb-8 sm:mb-10 leading-relaxed"
+          >
+            Browse all <strong>184</strong> organizations. Filter by language,
+            domain, competition, and live GitHub activity. Land your summer
+            internship.
+          </p>
+          <!-- Search Bar -->
+          <div class="relative max-w-xl mb-6 sm:mb-8">
+            <span
+              class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400"
+              >search</span
+            >
+            <input
+              id="hero-search"
+              type="text"
+              placeholder="Search organization names..."
+              aria-label="Search GSoC 2026 organizations"
+              class="w-full bg-white border-2 border-zinc-100 rounded-2xl py-3 sm:py-4 pl-12 pr-4 text-sm font-medium focus:ring-2 focus:ring-primary/30 focus:border-primary/40 transition-all shadow-lg shadow-zinc-200/50"
+            />
+          </div>
+          <!-- Surprise Button -->
+          <div class="mb-8 sm:mb-10">
+            <button
+              id="surpriseBtn"
+              class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-primary to-primary-container text-white rounded-full text-sm font-bold hover:shadow-lg hover:scale-105 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:ring-offset-2"
+              aria-label="🎲 Surprise Me! - Open a random organization"
+            >
+              <span class="material-symbols-outlined text-sm">casino</span>
+              🎲 Surprise Me!
+            </button>
+          </div>
+          <!-- Stat Badges -->
+          <div class="flex flex-wrap gap-3 sm:gap-4">
+            <div
+              class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm"
+            >
+              <span class="material-symbols-outlined text-primary text-lg"
+                >groups</span
+              >
+              <div>
+                <p class="text-[10px] sm:text-xs text-zinc-500">Total Orgs</p>
+                <p class="font-bold text-sm">184</p>
+              </div>
+            </div>
+            <div
+              class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm"
+            >
+              <span class="material-symbols-outlined text-secondary text-lg"
+                >code</span
+              >
+              <div>
+                <p class="text-[10px] sm:text-xs text-zinc-500">Languages</p>
+                <p class="font-bold text-sm">30+</p>
+              </div>
+            </div>
+            <div
+              class="flex items-center gap-2 px-3 sm:px-4 py-2 bg-white rounded-xl border border-zinc-100 shadow-sm"
+            >
+              <span
+                class="material-symbols-outlined text-primary-container text-lg"
+                >category</span
+              >
+              <div>
+                <p class="text-[10px] sm:text-xs text-zinc-500">Domains</p>
+                <p class="font-bold text-sm">15+</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Timeline Card -->
+        <div
+          id="timeline"
+          class="lg:col-span-5 fade-up"
+          style="animation-delay: 0.2s"
+        >
+          <div
+            class="bg-white rounded-2xl sm:rounded-3xl p-6 sm:p-8 shadow-2xl shadow-zinc-200/50 border border-zinc-100"
+          >
+            <div class="flex items-center justify-between mb-6 sm:mb-8">
+              <h3 class="font-headline font-extrabold text-lg sm:text-xl">
+                2026 Timeline
+              </h3>
+              <span
+                class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-[10px] font-bold uppercase tracking-wider"
+                >Live</span
+              >
+            </div>
+            <div id="timeline-milestones" class="space-y-4 sm:space-y-5"></div>
+            <div class="mt-5 sm:mt-6 pt-5 sm:pt-6 border-t border-zinc-100">
+              <div class="flex items-center justify-between">
+                <span class="text-xs text-zinc-500" id="countdown-label"
+                  >Next milestone</span
+                >
+                <span
+                  id="countdown"
+                  class="font-mono text-sm font-bold text-primary"
+                  >--d --h --m</span
+                >
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════ ORG DIRECTORY ═══════════════════ -->
+    <section id="orgs" class="px-6 max-w-7xl mx-auto pb-20">
+      <div class="mb-12">
+        <span
+          class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary"
+          >Find projects that fit you</span
+        >
+        <h2
+          class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2"
+        >
+          Organizations
+        </h2>
+        <p class="text-zinc-600 dark:text-zinc-400 mt-4 max-w-2xl">
+          Browse and filter GSoC 2026 organizations by tech stack, difficulty
+          level, and interests to discover projects that match your skills and
+          goals.
+        </p>
+      </div>
+      <!-- ═══════════════════ FILTER CHIPS ═══════════════════ -->
+      <div class="mb-6 fade-up" style="animation-delay: 0.3s">
+        <div class="flex flex-wrap gap-2 mb-4">
+          <button
+            id="chip-veteran"
+            class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"
+          >
+            <span class="material-symbols-outlined text-sm">military_tech</span>
+            Veterans Only
+          </button>
+          <button
+            id="chip-newcomer"
+            class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"
+          >
+            <span class="material-symbols-outlined text-sm">fiber_new</span>
+            Newcomers
+          </button>
+          <button
+            id="chip-hot"
+            class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"
+          >
+            <span class="material-symbols-outlined text-sm"
+              >local_fire_department</span
+            >
+            High Competition
+          </button>
+          <button
+            id="chip-chill"
+            class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"
+          >
+            <span class="material-symbols-outlined text-sm"
+              >sentiment_satisfied</span
+            >
+            Low Competition
+          </button>
+          <button
+            id="chip-active"
+            class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"
+          >
+            <span class="material-symbols-outlined text-sm">bolt</span> Actively
+            Maintained
+          </button>
+          <button
+            id="chip-bookmarked"
+            class="filter-chip px-4 py-2 rounded-full bg-surface-container-highest text-xs font-medium hover:bg-primary hover:text-white transition-colors flex items-center gap-1"
+          >
+            <span
+              class="material-symbols-outlined text-sm icon-fill"
+              style="color: #f59e0b"
+              >star</span
+            >
+            Bookmarked
+          </button>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="Python"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            Python
+          </button>
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="JavaScript"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            JavaScript
+          </button>
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="TypeScript"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            TypeScript
+          </button>
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="C/C++"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            C/C++
+          </button>
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="Java"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            Java
+          </button>
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="Rust"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            Rust
+          </button>
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="Go"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            Go
+          </button>
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="Ruby"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            Ruby
+          </button>
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="Haskell"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            Haskell
+          </button>
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="Scala"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            Scala
+          </button>
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="ML/AI"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            ML/AI
+          </button>
+          <button
+            class="pill px-3 py-1.5 rounded-full bg-surface-container-high border-zinc-200 text-xs font-medium hover:border-primary hover:text-primary transition-colors"
+            data-lang="Robotics"
+            aria-pressed="false"
+            onclick="togglePill(this)"
+          >
+            Robotics
+          </button>
+        </div>
+        <div
+          id="selectedLangsStrip"
+          class="mt-3 flex flex-wrap items-center gap-2 min-h-[32px]"
+        >
+          <span class="empty-state">No languages selected</span>
+        </div>
+        <div class="mt-2 flex items-center gap-2">
+          <label
+            class="inline-flex items-center gap-2 cursor-pointer select-none"
+          >
+            <input
+              id="matchAllLanguagesToggle"
+              type="checkbox"
+              class="rounded border-zinc-300 text-primary focus:ring-primary"
+              aria-describedby="languageLogicHint"
+            />
+            <span class="text-xs text-zinc-600 font-medium"
+              >Match all selected languages
+            </span>
+          </label>
+          <span
+            id="languageLogicHint"
+            class="text-xs text-primary font-medium italic"
+          >
+          </span>
         </div>
       </div>
 
-      <!-- Top Categories -->
-      <div style="margin-bottom:20px">
-        <h3 style="font-size:10px;font-weight:700;color:var(--muted);letter-spacing:.1em;text-transform:uppercase;margin-bottom:8px">Top Categories</h3>
-        <div id="catChart"></div>
+      <div class="flex flex-wrap items-center justify-between gap-4 mb-8">
+        <p class="font-label text-xs uppercase tracking-widest text-zinc-500">
+          Showing <strong id="orgCount">184</strong> of 184 organizations
+        </p>
+        <div class="flex flex-wrap items-center gap-4">
+          <select
+            id="categoryFilter"
+            aria-label="Filter by category"
+            class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-2 focus:ring-zinc-500 focus:outline-none cursor-pointer text-zinc-600"
+          >
+            <option value="all">Categories: All</option>
+            <option value="web">Web</option>
+            <option value="programming">Programming</option>
+            <option value="science">Science</option>
+            <option value="os">OS</option>
+            <option value="infra">Infra</option>
+            <option value="security">Security</option>
+            <option value="data">Data</option>
+            <option value="media">Media</option>
+            <option value="other">Other</option>
+          </select>
+          <select
+            id="complexityFilter"
+            aria-label="Filter by complexity"
+            class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-2 focus:ring-zinc-500 focus:outline-none cursor-pointer text-zinc-600"
+          >
+            <option value="all">Complexity: All</option>
+            <option value="beginner">Beginner</option>
+            <option value="intermediate">Intermediate</option>
+            <option value="advanced">Advanced</option>
+          </select>
+          <select
+            id="sortSelect"
+            aria-label="Sort organizations"
+            class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-2 focus:ring-zinc-500 focus:outline-none cursor-pointer text-zinc-600"
+          >
+            <option value="alpha">Sort: A-Z</option>
+            <option value="years-desc">Years (High-Low)</option>
+            <option value="years-asc">Years (Low-High)</option>
+            <option value="comp-low">Competition (Chill First)</option>
+            <option value="stars">GitHub Stars</option>
+            <option value="gfi">Good First Issues</option>
+          </select>
+        </div>
       </div>
 
-      <!-- Top Organizations -->
-      <div style="margin-bottom:20px">
-        <h3 style="font-size:10px;font-weight:700;color:var(--muted);letter-spacing:.1em;text-transform:uppercase;margin-bottom:8px">Most Viewed Orgs</h3>
-        <div id="orgChart"></div>
+      <!-- Hidden search input for JavaScript compatibility -->
+      <input type="hidden" id="searchInput" />
+
+      <div
+        class="org-grid grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6"
+        id="orgGrid"
+      >
+        <!-- Organizations will be rendered here dynamically -->
+        <div class="col-span-full py-20 text-center animate-pulse">
+          <p class="text-zinc-400 font-headline italic">
+            Loading organization directory...
+          </p>
+        </div>
       </div>
 
-      <!-- Search Terms -->
-      <div>
-        <h3 style="font-size:10px;font-weight:700;color:var(--muted);letter-spacing:.1em;text-transform:uppercase;margin-bottom:8px">Recent Searches</h3>
-        <div id="srchTerms"></div>
+      <!-- Empty State -->
+      <div id="emptyState" class="hidden py-20 text-center animate-fade-up">
+        <div class="text-6xl mb-4">🔍</div>
+        <h3 class="text-2xl font-bold text-zinc-900 dark:text-white mb-2">
+          No organizations match your current filters.
+        </h3>
+        <p class="text-zinc-500 dark:text-zinc-400 mb-8">
+          Try adjusting your search or clearing some filters.
+        </p>
+        <button
+          onclick="clearAllFilters()"
+          class="px-8 py-3 bg-primary text-white rounded-xl font-bold hover:bg-orange-600 transition-colors shadow-lg shadow-primary/20"
+        >
+          Clear All Filters
+        </button>
+      </div>
+
+      <div
+        class="mt-12 flex justify-center"
+        id="loadMoreContainer"
+        style="display: none"
+      >
+        <button
+          id="loadMoreBtn"
+          class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2"
+        >
+          View More Organizations
+          <span class="material-symbols-outlined text-lg">expand_more</span>
+        </button>
+      </div>
+    </section>
+
+    <!-- ═══════════════════ AI RECOMMENDER ═══════════════════ -->
+    <section
+      id="ai-recommender"
+      class="px-6 max-w-7xl mx-auto py-20 border-t border-zinc-100 dark:border-zinc-800"
+    >
+      <div class="mb-12">
+        <span
+          class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary"
+          >AI-Powered</span
+        >
+        <h2
+          class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2"
+        >
+          Personalized Org Suggestions
+        </h2>
+        <p class="text-zinc-600 dark:text-zinc-400 mt-4 max-w-2xl">
+          Enter your GitHub username or paste your resume to get deterministic
+          AI-style organization recommendations tailored to your skills and
+          experience.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
+        <!-- Input Form -->
+        <div
+          class="lg:col-span-4 bg-white dark:bg-[#18181b] p-6 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm h-fit"
+        >
+          <div class="space-y-5">
+            <div>
+              <label
+                for="aiGhUsername"
+                class="block text-sm font-bold text-zinc-900 dark:text-zinc-100 mb-1"
+                >GitHub Username</label
+              >
+              <div class="relative">
+                <span
+                  class="material-symbols-outlined absolute left-3 top-2.5 text-zinc-400 text-sm"
+                  >person</span
+                >
+                <input
+                  type="text"
+                  id="aiGhUsername"
+                  placeholder="e.g. torvalds"
+                  class="w-full pl-9 pr-4 py-2 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm focus:ring-2 focus:ring-primary dark:text-white transition-all"
+                />
+              </div>
+              <p class="text-[10px] text-zinc-500 mt-1 ml-1">
+                Used to analyze your repo languages and activity.
+              </p>
+            </div>
+
+            <div>
+              <label
+                for="aiResumeText"
+                class="block text-sm font-bold text-zinc-900 dark:text-zinc-100 mb-1"
+                >Resume / Skills</label
+              >
+              <textarea
+                id="aiResumeText"
+                rows="4"
+                placeholder="Paste your resume or list your skills here (e.g. Python, React, Machine Learning)..."
+                class="w-full p-3 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm focus:ring-2 focus:ring-primary dark:text-white transition-all resize-none"
+              ></textarea>
+              <div class="mt-2 flex items-center justify-between">
+                <label
+                  class="text-xs text-primary font-bold cursor-pointer hover:underline flex items-center gap-1"
+                >
+                  <span class="material-symbols-outlined text-[14px]"
+                    >upload_file</span
+                  >
+                  Upload .txt
+                  <input
+                    type="file"
+                    id="aiResumeFile"
+                    accept=".txt"
+                    class="hidden"
+                  />
+                </label>
+              </div>
+            </div>
+
+            <button
+              id="btnGetRecommendations"
+              class="w-full py-3 bg-gradient-to-r from-primary to-primary-container text-white rounded-xl font-bold text-sm shadow-md hover:shadow-lg hover:scale-[1.02] transition-all flex items-center justify-center gap-2"
+            >
+              <span class="material-symbols-outlined text-sm"
+                >auto_awesome</span
+              >
+              Get Recommendations
+            </button>
+          </div>
+        </div>
+
+        <!-- Results Area -->
+        <div class="lg:col-span-8">
+          <!-- Initial State -->
+          <div
+            id="aiLoadingState"
+            aria-live="polite"
+            class="hidden flex flex-col items-center justify-center py-16 bg-zinc-50 dark:bg-zinc-900/50 rounded-2xl border border-dashed border-zinc-300 dark:border-zinc-700"
+          >
+            <div
+              class="w-10 h-10 border-4 border-primary border-t-transparent rounded-full animate-spin mb-4"
+            ></div>
+            <p class="text-zinc-600 dark:text-zinc-400 font-bold animate-pulse">
+              Analyzing profile & calculating matches...
+            </p>
+          </div>
+
+          <!-- Error State -->
+          <div
+            id="aiErrorState"
+            aria-live="assertive"
+            class="hidden bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-2xl p-6 text-center block"
+          >
+            <span class="material-symbols-outlined text-red-500 text-4xl mb-2"
+              >error</span
+            >
+            <h3 class="text-red-800 dark:text-red-400 font-bold mb-1">
+              Analysis Failed
+            </h3>
+            <p
+              id="aiErrorMsg"
+              class="text-red-600 dark:text-red-300 text-sm"
+            ></p>
+          </div>
+
+          <!-- Results Container -->
+          <div id="aiResultsContainer" class="org-grid w-full">
+            <div
+              class="flex flex-col items-center justify-center py-20 text-center text-zinc-400 dark:text-zinc-500"
+            >
+              <span class="material-symbols-outlined text-6xl mb-4 opacity-50"
+                >magic_button</span
+              >
+              <p class="font-bold">
+                Provide your details to see personalized matches.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════ WATCHLIST ═══════════════════ -->
+    <section id="watchlist" class="bg-surface-container-low py-20 px-6">
+      <div class="max-w-7xl mx-auto">
+        <div class="mb-12 flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <span
+              class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary"
+              >Scholarly Sandbox</span
+            >
+            <h2
+              class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2"
+            >
+              Watchlist.
+            </h2>
+            <p class="text-zinc-600 mt-4 max-w-2xl">
+              Curate your open-source journey. Track organizations, monitor
+              deadlines, and prepare your proposals for GSoC 2026.
+            </p>
+          </div>
+          <button
+            id="clearAllBookmarksBtn"
+            class="hidden mt-8 flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-red-500 border border-red-200 rounded-full px-4 py-2 hover:bg-red-50 transition-colors"
+            title="Remove all bookmarks"
+          >
+            <span class="material-symbols-outlined text-sm">delete_sweep</span>
+            Clear All
+          </button>
+        </div>
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div class="lg:col-span-2 space-y-6">
+            <div id="recentlyViewedSection" class="space-y-4">
+              <div class="flex items-center justify-between gap-3">
+                <div class="flex items-center gap-3 flex-wrap">
+                  <h3 class="text-lg font-bold text-zinc-900">
+                    Recently Viewed Organizations
+                  </h3>
+                  <span
+                    id="recentlyViewedOverflowBadge"
+                    class="hidden rounded-full bg-zinc-100 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-zinc-500"
+                    >+0</span
+                  >
+                </div>
+                <button
+                  id="clearRecentlyViewedBtn"
+                  class="text-xs font-bold uppercase tracking-wider text-zinc-500 hover:text-red-500 transition-colors"
+                  aria-label="Clear All recently viewed organizations"
+                >
+                  Clear All
+                </button>
+              </div>
+              <div id="recentlyViewedContainer" class="space-y-3">
+                <!-- Recently viewed items will be rendered here -->
+              </div>
+            </div>
+
+            <div class="space-y-4" id="watchlistContainer">
+              <!-- Watchlist items will be rendered here -->
+            </div>
+          </div>
+          <!-- Sidebar -->
+          <div class="space-y-6">
+            <div class="bg-white rounded-2xl p-6 border border-zinc-100">
+              <h4 class="font-bold mb-4 flex items-center gap-2">
+                <span class="material-symbols-outlined text-primary text-lg"
+                  >event</span
+                >
+                Upcoming Deadlines
+              </h4>
+              <div class="space-y-4">
+                <div>
+                  <p
+                    class="text-[10px] font-label uppercase tracking-wider text-zinc-400"
+                  >
+                    MAR 31, 2026
+                  </p>
+                  <p class="text-sm font-bold">Proposal Submission Deadline</p>
+                  <p class="text-xs text-zinc-500">
+                    Ensure your final proposals are submitted by 18:00 UTC.
+                  </p>
+                </div>
+                <div>
+                  <p
+                    class="text-[10px] font-label uppercase tracking-wider text-zinc-400"
+                  >
+                    APR 21, 2026
+                  </p>
+                  <p class="text-sm font-bold">Review Period Starts</p>
+                  <p class="text-xs text-zinc-500">
+                    Mentors begin ranking of proposals.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              class="bg-gradient-to-br from-primary to-primary-container text-white rounded-2xl p-6 relative overflow-hidden"
+            >
+              <div class="absolute top-0 right-0 p-4 opacity-20">
+                <span class="material-symbols-outlined text-5xl"
+                  >auto_awesome</span
+                >
+              </div>
+              <h4 class="font-bold mb-3">AI Application Insight</h4>
+              <p
+                id="aiInsightText"
+                class="text-sm text-orange-100 leading-relaxed mb-4"
+              >
+                Select organizations to get personalized contribution advice.
+              </p>
+              <span
+                class="text-[10px] font-label uppercase tracking-widest text-orange-200"
+                >Automated System Advice</span
+              >
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════ GOOD FIRST ISSUES ═══════════════════ -->
+    <section id="issues" class="py-20 px-6 max-w-7xl mx-auto">
+      <div class="mb-12">
+        <span
+          class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary"
+          >First Contributions</span
+        >
+        <h2
+          class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2"
+        >
+          Good First Issues
+        </h2>
+        <p class="text-zinc-600 mt-4 max-w-2xl">
+          Pre-fetched from all GSoC 2026 orgs every 6 hours — no rate limits, no
+          token required, instant results.
+        </p>
+      </div>
+      <!-- Status Banner -->
+      <div
+        id="issuesBanner"
+        class="bg-green-50 border border-green-200 rounded-2xl p-6 mb-8 flex flex-col sm:flex-row items-start sm:items-center gap-4"
+      >
+        <div class="flex items-center gap-3">
+          <div
+            class="w-3 h-3 rounded-full bg-green-500 pulse-dot"
+            id="issuesBannerDot"
+          ></div>
+          <div>
+            <p class="font-bold text-green-800 text-sm" id="issuesBannerTitle">
+              Pre-fetched Issues Ready
+            </p>
+            <p class="text-xs text-green-600" id="issuesBannerSubtitle">
+              Updated every 6 hours via GitHub Actions — no API rate limits for
+              visitors.
+            </p>
+          </div>
+        </div>
+        <div class="ml-auto text-right">
+          <span id="issuesLastUpdated" class="text-xs font-mono text-green-600"
+            >Last updated: pending refresh</span
+          >
+          <span
+            id="issuesStaleNote"
+            class="hidden ml-2 text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2 py-0.5"
+            >⏸ GSoC selection complete. Data won't update frequently.</span
+          >
+        </div>
+      </div>
+      <!-- Issue Cards -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div
+          class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card"
+          data-url="https://github.com/rust-lang/rust/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22"
+        >
+          <div class="flex items-start justify-between mb-3">
+            <h4
+              class="font-bold text-sm group-hover:text-primary transition-colors"
+            >
+              Browse open Good First Issues
+            </h4>
+            <span
+              class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg"
+              >open_in_new</span
+            >
+          </div>
+          <p class="text-xs text-zinc-500 mb-3 font-mono">rust-lang/rust</p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold"
+              >GitHub search</span
+            >
+            <span
+              class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded"
+              >Label: good first issue</span
+            >
+          </div>
+        </div>
+        <div
+          class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card"
+          data-url="https://github.com/django/django/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22"
+        >
+          <div class="flex items-start justify-between mb-3">
+            <h4
+              class="font-bold text-sm group-hover:text-primary transition-colors"
+            >
+              Browse open Good First Issues
+            </h4>
+            <span
+              class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg"
+              >open_in_new</span
+            >
+          </div>
+          <p class="text-xs text-zinc-500 mb-3 font-mono">django/django</p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold"
+              >GitHub search</span
+            >
+            <span
+              class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded"
+              >Label: good first issue</span
+            >
+          </div>
+        </div>
+        <div
+          class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card"
+          data-url="https://github.com/tensorflow/tensorflow/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22"
+        >
+          <div class="flex items-start justify-between mb-3">
+            <h4
+              class="font-bold text-sm group-hover:text-primary transition-colors"
+            >
+              Browse open Good First Issues
+            </h4>
+            <span
+              class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg"
+              >open_in_new</span
+            >
+          </div>
+          <p class="text-xs text-zinc-500 mb-3 font-mono">
+            tensorflow/tensorflow
+          </p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold"
+              >GitHub search</span
+            >
+            <span
+              class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded"
+              >Label: good first issue</span
+            >
+          </div>
+        </div>
+        <div
+          class="bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer issue-fallback-card"
+          data-url="https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22"
+        >
+          <div class="flex items-start justify-between mb-3">
+            <h4
+              class="font-bold text-sm group-hover:text-primary transition-colors"
+            >
+              Browse open Good First Issues
+            </h4>
+            <span
+              class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg"
+              >open_in_new</span
+            >
+          </div>
+          <p class="text-xs text-zinc-500 mb-3 font-mono">
+            kubernetes/kubernetes
+          </p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold"
+              >GitHub search</span
+            >
+            <span
+              class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded"
+              >Label: good first issue</span
+            >
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════ MENTOR FINDER ═══════════════════ -->
+    <section id="mentors" class="py-20 px-6 bg-surface-container-low">
+      <div class="max-w-7xl mx-auto">
+        <div class="mb-12">
+          <span
+            class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary"
+            >Mentor Outreach</span
+          >
+          <h2
+            class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2"
+          >
+            Mentor Finder
+          </h2>
+          <p class="text-zinc-600 mt-4 max-w-3xl">
+            Pre-fetched contact channels and conservative mentor handles from
+            org ideas pages, so you can find where to introduce yourself before
+            proposal season gets busy.
+          </p>
+        </div>
+
+        <div
+          class="bg-white border border-zinc-100 rounded-2xl p-6 mb-8 flex flex-col sm:flex-row items-start sm:items-center gap-4"
+        >
+          <div class="flex items-center gap-3">
+            <div
+              class="w-3 h-3 rounded-full pulse-dot"
+              id="mentorBannerDot"
+              style="background-color: #f97316"
+            ></div>
+            <div>
+              <p class="font-bold text-zinc-900 text-sm">
+                Cached mentor contact data
+              </p>
+              <p class="text-xs text-zinc-600">
+                Generated offline by the project workflow to keep scraping out
+                of the browser.
+              </p>
+            </div>
+          </div>
+          <div class="ml-auto text-right">
+            <span id="mentorLastUpdated" class="text-xs font-mono text-zinc-500"
+              >Last updated: pending refresh</span
+            >
+            <span
+              id="mentorStaleNote"
+              class="hidden ml-2 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-full px-2 py-0.5"
+              >ℹ GSoC selection complete. Data won't update frequently.</span
+            >
+          </div>
+        </div>
+
+        <div class="bg-white rounded-2xl border border-zinc-100 p-6 mb-8">
+          <div
+            class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_220px] gap-4"
+          >
+            <label class="relative block">
+              <span
+                class="material-symbols-outlined absolute left-3 top-3 text-zinc-400 text-sm"
+                >search</span
+              >
+              <input
+                id="mentorSearchInput"
+                type="text"
+                placeholder="Search org name or mentor GitHub handle..."
+                class="w-full pl-10 pr-4 py-3 bg-surface-container-low border-none rounded-xl text-sm focus:ring-2 focus:ring-primary"
+              />
+            </label>
+            <select
+              id="mentorChannelFilter"
+              class="bg-surface-container-low border-none rounded-xl text-sm font-medium focus:ring-2 focus:ring-primary text-zinc-700 px-4"
+            >
+              <option value="all">All channels</option>
+              <option value="Slack">Slack</option>
+              <option value="Zulip">Zulip</option>
+              <option value="Discord">Discord</option>
+              <option value="Matrix">Matrix</option>
+              <option value="IRC">IRC</option>
+              <option value="Mailing list">Mailing list</option>
+            </select>
+          </div>
+        </div>
+
+        <div
+          id="mentorGrid"
+          class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6"
+        >
+          <div
+            class="col-span-full bg-white rounded-2xl border border-zinc-100 p-8 text-center"
+          >
+            <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
+          </div>
+        </div>
+
+        <div
+          class="mt-12 flex justify-center"
+          id="loadMoreMentorContainer"
+          style="display: none"
+        >
+          <button
+            type="button"
+            id="loadMoreMentorBtn"
+            aria-label="View More Mentors"
+            class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2"
+          >
+            View More Mentors
+            <span class="material-symbols-outlined text-lg">expand_more</span>
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════ CONTRIBUTOR GUIDE ═══════════════════ -->
+    <section id="guide" class="py-20 px-6 max-w-7xl mx-auto">
+      <div class="mb-12">
+        <span
+          class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary"
+          >Contributor Guide</span
+        >
+        <h2
+          class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2"
+        >
+          Start Contributing with Confidence
+        </h2>
+        <p class="text-zinc-600 mt-4 max-w-3xl">
+          New to open source or this project? Follow this quick path: learn the
+          basics, set up locally, find a good first issue, and open your first
+          PR.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <article
+          class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm"
+        >
+          <h3 class="text-xl font-bold mb-3">1) Open Source Basics</h3>
+          <p class="text-sm text-zinc-600 mb-4 leading-relaxed">
+            Open source projects publish source code publicly so anyone can
+            inspect, improve, and share it. Contribution usually starts with
+            reading contribution guidelines and making small, focused changes.
+          </p>
+          <ul class="space-y-2 text-sm text-zinc-700 list-disc pl-5">
+            <li>Understand how licensing and collaboration work.</li>
+            <li>Start with documentation or beginner-friendly issues.</li>
+            <li>Communicate early through issues and PR comments.</li>
+          </ul>
+        </article>
+
+        <article
+          class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm"
+        >
+          <h3 class="text-xl font-bold mb-3">
+            2) Contribute to a GSoC Organization
+          </h3>
+          <ol class="space-y-2 text-sm text-zinc-700 list-decimal pl-5">
+            <li>
+              Pick 2–3 organizations that match your skills and interests.
+            </li>
+            <li>
+              Read their ideas page, contribution guide, and communication
+              channels.
+            </li>
+            <li>
+              Set up the project locally and start with a small issue or
+              documentation task.
+            </li>
+            <li>
+              Open a focused pull request and respond to mentor feedback
+              quickly.
+            </li>
+            <li>
+              Document your contributions and turn them into a stronger GSoC
+              proposal.
+            </li>
+          </ol>
+          <p class="text-xs text-zinc-500 mt-4">
+            Tip: quality communication and small, consistent contributions
+            usually matter more than a single large PR.
+          </p>
+        </article>
+
+        <article
+          class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm lg:col-span-2"
+        >
+          <h3 class="text-xl font-bold mb-5">3) Useful Resources</h3>
+          <div
+            class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm"
+          >
+            <a
+              href="https://opensource.guide/how-to-contribute/"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors"
+            >
+              <p class="font-bold mb-1">Open Source Guide</p>
+              <p class="text-zinc-600">
+                Practical guide for first-time and returning contributors.
+              </p>
+            </a>
+            <a
+              href="https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors"
+            >
+              <p class="font-bold mb-1">GitHub Contribution Flow</p>
+              <p class="text-zinc-600">
+                Official docs for forking, cloning, and opening pull requests.
+              </p>
+            </a>
+            <a
+              href="https://developers.google.com/open-source/gsoc/resources/guide"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors"
+            >
+              <p class="font-bold mb-1">GSoC Contributor/Student Guide</p>
+              <p class="text-zinc-600">
+                Official program timeline and best practices for applicants.
+              </p>
+            </a>
+            <a
+              href="https://developers.google.com/open-source/gsoc/help/student-advice"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors"
+            >
+              <p class="font-bold mb-1">Student Advice</p>
+              <p class="text-zinc-600">
+                Official guidance for choosing orgs, communicating well, and
+                writing proposals.
+              </p>
+            </a>
+            <a
+              href="https://firstcontributions.github.io/"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="block p-4 rounded-2xl border border-zinc-200 hover:border-primary hover:bg-orange-50/30 transition-colors"
+            >
+              <p class="font-bold mb-1">First Contributions</p>
+              <p class="text-zinc-600">
+                Hands-on tutorial to practice your first fork, commit, and pull
+                request.
+              </p>
+            </a>
+          </div>
+        </article>
+
+        <article
+          class="bg-white border border-zinc-100 rounded-3xl p-8 shadow-sm lg:col-span-2"
+        >
+          <h3 class="text-xl font-bold mb-4">4) FAQ</h3>
+          <div class="space-y-3 text-sm">
+            <details class="group border border-zinc-200 rounded-xl p-4">
+              <summary class="font-semibold cursor-pointer">
+                Do I need prior GSoC experience to contribute?
+              </summary>
+              <p class="text-zinc-600 mt-2">
+                No. Start with small docs or UI fixes, then move to larger tasks
+                as you learn the codebase.
+              </p>
+            </details>
+            <details class="group border border-zinc-200 rounded-xl p-4">
+              <summary class="font-semibold cursor-pointer">
+                What should my first pull request look like?
+              </summary>
+              <p class="text-zinc-600 mt-2">
+                Keep it focused on one change, reference the issue number, and
+                include a short explanation of what you tested.
+              </p>
+            </details>
+            <details class="group border border-zinc-200 rounded-xl p-4">
+              <summary class="font-semibold cursor-pointer">
+                How do I find tasks I can start quickly?
+              </summary>
+              <p class="text-zinc-600 mt-2">
+                Look for issues labeled
+                <span class="font-mono text-xs bg-zinc-100 px-1 py-0.5 rounded"
+                  >good first issue</span
+                >
+                and comment before starting work.
+              </p>
+            </details>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <!-- ═══════════════════ HOW IT WORKS ═══════════════════ -->
+    <section class="bg-zinc-900 py-20 px-6">
+      <div class="max-w-7xl mx-auto">
+        <div class="text-center mb-16">
+          <h2
+            class="text-4xl font-extrabold font-headline tracking-tight text-white mb-4"
+          >
+            New to GSoC? Start here.
+          </h2>
+          <p class="text-zinc-400 max-w-2xl mx-auto">
+            Google Summer of Code is a global, online program focused on
+            bringing new contributors into open source software development.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div
+            class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all"
+          >
+            <div
+              class="w-14 h-14 rounded-2xl bg-orange-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-primary group-hover:scale-110 transition-transform"
+            >
+              1
+            </div>
+            <h3 class="text-xl font-bold text-white mb-3">
+              Explore Organizations
+            </h3>
+            <p class="text-zinc-400 text-sm leading-relaxed">
+              Browse 185+ open source organizations. Filter by language, domain,
+              and competition level to find your match.
+            </p>
+          </div>
+          <div
+            class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all"
+          >
+            <div
+              class="w-14 h-14 rounded-2xl bg-blue-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-blue-400 group-hover:scale-110 transition-transform"
+            >
+              2
+            </div>
+            <h3 class="text-xl font-bold text-white mb-3">Submit a Proposal</h3>
+            <p class="text-zinc-400 text-sm leading-relaxed">
+              Reach out to mentors and write a detailed proposal outlining how
+              you'll contribute to your chosen project.
+            </p>
+          </div>
+          <div
+            class="bg-white/5 border border-white/10 p-8 rounded-3xl group hover:bg-white/10 transition-all"
+          >
+            <div
+              class="w-14 h-14 rounded-2xl bg-green-500/20 flex items-center justify-center mb-6 font-bold text-2xl text-green-400 group-hover:scale-110 transition-transform"
+            >
+              3
+            </div>
+            <h3 class="text-xl font-bold text-white mb-3">Start Coding</h3>
+            <p class="text-zinc-400 text-sm leading-relaxed">
+              If accepted, spend your summer coding under the guidance of
+              experienced mentors and earn a stipend of $1,500–$6,600.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════ COMPARE ═══════════════════ -->
+    <section class="py-20 px-6 max-w-7xl mx-auto">
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+        <div>
+          <span
+            class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary"
+            >Decision Tool</span
+          >
+          <h2
+            class="text-4xl font-extrabold font-headline tracking-tighter mt-2 mb-6"
+          >
+            Compare Organizations
+          </h2>
+          <p class="text-zinc-600 leading-relaxed mb-8">
+            Select up to 3 orgs to compare side-by-side. See history, mentor
+            count, tech stack, competition level, and active GFIs at a glance.
+          </p>
+          <button
+            onclick="openCompareModal()"
+            class="inline-flex items-center gap-2 px-8 py-4 bg-primary text-white font-bold rounded-xl hover:scale-95 transition-all shadow-lg"
+          >
+            <span class="material-symbols-outlined">compare</span> Open
+            Comparison Tool
+          </button>
+        </div>
+        <div
+          id="compare"
+          class="bg-surface-container-low rounded-3xl p-8 border border-zinc-100"
+        >
+          <div class="grid grid-cols-3 gap-4 text-center">
+            <div class="bg-white rounded-xl p-4 border border-zinc-100">
+              <div
+                class="w-10 h-10 rounded-lg bg-orange-100 flex items-center justify-center mx-auto mb-3"
+              >
+                <span class="material-symbols-outlined text-orange-600"
+                  >psychology</span
+                >
+              </div>
+              <p class="font-bold text-sm">TensorFlow</p>
+              <p class="text-[10px] text-zinc-500 font-label uppercase mt-1">
+                15y · 42 mentors
+              </p>
+            </div>
+            <div class="bg-white rounded-xl p-4 border border-zinc-100">
+              <div
+                class="w-10 h-10 rounded-lg bg-amber-100 flex items-center justify-center mx-auto mb-3"
+              >
+                <span class="material-symbols-outlined text-amber-600"
+                  >developer_board</span
+                >
+              </div>
+              <p class="font-bold text-sm">Apache</p>
+              <p class="text-[10px] text-zinc-500 font-label uppercase mt-1">
+                19y · 64 mentors
+              </p>
+            </div>
+            <div
+              class="bg-white rounded-xl p-4 border border-zinc-100 border-dashed border-zinc-300"
+            >
+              <div
+                class="w-10 h-10 rounded-lg bg-zinc-100 flex items-center justify-center mx-auto mb-3"
+              >
+                <span class="material-symbols-outlined text-zinc-400">add</span>
+              </div>
+              <p class="font-bold text-sm text-zinc-400">Add org</p>
+              <p class="text-[10px] text-zinc-400 font-label uppercase mt-1">
+                slot 3
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════ CONTACT ═══════════════════ -->
+    <section id="contact" class="py-20 px-6 max-w-7xl mx-auto">
+      <div class="text-center mb-12">
+        <h2 class="text-4xl font-extrabold font-headline tracking-tight mb-4">
+          Get in Touch
+        </h2>
+        <p class="text-zinc-600 max-w-2xl mx-auto">
+          Have questions, feedback, or need help? We'd love to hear from you.
+        </p>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
+        <a
+          href="https://github.com/S3DFX-CYBER"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group"
+        >
+          <div
+            class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors"
+          >
+            <span
+              class="material-symbols-outlined text-zinc-600 group-hover:text-primary"
+              >person</span
+            >
+          </div>
+          <h3 class="font-bold mb-2">GitHub Profile</h3>
+          <p class="text-sm text-zinc-600">
+            Follow the maintainer and check out other projects.
+          </p>
+        </a>
+        <a
+          href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group"
+        >
+          <div
+            class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors"
+          >
+            <span
+              class="material-symbols-outlined text-zinc-600 group-hover:text-primary"
+              >bug_report</span
+            >
+          </div>
+          <h3 class="font-bold mb-2">Report Issues</h3>
+          <p class="text-sm text-zinc-600">
+            Found a bug or have a feature request? Open an issue.
+          </p>
+        </a>
+        <a
+          href="https://discord.gg/mgWV3xSV7"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="bg-white border border-zinc-200 rounded-2xl p-6 hover:border-primary hover:shadow-lg transition-all text-center group"
+        >
+          <div
+            class="w-12 h-12 rounded-xl bg-zinc-100 flex items-center justify-center mx-auto mb-4 group-hover:bg-orange-100 transition-colors"
+          >
+            <span
+              class="material-symbols-outlined text-zinc-600 group-hover:text-primary"
+              >forum</span
+            >
+          </div>
+          <h3 class="font-bold mb-2">Join Discord</h3>
+          <p class="text-sm text-zinc-600">
+            Connect with the community for discussions and support.
+          </p>
+        </a>
+      </div>
+    </section>
+
+    <!-- ═══════════════════ FOOTER ═══════════════════ -->
+    <footer class="w-full border-t border-zinc-200 bg-zinc-100 pb-48">
+      <div
+        class="flex flex-col md:flex-row justify-between items-center px-8 py-12 gap-6 max-w-7xl mx-auto"
+      >
+        <div class="flex flex-col gap-2">
+          <div class="flex items-center gap-2">
+            <div
+              class="w-6 h-6 rounded bg-gradient-to-br from-primary to-primary-container flex items-center justify-center"
+            >
+              <span class="text-white font-bold text-[10px]">G</span>
+            </div>
+            <span class="text-lg font-bold text-zinc-900">FindMyGSoC</span>
+          </div>
+          <p
+            class="text-[10px] font-bold uppercase tracking-widest text-zinc-400"
+          >
+            © 2026 S3DFX-CYBER · Built for the Open Source Community
+          </p>
+        </div>
+        <nav class="flex flex-wrap gap-6" aria-label="Footer navigation">
+          <a
+            class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all"
+            href="https://discord.gg/mgWV3xSV7"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Community</a
+          >
+          <a
+            class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all"
+            href="https://summerofcode.withgoogle.com/programs/2026/organizations"
+            target="_blank"
+            rel="noopener noreferrer"
+            >GSoC 2026</a
+          >
+          <a
+            class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all"
+            href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-"
+            target="_blank"
+            rel="noopener noreferrer"
+            >GitHub</a
+          >
+          <a
+            class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all"
+            href="https://findmygsoc.vercel.app/privacy.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Privacy</a
+          >
+          <a
+            class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all"
+            href="#contact"
+            >Contact</a
+          >
+        </nav>
+      </div>
+    </footer>
+
+    <!-- ═══════════════════ MODAL ═══════════════════ -->
+    <div class="modal-bg" id="orgModal">
+      <div class="modal">
+        <button class="close-btn" onclick="closeOrgModal()">
+          <span class="material-symbols-outlined">close</span>
+        </button>
+        <div class="modal-header" id="mHeader">
+          <!-- Injected: Category, Name, Tagline -->
+        </div>
+        <div class="modal-body">
+          <div class="metrics-grid mb-8" id="mMetrics">
+            <!-- Injected: Years, Competition, First Year, etc. -->
+          </div>
+
+          <div class="github-stats-container mb-8">
+            <button class="gh-fetch" id="mFetchBtn">Fetch Live Stats</button>
+            <div class="gh-stat-item">
+              <span class="material-symbols-outlined text-sm">star</span>
+              <span id="mStars">---</span>
+            </div>
+            <div class="gh-stat-item">
+              <span class="material-symbols-outlined text-sm">fork_right</span>
+              <span id="mForks">---</span>
+            </div>
+            <div class="gh-stat-item">
+              <span class="material-symbols-outlined text-sm">bug_report</span>
+              <span id="mIssues">---</span>
+            </div>
+            <div class="gh-stat-item text-blue-400">
+              <span class="material-symbols-outlined text-sm">history</span>
+              <span id="mActivity">Moderate</span>
+            </div>
+          </div>
+
+          <div class="section-title">Description</div>
+          <p id="mDesc" class="text-sm text-zinc-600 leading-relaxed mb-6"></p>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <div>
+              <div class="section-title">Technologies</div>
+              <div class="tech-tags" id="mTech"></div>
+            </div>
+            <div>
+              <div class="section-title">Ideal Fit</div>
+              <div class="fit-tags" id="mFit"></div>
+            </div>
+          </div>
+
+          <div class="section-title">Participation Timeline</div>
+          <div class="timeline-grid" id="mTimeline"></div>
+
+          <div class="section-title">Mentors &amp; Contact</div>
+          <div id="mMentorSection" class="space-y-4">
+            <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button
+            type="button"
+            id="mDraftBtn"
+            class="modal-cta modal-proposal-link flex items-center justify-center gap-2"
+          >
+            <span class="material-symbols-outlined text-lg">edit_document</span>
+            Open Proposal Builder
+          </button>
+          <a
+            href="#"
+            target="_blank"
+            rel="noopener noreferrer"
+            id="mIdeasBtn"
+            class="modal-cta modal-ideas-link flex items-center justify-center gap-2"
+          >
+            <span class="material-symbols-outlined text-lg">lightbulb</span>
+            Project Ideas
+          </a>
+          <a
+            href="#"
+            target="_blank"
+            rel="noopener noreferrer"
+            id="mRepoBtn"
+            class="modal-cta modal-repo-link flex items-center justify-center gap-2"
+          >
+            <span class="material-symbols-outlined text-lg">code</span>
+            Repository
+          </a>
+        </div>
       </div>
     </div>
-  </div>
-</div>
 
-<!-- ═══════════════════ JS ═══════════════════ -->
-<script src="agent/scripts/orgs.js"></script>
-<script>
-  // ══════════════════════════════════════════════
-  // THEME
-  // ══════════════════════════════════════════════
-  (function(){
-    const saved = localStorage.getItem('theme') || 'light';
-    document.documentElement.classList.toggle('dark', saved === 'dark');
-    updateThemeIcon();
-  })();
+    <!-- ═══════════════════ PROPOSAL BUILDER ═══════════════════ -->
+    <dialog class="proposal-bg" id="proposalModal" aria-labelledby="pwOrgName">
+      <div class="proposal-workspace">
+        <header class="proposal-header">
+          <div class="proposal-header-title">
+            <h2 id="pwOrgName">Organization Proposal</h2>
+            <p id="pwPrivacyNote">
+              Drafts are stored only on this device when autosave is enabled.
+            </p>
+          </div>
+          <label class="proposal-autosave">
+            <input
+              type="checkbox"
+              id="pwAutosaveToggle"
+              aria-describedby="pwPrivacyNote"
+            />
+            Enable autosave
+          </label>
+          <div class="proposal-toolbar">
+            <button
+              type="button"
+              id="pwClearBtn"
+              class="proposal-btn proposal-btn-danger"
+              aria-label="Clear proposal draft"
+            >
+              <span class="material-symbols-outlined text-sm">delete</span>
+              Clear
+            </button>
+            <button
+              type="button"
+              id="pwExportMDBtn"
+              class="proposal-btn"
+              aria-label="Export proposal as Markdown"
+            >
+              <span class="material-symbols-outlined text-sm">download</span>
+              Markdown
+            </button>
+            <button
+              type="button"
+              id="pwExportPDFBtn"
+              class="proposal-btn proposal-btn-primary"
+              aria-label="Download proposal as PDF"
+            >
+              <span class="material-symbols-outlined text-sm"
+                >picture_as_pdf</span
+              >
+              PDF
+            </button>
+            <button
+              type="button"
+              id="pwCloseBtn"
+              class="proposal-btn"
+              aria-label="Close proposal builder"
+            >
+              <span class="material-symbols-outlined text-sm">close</span> Close
+            </button>
+          </div>
+        </header>
+        <div class="proposal-body">
+          <div class="proposal-editor">
+            <label for="pwEditor" class="sr-only"
+              >Proposal markdown editor</label
+            >
+            <textarea
+              id="pwEditor"
+              class="proposal-textarea"
+              spellcheck="true"
+              aria-label="Proposal markdown editor"
+            ></textarea>
+          </div>
+          <div
+            id="pwPreview"
+            class="proposal-preview"
+            aria-live="polite"
+            aria-label="Proposal preview"
+          ></div>
+        </div>
+      </div>
+    </dialog>
 
-  window.toggleTheme = function(){
-    const isDark = document.documentElement.classList.toggle('dark');
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    updateThemeIcon();
-  };
+    <!-- ═══════════════════ COMPARE MODAL ═══════════════════ -->
+    <div class="modal-bg compare-bg" id="compareModal">
+      <div class="modal w-full max-w-5xl">
+        <button class="close-btn" onclick="closeCompareModal()">
+          <span class="material-symbols-outlined">close</span>
+        </button>
+        <div class="modal-header pb-4 border-b border-zinc-100">
+          <h2 class="text-3xl font-extrabold font-headline">
+            Compare Organizations
+          </h2>
+          <p class="text-zinc-500 text-sm mt-1">
+            Side-by-side comparison of your selected projects
+          </p>
+        </div>
+        <div class="modal-body p-6 overflow-x-auto" id="compareModalBody">
+          <!-- Injected table -->
+        </div>
+      </div>
+    </div>
 
-  function updateThemeIcon(){
-    const btn = document.getElementById('themeToggleBtn');
-    const icon = btn ? btn.querySelector('.material-symbols-outlined') : null;
-    if(icon){
-      const isDark = document.documentElement.classList.contains('dark');
-      icon.textContent = isDark ? 'light_mode' : 'dark_mode';
-      btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
-      btn.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
-      btn.setAttribute('title', isDark ? 'Switch to light theme' : 'Switch to dark theme');
-    }
-  }
+    <!-- ═══════════════════ ANALYTICS PANEL ═══════════════════ -->
 
-  // ══════════════════════════════════════════════
-  // MOBILE MENU
-  // ══════════════════════════════════════════════
-  window.toggleMenu = function(){
-    const menu = document.getElementById('mobileMenu');
-    const panel = document.getElementById('menuPanel');
-    const menuBtn = document.getElementById('menuBtn');
-    
-    if(menu.classList.contains('hidden')){
-      // Open menu
-      menu.classList.remove('hidden');
-      menuBtn.setAttribute('aria-expanded', 'true');
-      menuBtn.setAttribute('aria-label', 'Close menu');
-      setTimeout(() => {
-        panel.style.transform = 'translateX(0)';
-      }, 10);
-      document.addEventListener('keydown', handleMenuEscape);
-    } else {
-      // Close menu
-      panel.style.transform = 'translateX(-100%)';
-      menuBtn.setAttribute('aria-expanded', 'false');
-      menuBtn.setAttribute('aria-label', 'Open menu');
-      document.removeEventListener('keydown', handleMenuEscape);
-      setTimeout(() => {
-        menu.classList.add('hidden');
-      }, 300);
-    }
-  };
-  
-  function handleMenuEscape(e){
-    if(e.key === 'Escape'){
-      const menu = document.getElementById('mobileMenu');
-      if(!menu.classList.contains('hidden')){
-        toggleMenu();
-      }
-    }
-  }
+    <div
+      class="modal-bg"
+      id="anBg"
+      onclick="closeAnEvent(event)"
+      onkeydown="if (event.key === 'Enter' || event.key === ' ') closeAn();"
+      tabindex="-1"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Analytics & Achievements"
+    >
+      <div class="modal w-full max-w-4xl">
+        <button class="close-btn" onclick="closeAn()">
+          <span class="material-symbols-outlined">close</span>
+        </button>
+        <div class="modal-header pb-4 border-b border-zinc-100">
+          <div class="flex items-center justify-between">
+            <div>
+              <h2 class="text-3xl font-extrabold font-headline">
+                Analytics & Achievements
+              </h2>
+              <p class="text-zinc-500 text-sm mt-1">
+                Your activity stats and unlocked badges
+              </p>
+              <p class="text-zinc-400 text-xs mt-1 flex items-center gap-1">
+                <span class="material-symbols-outlined" style="font-size: 14px"
+                  >info</span
+                >
+                Badges are stored locally in your browser (per-device, cleared
+                with browser data)
+              </p>
+            </div>
+            <span class="badge-indicator" id="badgeIndicator">
+              <span class="material-symbols-outlined" style="font-size: 16px"
+                >emoji_events</span
+              >
+              0/16
+            </span>
+          </div>
+        </div>
+        <div class="modal-body p-6">
+          <!-- Stats Grid -->
+          <div
+            style="
+              display: grid;
+              grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+              gap: 12px;
+              margin-bottom: 24px;
+            "
+          >
+            <div
+              style="
+                background: var(--bg);
+                border: 1.5px solid var(--border2);
+                border-radius: 11px;
+                padding: 11px;
+                text-align: center;
+              "
+            >
+              <div
+                style="
+                  font-family: &quot;Playfair Display&quot;, serif;
+                  font-size: 19px;
+                  font-weight: 900;
+                  margin-bottom: 2px;
+                "
+                id="aTot"
+              >
+                0
+              </div>
+              <div
+                style="
+                  font-size: 9px;
+                  color: var(--muted);
+                  text-transform: uppercase;
+                  letter-spacing: 0.07em;
+                "
+              >
+                Total Visits
+              </div>
+            </div>
+            <div
+              style="
+                background: var(--bg);
+                border: 1.5px solid var(--border2);
+                border-radius: 11px;
+                padding: 11px;
+                text-align: center;
+              "
+            >
+              <div
+                style="
+                  font-family: &quot;Playfair Display&quot;, serif;
+                  font-size: 19px;
+                  font-weight: 900;
+                  margin-bottom: 2px;
+                "
+                id="aToday"
+              >
+                0
+              </div>
+              <div
+                style="
+                  font-size: 9px;
+                  color: var(--muted);
+                  text-transform: uppercase;
+                  letter-spacing: 0.07em;
+                "
+              >
+                Today
+              </div>
+            </div>
+            <div
+              style="
+                background: var(--bg);
+                border: 1.5px solid var(--border2);
+                border-radius: 11px;
+                padding: 11px;
+                text-align: center;
+              "
+            >
+              <div
+                style="
+                  font-family: &quot;Playfair Display&quot;, serif;
+                  font-size: 19px;
+                  font-weight: 900;
+                  margin-bottom: 2px;
+                "
+                id="aSearches"
+              >
+                0
+              </div>
+              <div
+                style="
+                  font-size: 9px;
+                  color: var(--muted);
+                  text-transform: uppercase;
+                  letter-spacing: 0.07em;
+                "
+              >
+                Searches
+              </div>
+            </div>
+            <div
+              style="
+                background: var(--bg);
+                border: 1.5px solid var(--border2);
+                border-radius: 11px;
+                padding: 11px;
+                text-align: center;
+              "
+            >
+              <div
+                style="
+                  font-family: &quot;Playfair Display&quot;, serif;
+                  font-size: 19px;
+                  font-weight: 900;
+                  margin-bottom: 2px;
+                "
+                id="aViews"
+              >
+                0
+              </div>
+              <div
+                style="
+                  font-size: 9px;
+                  color: var(--muted);
+                  text-transform: uppercase;
+                  letter-spacing: 0.07em;
+                "
+              >
+                Org Views
+              </div>
+            </div>
+            <div
+              style="
+                background: var(--bg);
+                border: 1.5px solid var(--border2);
+                border-radius: 11px;
+                padding: 11px;
+                text-align: center;
+              "
+            >
+              <div
+                style="
+                  font-family: &quot;Playfair Display&quot;, serif;
+                  font-size: 19px;
+                  font-weight: 900;
+                  margin-bottom: 2px;
+                "
+                id="aFilters"
+              >
+                0
+              </div>
+              <div
+                style="
+                  font-size: 9px;
+                  color: var(--muted);
+                  text-transform: uppercase;
+                  letter-spacing: 0.07em;
+                "
+              >
+                Filters Used
+              </div>
+            </div>
+            <div
+              style="
+                background: var(--bg);
+                border: 1.5px solid var(--border2);
+                border-radius: 11px;
+                padding: 11px;
+                text-align: center;
+              "
+            >
+              <div
+                style="
+                  font-family: &quot;Playfair Display&quot;, serif;
+                  font-size: 19px;
+                  font-weight: 900;
+                  margin-bottom: 2px;
+                "
+                id="aTime"
+              >
+                —
+              </div>
+              <div
+                style="
+                  font-size: 9px;
+                  color: var(--muted);
+                  text-transform: uppercase;
+                  letter-spacing: 0.07em;
+                "
+              >
+                Session Time
+              </div>
+            </div>
+          </div>
 
-window.setActiveMenu = function(clickedLink) {
-  // Remove active class from all menu links
-  const allLinks = document.querySelectorAll('.mobile-menu-link');
+          <!-- Badges Section -->
+          <div style="margin-bottom: 24px">
+            <div
+              style="
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                margin-bottom: 12px;
+              "
+            >
+              <h3
+                style="
+                  font-size: 10px;
+                  font-weight: 700;
+                  color: var(--muted);
+                  letter-spacing: 0.1em;
+                  text-transform: uppercase;
+                "
+              >
+                🏆 Achievement Badges
+              </h3>
+              <button
+                onclick="
+                  if (typeof BadgeSystem !== 'undefined') {
+                    BadgeSystem.resetProgress();
+                    renderBadges();
+                  }
+                "
+                style="
+                  font-size: 10px;
+                  font-weight: 700;
+                  color: var(--red);
+                  background: transparent;
+                  border: 1.5px solid var(--border);
+                  border-radius: 8px;
+                  padding: 4px 10px;
+                  cursor: pointer;
+                  transition: all 0.18s;
+                "
+                onmouseover="
+                  this.style.borderColor = 'var(--red)';
+                  this.style.background = 'rgba(197,48,48,.06)';
+                "
+                onmouseout="
+                  this.style.borderColor = 'var(--border)';
+                  this.style.background = 'transparent';
+                "
+              >
+                Reset Progress
+              </button>
+            </div>
+            <div id="badgesContainer">
+              <!-- Badges will be rendered here -->
+            </div>
+          </div>
 
-  allLinks.forEach(link => {
-    link.classList.remove(
-      'bg-orange-50',
-      'text-orange-600',
-      'font-bold'
-    );
+          <!-- Top Categories -->
+          <div style="margin-bottom: 20px">
+            <h3
+              style="
+                font-size: 10px;
+                font-weight: 700;
+                color: var(--muted);
+                letter-spacing: 0.1em;
+                text-transform: uppercase;
+                margin-bottom: 8px;
+              "
+            >
+              Top Categories
+            </h3>
+            <div id="catChart"></div>
+          </div>
 
-    link.classList.add(
-      'text-zinc-700',
-      'font-medium'
-    );
-  });
+          <!-- Top Organizations -->
+          <div style="margin-bottom: 20px">
+            <h3
+              style="
+                font-size: 10px;
+                font-weight: 700;
+                color: var(--muted);
+                letter-spacing: 0.1em;
+                text-transform: uppercase;
+                margin-bottom: 8px;
+              "
+            >
+              Most Viewed Orgs
+            </h3>
+            <div id="orgChart"></div>
+          </div>
 
-  // Add active class to clicked link
-  clickedLink.classList.remove(
-    'text-zinc-700',
-    'font-medium'
-  );
+          <!-- Search Terms -->
+          <div>
+            <h3
+              style="
+                font-size: 10px;
+                font-weight: 700;
+                color: var(--muted);
+                letter-spacing: 0.1em;
+                text-transform: uppercase;
+                margin-bottom: 8px;
+              "
+            >
+              Recent Searches
+            </h3>
+            <div id="srchTerms"></div>
+          </div>
+        </div>
+      </div>
+    </div>
 
-  clickedLink.classList.add(
-    'bg-orange-50',
-    'text-orange-600',
-    'font-bold'
-  );
+    <!-- ═══════════════════ JS ═══════════════════ -->
+    <script src="agent/scripts/orgs.js"></script>
+    <script>
+      // ══════════════════════════════════════════════
+      // THEME
+      // ══════════════════════════════════════════════
+      (function () {
+        const saved = localStorage.getItem("theme") || "light";
+        document.documentElement.classList.toggle("dark", saved === "dark");
+        updateThemeIcon();
+      })();
 
-  // Close menu
-  toggleMenu();
-};
+      window.toggleTheme = function () {
+        const isDark = document.documentElement.classList.toggle("dark");
+        localStorage.setItem("theme", isDark ? "dark" : "light");
+        updateThemeIcon();
+      };
 
-  // Update active state based on scroll position
-  function updateActiveSection() {
-    const sections = ['orgs', 'guide', 'watchlist', 'issues', 'mentors', 'timeline', 'ai-recommender'];
-    const scrollPosition = window.scrollY + 80; // Offset for fixed header
-    
-let currentSection = 'timeline';
-
-sections.forEach(sectionId => {
-    const section = document.getElementById(sectionId);
-
-    if (section) {
-        const sectionTop = section.offsetTop;
-        const sectionBottom = sectionTop + section.offsetHeight;
-
-        const triggerPoint = window.innerHeight / 2;
-
-        if (
-            sectionTop <= scrollPosition + triggerPoint &&
-            sectionBottom > scrollPosition + triggerPoint
-        ) {
-            currentSection = sectionId;
+      function updateThemeIcon() {
+        const btn = document.getElementById("themeToggleBtn");
+        const icon = btn
+          ? btn.querySelector(".material-symbols-outlined")
+          : null;
+        if (icon) {
+          const isDark = document.documentElement.classList.contains("dark");
+          icon.textContent = isDark ? "light_mode" : "dark_mode";
+          btn.setAttribute("aria-pressed", isDark ? "true" : "false");
+          btn.setAttribute(
+            "aria-label",
+            isDark ? "Switch to light theme" : "Switch to dark theme",
+          );
+          btn.setAttribute(
+            "title",
+            isDark ? "Switch to light theme" : "Switch to dark theme",
+          );
         }
-    }
-});
-    
-    // Update mobile menu items
-    const allMobileLinks = document.querySelectorAll('.mobile-menu-link');
-    allMobileLinks.forEach(link => {
-      const linkSection = link.getAttribute('data-section');
-      if (linkSection === currentSection) {
-        link.classList.remove('text-zinc-700', 'hover:bg-zinc-100', 'font-medium');
-        link.classList.add('text-orange-600', 'bg-orange-50', 'font-bold');
-      } else {
-        link.classList.remove('text-orange-600', 'bg-orange-50', 'font-bold');
-        link.classList.add('text-zinc-700', 'hover:bg-zinc-100', 'font-medium');
       }
-    });
 
-    // Update desktop navbar items
-    const allDesktopLinks = document.querySelectorAll('.desktop-nav-link');
-    allDesktopLinks.forEach(link => {
-      const linkSection = link.getAttribute('data-section');
-      if (linkSection === currentSection) {
-        link.classList.remove('text-zinc-600', 'hover:text-zinc-900');
-        link.classList.add('text-orange-600', 'font-bold', 'border-b-2', 'border-orange-600');
-      } else {
-        link.classList.remove('text-orange-600', 'font-bold', 'border-b-2', 'border-orange-600');
-        link.classList.add('text-zinc-600', 'hover:text-zinc-900');
+      // ══════════════════════════════════════════════
+      // MOBILE MENU
+      // ══════════════════════════════════════════════
+      window.toggleMenu = function () {
+        const menu = document.getElementById("mobileMenu");
+        const panel = document.getElementById("menuPanel");
+        const menuBtn = document.getElementById("menuBtn");
+
+        if (menu.classList.contains("hidden")) {
+          // Open menu
+          menu.classList.remove("hidden");
+          menuBtn.setAttribute("aria-expanded", "true");
+          menuBtn.setAttribute("aria-label", "Close menu");
+          setTimeout(() => {
+            panel.style.transform = "translateX(0)";
+          }, 10);
+          document.addEventListener("keydown", handleMenuEscape);
+        } else {
+          // Close menu
+          panel.style.transform = "translateX(-100%)";
+          menuBtn.setAttribute("aria-expanded", "false");
+          menuBtn.setAttribute("aria-label", "Open menu");
+          document.removeEventListener("keydown", handleMenuEscape);
+          setTimeout(() => {
+            menu.classList.add("hidden");
+          }, 300);
+        }
+      };
+
+      function handleMenuEscape(e) {
+        if (e.key === "Escape") {
+          const menu = document.getElementById("mobileMenu");
+          if (!menu.classList.contains("hidden")) {
+            toggleMenu();
+          }
+        }
       }
-    });
-  }
 
-  // Listen for scroll events
-  window.addEventListener('scroll', updateActiveSection);
-  
-  // Initialize on page load
-  document.addEventListener('DOMContentLoaded', updateActiveSection);
+      window.setActiveMenu = function (clickedLink) {
+        // Remove active class from all menu links
+        const allLinks = document.querySelectorAll(".mobile-menu-link");
 
-  // ══════════════════════════════════════════════
-  // Shared escaping helper (for all dynamic text used in HTML strings)
-  // Prevents HTML injection via <, >, &, quotes.
-  function escapeHtml(value) {
-    return String(value)
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;')
-      .replaceAll('"', '&quot;')
-      .replaceAll("'", '&#39;');
-  }
+        allLinks.forEach((link) => {
+          link.classList.remove("bg-orange-50", "text-orange-600", "font-bold");
 
-  // Sanitize hrefs: only allow http(s) absolute URLs.
-  // Returns the original URL string when allowed, otherwise null.
-  function sanitizeHrefUrl(url) {
-    if (!url || !String(url).trim()) return null;
-    try {
-      const u = new URL(String(url).trim());
-      if (u.protocol === 'http:' || u.protocol === 'https:') return u.toString();
-    } catch (e) {
-      // invalid URL
-    }
-    return null;
-  }
+          link.classList.add("text-zinc-700", "font-medium");
+        });
 
-  function parseStoredBookmarks() {
-    try {
-      const parsed = JSON.parse(localStorage.getItem('bookmarks') || '[]');
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
-  }
+        // Add active class to clicked link
+        clickedLink.classList.remove("text-zinc-700", "font-medium");
 
-  function trimGitHubPathSlashes(path) {
-    let start = 0;
-    let end = path.length;
-    while (start < end && path[start] === '/') start += 1;
-    while (end > start && path[end - 1] === '/') end -= 1;
-    return path.slice(start, end);
-  }
+        clickedLink.classList.add(
+          "bg-orange-50",
+          "text-orange-600",
+          "font-bold",
+        );
 
-  function githubPathFromValue(value) {
-    const github = String(value || '').trim();
-    if (!github) return '';
-    try {
-      const url = new URL(github);
-      const hostname = url.hostname.toLowerCase();
-      if (hostname !== 'github.com' && hostname !== 'www.github.com') return '';
-      return trimGitHubPathSlashes(url.pathname);
-    } catch {
-      return trimGitHubPathSlashes(github);
-    }
-  }
+        // Close menu
+        toggleMenu();
+      };
 
-  function githubOwnerFromValue(value) {
-    return githubPathFromValue(value).split('/')[0] || '';
-  }
+      // Update active state based on scroll position
+      function updateActiveSection() {
+        const sections = [
+          "orgs",
+          "guide",
+          "watchlist",
+          "issues",
+          "mentors",
+          "timeline",
+          "ai-recommender",
+        ];
+        const scrollPosition = window.scrollY + 80; // Offset for fixed header
 
-  function githubUrlFromValue(value) {
-    const path = githubPathFromValue(value);
-    return path ? `https://github.com/${path}` : null;
-  }
+        let currentSection = "timeline";
 
-  const CATEGORY_META = {
-    science: { className: 'bg-blue-100 text-blue-700', label: 'Science' },
-    programming: { className: 'bg-violet-100 text-violet-700', label: 'Programming' },
-    data: { className: 'bg-cyan-100 text-cyan-700', label: 'Data' },
-    web: { className: 'bg-green-100 text-green-700', label: 'Web' },
-    os: { className: 'bg-orange-100 text-orange-700', label: 'OS / Systems' },
-    security: { className: 'bg-red-100 text-red-700', label: 'Security' },
-    media: { className: 'bg-pink-100 text-pink-700', label: 'Media' },
-    infra: { className: 'bg-yellow-100 text-yellow-700', label: 'Infrastructure' },
-    ai: { className: 'bg-purple-100 text-purple-700', label: 'AI / ML' },
-    dev: { className: 'bg-teal-100 text-teal-700', label: 'Dev Tools' },
-    other: { className: 'bg-zinc-100 text-zinc-600', label: 'Other' },
-  };
+        sections.forEach((sectionId) => {
+          const section = document.getElementById(sectionId);
 
-  function getCategoryMeta(category) {
-    return CATEGORY_META[category] || CATEGORY_META.other;
-  }
+          if (section) {
+            const sectionTop = section.offsetTop;
+            const sectionBottom = sectionTop + section.offsetHeight;
 
-  // NOTE: For JS-string contexts inside inline event handlers,
-  // we must also escape quotes. Prefer removing inline handlers.
+            const triggerPoint = window.innerHeight / 2;
 
-  // ══════════════════════════════════════════════
-  // MAIN APP LOGIC
-  // ══════════════════════════════════════════════
-  let visibleCount = 12;
-  let visibleMentorCount = 12;
+            if (
+              sectionTop <= scrollPosition + triggerPoint &&
+              sectionBottom > scrollPosition + triggerPoint
+            ) {
+              currentSection = sectionId;
+            }
+          }
+        });
 
-  let filteredOrgs = [...ORGS];
-  let MENTOR_DATA = {};
-  let mentorDataState = 'idle';
-  let compareList = [];
-  const bookmarkedSet = (() => {
-    return new Set(parseStoredBookmarks());
-  })();
+        // Update mobile menu items
+        const allMobileLinks = document.querySelectorAll(".mobile-menu-link");
+        allMobileLinks.forEach((link) => {
+          const linkSection = link.getAttribute("data-section");
+          if (linkSection === currentSection) {
+            link.classList.remove(
+              "text-zinc-700",
+              "hover:bg-zinc-100",
+              "font-medium",
+            );
+            link.classList.add("text-orange-600", "bg-orange-50", "font-bold");
+          } else {
+            link.classList.remove(
+              "text-orange-600",
+              "bg-orange-50",
+              "font-bold",
+            );
+            link.classList.add(
+              "text-zinc-700",
+              "hover:bg-zinc-100",
+              "font-medium",
+            );
+          }
+        });
 
-  // Recently Viewed Organizations
-  const RECENTLY_VIEWED_KEY = 'recentlyViewedOrgs';
-  const RECENTLY_VIEWED_LIMIT = 8;
-  let recentlyViewed = (() => {
-    try {
-      const parsed = JSON.parse(localStorage.getItem(RECENTLY_VIEWED_KEY) || '[]');
-      if (!Array.isArray(parsed)) return [];
-      const orgNames = new Set(ORGS.map(org => org.name));
-      const seen = new Set();
-      return parsed.filter(name => {
-        if (typeof name !== 'string' || !orgNames.has(name) || seen.has(name)) return false;
-        seen.add(name);
-        return true;
-      });
-    } catch {
-      return [];
-    }
-  })();
+        // Update desktop navbar items
+        const allDesktopLinks = document.querySelectorAll(".desktop-nav-link");
+        allDesktopLinks.forEach((link) => {
+          const linkSection = link.getAttribute("data-section");
+          if (linkSection === currentSection) {
+            link.classList.remove("text-zinc-600", "hover:text-zinc-900");
+            link.classList.add(
+              "text-orange-600",
+              "font-bold",
+              "border-b-2",
+              "border-orange-600",
+            );
+          } else {
+            link.classList.remove(
+              "text-orange-600",
+              "font-bold",
+              "border-b-2",
+              "border-orange-600",
+            );
+            link.classList.add("text-zinc-600", "hover:text-zinc-900");
+          }
+        });
+      }
 
-  const selectedLanguages = new Set();
-  let matchAllLanguages = false;
-  let activeChip = null; // tracks the active quick-filter chip key ('veterans' | 'newcomers' | 'low-competition' | 'high-competition' | 'bookmarked' | 'active' | null)
-  const CHANNEL_ICONS = {
-    Slack: '💬',
-    Zulip: '💬',
-    Discord: '🎮',
-    Matrix: '🔗',
-    IRC: '🖥️',
-    'Mailing list': '📧'
-  };
-  const CONTACT_TIPS = {
-    Slack: 'Join and say hi in the GSoC channel before DMing mentors.',
-    Discord: 'Introduce yourself in the public channel before asking project-specific questions.',
-    Zulip: 'Post a new topic in the GSoC stream with your background and interest.',
-    Matrix: "Say hello in the public room and mention the project area you're exploring.",
-    IRC: 'Stay in the channel for a while; replies are often asynchronous.',
-    'Mailing list': "Send a short intro email with your background and the idea you're interested in."
-  };
-  const LANGUAGE_ALIASES = {
-    'python': ['python'],
-    'javascript': ['javascript', 'js'],
-    'typescript': ['typescript', 'ts'],
-    'c/c++': ['c', 'c++', 'cpp'],
-    'java': ['java'],
-    'rust': ['rust'],
-    'go': ['go', 'golang'],
-    'ruby': ['ruby'],
-    'haskell': ['haskell'],
-    'scala': ['scala'],
-    'ml/ai': ['ml', 'ai', 'machine learning', 'artificial intelligence'],
-    'robotics': ['robotics', 'robot', 'ros']
-  };
+      // Listen for scroll events
+      window.addEventListener("scroll", updateActiveSection);
 
-  // Compatibility layer: expose a single LANGUAGE_MAP and shared `pills` set
-  // so the embedded script and any external `src/js/app.js` logic agree.
-  (function buildCompatibilityLayer(){
-    // Expose the selectedLanguages set as `pills` for compatibility
-    globalThis.pills = selectedLanguages;
-    // Expose matchAllLanguages as a global variable reference (kept in sync below)
-    globalThis.matchAllLanguages = matchAllLanguages;
-    globalThis.compareList = compareList;
-    globalThis.bookmarkedSet = bookmarkedSet;
+      // Initialize on page load
+      document.addEventListener("DOMContentLoaded", updateActiveSection);
 
-    // Build a LANGUAGE_MAP with display-label keys matching src/js/app.js expectations
-    const toDisplayKey = (k) => {
-      if (k === 'ml/ai') return 'ML/AI';
-      if (k === 'c/c++') return 'C/C++';
-      return k.split(/[\s\/]+/).map(p => p.charAt(0).toUpperCase()+p.slice(1)).join(' ');
-    };
-    const LANG_MAP = {};
-    Object.keys(LANGUAGE_ALIASES).forEach(k => {
-      LANG_MAP[toDisplayKey(k)] = LANGUAGE_ALIASES[k];
-    });
-    // Also expose the lowercase-keyed aliases for any consumers that expect that
-    Object.keys(LANGUAGE_ALIASES).forEach(k => { LANG_MAP[k] = LANGUAGE_ALIASES[k]; });
-    globalThis.LANGUAGE_MAP = globalThis.LANGUAGE_MAP || LANG_MAP;
-  })();
+      // ══════════════════════════════════════════════
+      // Shared escaping helper (for all dynamic text used in HTML strings)
+      // Prevents HTML injection via <, >, &, quotes.
+      function escapeHtml(value) {
+        return String(value)
+          .replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;")
+          .replaceAll('"', "&quot;")
+          .replaceAll("'", "&#39;");
+      }
 
-  function updateLanguageModeHint() {
-    const hint = document.getElementById('languageLogicHint');
-    if (!hint) return;
-    hint.textContent = matchAllLanguages
-      ? 'Multiple language chips use AND (must match all selected).'
-      : 'Multiple language chips use OR (any selected).';
-  }
+      // Sanitize hrefs: only allow http(s) absolute URLs.
+      // Returns the original URL string when allowed, otherwise null.
+      function sanitizeHrefUrl(url) {
+        if (!url || !String(url).trim()) return null;
+        try {
+          const u = new URL(String(url).trim());
+          if (u.protocol === "http:" || u.protocol === "https:")
+            return u.toString();
+        } catch (e) {
+          // invalid URL
+        }
+        return null;
+      }
 
-  function languageMatchesSelection(tags, lang) {
-    const langKey = lang.toLowerCase();
-    const aliases = LANGUAGE_ALIASES[langKey] || [langKey];
-    // Use exact token matching to prevent false positives like "Go" matching "django"
-    // Tags are split on whitespace, commas, slashes, and plus signs before comparing
-    return aliases.some(alias => {
-      const a = alias.toLowerCase();
-      return tags.some(tag => {
-        const tokens = tag.toLowerCase().split(/[\s,/+]+/);
-        return tokens.includes(a);
-      });
-    });
-  }
+      function parseStoredBookmarks() {
+        try {
+          const parsed = JSON.parse(localStorage.getItem("bookmarks") || "[]");
+          return Array.isArray(parsed) ? parsed : [];
+        } catch {
+          return [];
+        }
+      }
 
-  function clearSelectedLanguagePills() {
-    selectedLanguages.clear();
-    document.querySelectorAll('.pill.active').forEach(pill => {
-      pill.classList.remove('active');
-      pill.setAttribute('aria-pressed', 'false');
-    });
-    renderSelectedLanguages();
-  }
+      function trimGitHubPathSlashes(path) {
+        let start = 0;
+        let end = path.length;
+        while (start < end && path[start] === "/") start += 1;
+        while (end > start && path[end - 1] === "/") end -= 1;
+        return path.slice(start, end);
+      }
 
-  function renderSelectedLanguages() {
-    const container = document.getElementById('selectedLangsStrip');
-    if (!container) return;
+      function githubPathFromValue(value) {
+        const github = String(value || "").trim();
+        if (!github) return "";
+        try {
+          const url = new URL(github);
+          const hostname = url.hostname.toLowerCase();
+          if (hostname !== "github.com" && hostname !== "www.github.com")
+            return "";
+          return trimGitHubPathSlashes(url.pathname);
+        } catch {
+          return trimGitHubPathSlashes(github);
+        }
+      }
 
-    if (selectedLanguages.size === 0) {
-      container.innerHTML = '<span class="empty-state">No languages selected</span>';
-      return;
-    }
+      function githubOwnerFromValue(value) {
+        return githubPathFromValue(value).split("/")[0] || "";
+      }
 
-    const badges = [...selectedLanguages].map(lang => {
-      return `<span class="selected-lang-badge" data-lang="${lang}">
+      function githubUrlFromValue(value) {
+        const path = githubPathFromValue(value);
+        return path ? `https://github.com/${path}` : null;
+      }
+
+      const CATEGORY_META = {
+        science: { className: "bg-blue-100 text-blue-700", label: "Science" },
+        programming: {
+          className: "bg-violet-100 text-violet-700",
+          label: "Programming",
+        },
+        data: { className: "bg-cyan-100 text-cyan-700", label: "Data" },
+        web: { className: "bg-green-100 text-green-700", label: "Web" },
+        os: {
+          className: "bg-orange-100 text-orange-700",
+          label: "OS / Systems",
+        },
+        security: { className: "bg-red-100 text-red-700", label: "Security" },
+        media: { className: "bg-pink-100 text-pink-700", label: "Media" },
+        infra: {
+          className: "bg-yellow-100 text-yellow-700",
+          label: "Infrastructure",
+        },
+        ai: { className: "bg-purple-100 text-purple-700", label: "AI / ML" },
+        dev: { className: "bg-teal-100 text-teal-700", label: "Dev Tools" },
+        other: { className: "bg-zinc-100 text-zinc-600", label: "Other" },
+      };
+
+      function getCategoryMeta(category) {
+        return CATEGORY_META[category] || CATEGORY_META.other;
+      }
+
+      // NOTE: For JS-string contexts inside inline event handlers,
+      // we must also escape quotes. Prefer removing inline handlers.
+
+      // ══════════════════════════════════════════════
+      // MAIN APP LOGIC
+      // ══════════════════════════════════════════════
+      let visibleCount = 12;
+      let visibleMentorCount = 12;
+
+      let filteredOrgs = [...ORGS];
+      let MENTOR_DATA = {};
+      let mentorDataState = "idle";
+      let compareList = [];
+      const bookmarkedSet = (() => {
+        return new Set(parseStoredBookmarks());
+      })();
+
+      // Recently Viewed Organizations
+      const RECENTLY_VIEWED_KEY = "recentlyViewedOrgs";
+      const RECENTLY_VIEWED_LIMIT = 8;
+      let recentlyViewed = (() => {
+        try {
+          const parsed = JSON.parse(
+            localStorage.getItem(RECENTLY_VIEWED_KEY) || "[]",
+          );
+          if (!Array.isArray(parsed)) return [];
+          const orgNames = new Set(ORGS.map((org) => org.name));
+          const seen = new Set();
+          return parsed.filter((name) => {
+            if (
+              typeof name !== "string" ||
+              !orgNames.has(name) ||
+              seen.has(name)
+            )
+              return false;
+            seen.add(name);
+            return true;
+          });
+        } catch {
+          return [];
+        }
+      })();
+
+      const selectedLanguages = new Set();
+      let matchAllLanguages = false;
+      let activeChip = null; // tracks the active quick-filter chip key ('veterans' | 'newcomers' | 'low-competition' | 'high-competition' | 'bookmarked' | 'active' | null)
+      const CHANNEL_ICONS = {
+        Slack: "💬",
+        Zulip: "💬",
+        Discord: "🎮",
+        Matrix: "🔗",
+        IRC: "🖥️",
+        "Mailing list": "📧",
+      };
+      const CONTACT_TIPS = {
+        Slack: "Join and say hi in the GSoC channel before DMing mentors.",
+        Discord:
+          "Introduce yourself in the public channel before asking project-specific questions.",
+        Zulip:
+          "Post a new topic in the GSoC stream with your background and interest.",
+        Matrix:
+          "Say hello in the public room and mention the project area you're exploring.",
+        IRC: "Stay in the channel for a while; replies are often asynchronous.",
+        "Mailing list":
+          "Send a short intro email with your background and the idea you're interested in.",
+      };
+      const LANGUAGE_ALIASES = {
+        python: ["python"],
+        javascript: ["javascript", "js"],
+        typescript: ["typescript", "ts"],
+        "c/c++": ["c", "c++", "cpp"],
+        java: ["java"],
+        rust: ["rust"],
+        go: ["go", "golang"],
+        ruby: ["ruby"],
+        haskell: ["haskell"],
+        scala: ["scala"],
+        "ml/ai": ["ml", "ai", "machine learning", "artificial intelligence"],
+        robotics: ["robotics", "robot", "ros"],
+      };
+
+      // Compatibility layer: expose a single LANGUAGE_MAP and shared `pills` set
+      // so the embedded script and any external `src/js/app.js` logic agree.
+      (function buildCompatibilityLayer() {
+        // Expose the selectedLanguages set as `pills` for compatibility
+        globalThis.pills = selectedLanguages;
+        // Expose matchAllLanguages as a global variable reference (kept in sync below)
+        globalThis.matchAllLanguages = matchAllLanguages;
+        globalThis.compareList = compareList;
+        globalThis.bookmarkedSet = bookmarkedSet;
+
+        // Build a LANGUAGE_MAP with display-label keys matching src/js/app.js expectations
+        const toDisplayKey = (k) => {
+          if (k === "ml/ai") return "ML/AI";
+          if (k === "c/c++") return "C/C++";
+          return k
+            .split(/[\s\/]+/)
+            .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+            .join(" ");
+        };
+        const LANG_MAP = {};
+        Object.keys(LANGUAGE_ALIASES).forEach((k) => {
+          LANG_MAP[toDisplayKey(k)] = LANGUAGE_ALIASES[k];
+        });
+        // Also expose the lowercase-keyed aliases for any consumers that expect that
+        Object.keys(LANGUAGE_ALIASES).forEach((k) => {
+          LANG_MAP[k] = LANGUAGE_ALIASES[k];
+        });
+        globalThis.LANGUAGE_MAP = globalThis.LANGUAGE_MAP || LANG_MAP;
+      })();
+
+      function updateLanguageModeHint() {
+        const hint = document.getElementById("languageLogicHint");
+        if (!hint) return;
+        hint.textContent = matchAllLanguages
+          ? "Multiple language chips use AND (must match all selected)."
+          : "Multiple language chips use OR (any selected).";
+      }
+
+      function languageMatchesSelection(tags, lang) {
+        const langKey = lang.toLowerCase();
+        const aliases = LANGUAGE_ALIASES[langKey] || [langKey];
+        // Use exact token matching to prevent false positives like "Go" matching "django"
+        // Tags are split on whitespace, commas, slashes, and plus signs before comparing
+        return aliases.some((alias) => {
+          const a = alias.toLowerCase();
+          return tags.some((tag) => {
+            const tokens = tag.toLowerCase().split(/[\s,/+]+/);
+            return tokens.includes(a);
+          });
+        });
+      }
+
+      function clearSelectedLanguagePills() {
+        selectedLanguages.clear();
+        document.querySelectorAll(".pill.active").forEach((pill) => {
+          pill.classList.remove("active");
+          pill.setAttribute("aria-pressed", "false");
+        });
+        renderSelectedLanguages();
+      }
+
+      function renderSelectedLanguages() {
+        const container = document.getElementById("selectedLangsStrip");
+        if (!container) return;
+
+        if (selectedLanguages.size === 0) {
+          container.innerHTML =
+            '<span class="empty-state">No languages selected</span>';
+          return;
+        }
+
+        const badges = [...selectedLanguages]
+          .map((lang) => {
+            return `<span class="selected-lang-badge" data-lang="${lang}">
         ${lang}
         <button class="unselect-lang-btn" onclick="unselectLanguage('${lang}')" aria-label="Remove ${lang}">×</button>
       </span>`;
-    }).join('');
+          })
+          .join("");
 
-    const clearAll = `<button class="clear-all-langs-btn" onclick="clearAllLanguages()">Clear all</button>`;
-    container.innerHTML = badges + clearAll;
-  }
+        const clearAll = `<button class="clear-all-langs-btn" onclick="clearAllLanguages()">Clear all</button>`;
+        container.innerHTML = badges + clearAll;
+      }
 
-  window.unselectLanguage = function(lang) {
-    selectedLanguages.delete(lang);
-    const pillBtn = document.querySelector(`.pill[data-lang="${lang}"]`);
-    if (pillBtn) {
-      pillBtn.classList.remove('active');
-      pillBtn.setAttribute('aria-pressed', 'false');
-    }
-    renderSelectedLanguages();
-    applyFilters();
-  }
+      window.unselectLanguage = function (lang) {
+        selectedLanguages.delete(lang);
+        const pillBtn = document.querySelector(`.pill[data-lang="${lang}"]`);
+        if (pillBtn) {
+          pillBtn.classList.remove("active");
+          pillBtn.setAttribute("aria-pressed", "false");
+        }
+        renderSelectedLanguages();
+        applyFilters();
+      };
 
-  window.clearAllLanguages = function() {
-    selectedLanguages.clear();
-    document.querySelectorAll('.pill.active').forEach(p => {
-      p.classList.remove('active');
-      p.setAttribute('aria-pressed', 'false');
-    });
-    renderSelectedLanguages();
-    applyFilters();
-  }
+      window.clearAllLanguages = function () {
+        selectedLanguages.clear();
+        document.querySelectorAll(".pill.active").forEach((p) => {
+          p.classList.remove("active");
+          p.setAttribute("aria-pressed", "false");
+        });
+        renderSelectedLanguages();
+        applyFilters();
+      };
 
-  // NOTE: toggleLanguageMode removed — the matchAllLanguagesToggle checkbox
-  // uses a direct event listener (line ~1538) and does not use onclick=.
+      // NOTE: toggleLanguageMode removed — the matchAllLanguagesToggle checkbox
+      // uses a direct event listener (line ~1538) and does not use onclick=.
 
-  window.togglePill = function(el) {
-    const langDisplay = el.dataset.lang || '';
-    const langKey = langDisplay.trim().toLowerCase();
-    if (!langKey) return;
-    const isActive = el.classList.toggle('active');
-    el.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-    if (selectedLanguages.has(langDisplay)) selectedLanguages.delete(langDisplay);
-    else selectedLanguages.add(langDisplay);
-    renderSelectedLanguages();
-    
-    // Track filter badge when user toggles language pill
-    if (typeof BadgeSystem !== 'undefined') {
-      BadgeSystem.trackFilter();
-    }
-    applyFilters();
-  };
+      window.togglePill = function (el) {
+        const langDisplay = el.dataset.lang || "";
+        const langKey = langDisplay.trim().toLowerCase();
+        if (!langKey) return;
+        const isActive = el.classList.toggle("active");
+        el.setAttribute("aria-pressed", isActive ? "true" : "false");
+        if (selectedLanguages.has(langDisplay))
+          selectedLanguages.delete(langDisplay);
+        else selectedLanguages.add(langDisplay);
+        renderSelectedLanguages();
 
-  function createDefaultMentorEntry(org) {
-    return {
-      org: org.name,
-      ideasUrl: org.ideas || '',
-      channels: [],
-      mentors: [],
-      mailingLists: [],
-      tip: '',
-      status: 'fetch-failed',
-      lastFetched: ''
-    };
-  }
+        // Track filter badge when user toggles language pill
+        if (typeof BadgeSystem !== "undefined") {
+          BadgeSystem.trackFilter();
+        }
+        applyFilters();
+      };
 
-  function getMentorEntry(name) {
-    const org = ORGS.find(item => item.name === name);
-    if (!org) return null;
-    return MENTOR_DATA[name] || createDefaultMentorEntry(org);
-  }
+      function createDefaultMentorEntry(org) {
+        return {
+          org: org.name,
+          ideasUrl: org.ideas || "",
+          channels: [],
+          mentors: [],
+          mailingLists: [],
+          tip: "",
+          status: "fetch-failed",
+          lastFetched: "",
+        };
+      }
 
-  function formatRelativeRefresh(isoString) {
-    if (!isoString) return 'Last updated: unavailable';
-    const timestamp = new Date(isoString).getTime();
-    if (Number.isNaN(timestamp)) return 'Last updated: unavailable';
-    const minutes = Math.max(1, Math.floor((Date.now() - timestamp) / 60000));
-    if (minutes < 60) return `Last updated: ${minutes} min ago`;
-    const hours = Math.floor(minutes / 60);
-    if (hours < 48) return `Last updated: ${hours} hour${hours === 1 ? '' : 's'} ago`;
-    const days = Math.floor(hours / 24);
-    return `Last updated: ${days} day${days === 1 ? '' : 's'} ago`;
-  }
+      function getMentorEntry(name) {
+        const org = ORGS.find((item) => item.name === name);
+        if (!org) return null;
+        return MENTOR_DATA[name] || createDefaultMentorEntry(org);
+      }
 
-  function getPrimaryMentorContact(entry) {
-    if ((entry.channels || []).length > 0) return entry.channels[0];
-    if ((entry.mailingLists || []).length > 0) return entry.mailingLists[0];
-    return null;
-  }
+      function formatRelativeRefresh(isoString) {
+        if (!isoString) return "Last updated: unavailable";
+        const timestamp = new Date(isoString).getTime();
+        if (Number.isNaN(timestamp)) return "Last updated: unavailable";
+        const minutes = Math.max(
+          1,
+          Math.floor((Date.now() - timestamp) / 60000),
+        );
+        if (minutes < 60) return `Last updated: ${minutes} min ago`;
+        const hours = Math.floor(minutes / 60);
+        if (hours < 48)
+          return `Last updated: ${hours} hour${hours === 1 ? "" : "s"} ago`;
+        const days = Math.floor(hours / 24);
+        return `Last updated: ${days} day${days === 1 ? "" : "s"} ago`;
+      }
 
-  function buildChannelChips(records) {
-    return records
-      .map((record) => {
-        const safe = sanitizeHrefUrl(record.url);
-        if (!safe) return '';
-        return `
+      function getPrimaryMentorContact(entry) {
+        if ((entry.channels || []).length > 0) return entry.channels[0];
+        if ((entry.mailingLists || []).length > 0) return entry.mailingLists[0];
+        return null;
+      }
+
+      function buildChannelChips(records) {
+        return records
+          .map((record) => {
+            const safe = sanitizeHrefUrl(record.url);
+            if (!safe) return "";
+            return `
           <a class="mentor-link-chip" href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer">
-            <span>${CHANNEL_ICONS[record.type] || '💬'}</span>
+            <span>${CHANNEL_ICONS[record.type] || "💬"}</span>
             <span>${escapeHtml(record.label || record.type)}</span>
           </a>
         `;
-      })
-      .filter(Boolean)
-      .join('');
-  }
+          })
+          .filter(Boolean)
+          .join("");
+      }
 
-  function buildMentorChips(mentors) {
-    return mentors
-      .map((mentor) => {
-        if (mentor.githubUrl) {
-          const safe = sanitizeHrefUrl(mentor.githubUrl);
-          const label = mentor.github ? `@${mentor.github}` : (mentor.name || mentor.githubUrl);
-          if (safe) {
-            return `
+      function buildMentorChips(mentors) {
+        return mentors
+          .map((mentor) => {
+            if (mentor.githubUrl) {
+              const safe = sanitizeHrefUrl(mentor.githubUrl);
+              const label = mentor.github
+                ? `@${mentor.github}`
+                : mentor.name || mentor.githubUrl;
+              if (safe) {
+                return `
               <a class="mentor-handle-chip" href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer">
                 <span>🐙</span>
                 <span>${escapeHtml(label)}</span>
               </a>
             `;
-          }
-        }
+              }
+            }
 
-        return `
+            return `
           <span class="mentor-handle-chip">
             <span>👤</span>
-            <span>${escapeHtml(mentor.name || 'Mentor')}</span>
+            <span>${escapeHtml(mentor.name || "Mentor")}</span>
           </span>
         `;
-      })
-      .join('');
-  }
-
-  function buildMentorPreviewChips(mentorPreview) {
-    if (mentorPreview.length === 0) {
-      return '<p class="text-sm text-zinc-600">No mentor handles parsed yet.</p>';
-    }
-
-    const chips = mentorPreview.map((mentor) => {
-      if (mentor.githubUrl) {
-        const safe = sanitizeHrefUrl(mentor.githubUrl);
-        if (safe) return `<a class="mentor-handle-chip" href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer"><span>🐙</span><span>${escapeHtml(mentor.displayLabel)}</span></a>`;
+          })
+          .join("");
       }
 
-      return `<span class="mentor-handle-chip"><span>👤</span><span>${escapeHtml(mentor.displayLabel)}</span></span>`;
-    }).join('');
+      function buildMentorPreviewChips(mentorPreview) {
+        if (mentorPreview.length === 0) {
+          return '<p class="text-sm text-zinc-600">No mentor handles parsed yet.</p>';
+        }
 
-    return `<div class="flex flex-wrap gap-2">${chips}</div>`;
-  }
+        const chips = mentorPreview
+          .map((mentor) => {
+            if (mentor.githubUrl) {
+              const safe = sanitizeHrefUrl(mentor.githubUrl);
+              if (safe)
+                return `<a class="mentor-handle-chip" href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer"><span>🐙</span><span>${escapeHtml(mentor.displayLabel)}</span></a>`;
+            }
 
-  function renderMentorContactSection(org) {
-    const container = document.getElementById('mMentorSection');
-    if (!container) return;
+            return `<span class="mentor-handle-chip"><span>👤</span><span>${escapeHtml(mentor.displayLabel)}</span></span>`;
+          })
+          .join("");
 
-    if (mentorDataState === 'idle' || mentorDataState === 'loading') {
-      container.innerHTML = '<p class="text-sm text-zinc-500">Loading mentor contact data...</p>';
-      return;
-    }
+        return `<div class="flex flex-wrap gap-2">${chips}</div>`;
+      }
 
-    const entry = getMentorEntry(org.name);
-    if (!entry) {
-      container.innerHTML = '<p class="text-sm text-zinc-500">Mentor data unavailable right now.</p>';
-      return;
-    }
+      function renderMentorContactSection(org) {
+        const container = document.getElementById("mMentorSection");
+        if (!container) return;
 
-    const fallbackIdeasLink = (function(){
-      const u = sanitizeHrefUrl(org.ideas);
-      return u ? `<a href="${escapeHtml(u)}" target="_blank" rel="noopener noreferrer" class="mentor-link-chip"><span>💡</span><span>Visit ideas page</span></a>` : '';
-    })();
+        if (mentorDataState === "idle" || mentorDataState === "loading") {
+          container.innerHTML =
+            '<p class="text-sm text-zinc-500">Loading mentor contact data...</p>';
+          return;
+        }
 
-    const sections = [];
-    if (entry.status === 'ok' && (entry.channels || []).length > 0) {
-      sections.push(`
+        const entry = getMentorEntry(org.name);
+        if (!entry) {
+          container.innerHTML =
+            '<p class="text-sm text-zinc-500">Mentor data unavailable right now.</p>';
+          return;
+        }
+
+        const fallbackIdeasLink = (function () {
+          const u = sanitizeHrefUrl(org.ideas);
+          return u
+            ? `<a href="${escapeHtml(u)}" target="_blank" rel="noopener noreferrer" class="mentor-link-chip"><span>💡</span><span>Visit ideas page</span></a>`
+            : "";
+        })();
+
+        const sections = [];
+        if (entry.status === "ok" && (entry.channels || []).length > 0) {
+          sections.push(`
         <div>
           <p class="text-xs font-bold uppercase tracking-widest text-zinc-400 mb-3">Channels</p>
           <div class="flex flex-wrap gap-2">${buildChannelChips(entry.channels)}</div>
         </div>
       `);
-    }
+        }
 
-    if (entry.status === 'ok' && (entry.mentors || []).length > 0) {
-      sections.push(`
+        if (entry.status === "ok" && (entry.mentors || []).length > 0) {
+          sections.push(`
         <div>
           <p class="text-xs font-bold uppercase tracking-widest text-zinc-400 mb-3">Mentors</p>
           <div class="flex flex-wrap gap-2">${buildMentorChips(entry.mentors)}</div>
         </div>
       `);
-    }
+        }
 
-    if (entry.status === 'ok' && (entry.mailingLists || []).length > 0) {
-      sections.push(`
+        if (entry.status === "ok" && (entry.mailingLists || []).length > 0) {
+          sections.push(`
         <div>
           <p class="text-xs font-bold uppercase tracking-widest text-zinc-400 mb-3">Mailing Lists</p>
-          <div class="flex flex-wrap gap-2">${buildChannelChips(entry.mailingLists.map((list) => ({ ...list, type: 'Mailing list' })))}</div>
+          <div class="flex flex-wrap gap-2">${buildChannelChips(entry.mailingLists.map((list) => ({ ...list, type: "Mailing list" })))}</div>
         </div>
       `);
-    }
+        }
 
-    if (entry.tip) {
-      sections.push(`
+        if (entry.tip) {
+          sections.push(`
         <div class="rounded-2xl bg-orange-50 border border-orange-100 p-4">
           <p class="text-xs font-bold uppercase tracking-widest text-primary mb-1">Contact Tip</p>
           <p class="text-sm text-zinc-700">${escapeHtml(entry.tip)}</p>
         </div>
       `);
-    }
+        }
 
-    if (sections.length === 0) {
-      let message = 'No contact info parsed yet.';
-      if (entry.status === 'fetch-failed') {
-        message = 'Mentor data unavailable right now.';
-      }
-      container.innerHTML = `
+        if (sections.length === 0) {
+          let message = "No contact info parsed yet.";
+          if (entry.status === "fetch-failed") {
+            message = "Mentor data unavailable right now.";
+          }
+          container.innerHTML = `
         <div class="rounded-2xl border border-dashed border-zinc-200 p-5">
           <p class="text-sm text-zinc-600 mb-3">${message}</p>
           <div class="flex flex-wrap gap-2">${fallbackIdeasLink || '<span class="text-xs text-zinc-400">No ideas page listed.</span>'}</div>
         </div>
       `;
-      return;
-    }
+          return;
+        }
 
-    container.innerHTML = `
+        container.innerHTML = `
       <div class="space-y-4">
-        ${sections.join('')}
-        ${fallbackIdeasLink ? `<div class="flex flex-wrap gap-2">${fallbackIdeasLink}</div>` : ''}
+        ${sections.join("")}
+        ${fallbackIdeasLink ? `<div class="flex flex-wrap gap-2">${fallbackIdeasLink}</div>` : ""}
       </div>
     `;
-  }
+      }
 
-  function getMentorFinderRecords() {
-    return ORGS.map((org) => ({
-      org,
-      entry: getMentorEntry(org.name)
-    }));
-  }
+      function getMentorFinderRecords() {
+        return ORGS.map((org) => ({
+          org,
+          entry: getMentorEntry(org.name),
+        }));
+      }
 
-  function renderMentorFinder(reset = true) {
-    const grid = document.getElementById('mentorGrid');
-    const lastUpdatedEl = document.getElementById('mentorLastUpdated');
-    if (!grid) return;
+      function renderMentorFinder(reset = true) {
+        const grid = document.getElementById("mentorGrid");
+        const lastUpdatedEl = document.getElementById("mentorLastUpdated");
+        if (!grid) return;
 
-    if (reset) {
-      grid.innerHTML = '';
-      visibleMentorCount = 12;
-    }
+        if (reset) {
+          grid.innerHTML = "";
+          visibleMentorCount = 12;
+        }
 
-    if (mentorDataState === 'loading' || mentorDataState === 'idle') {
-      grid.innerHTML = `
+        if (mentorDataState === "loading" || mentorDataState === "idle") {
+          grid.innerHTML = `
         <div class="col-span-full mentor-empty">
           <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
         </div>
       `;
-      return;
-    }
+          return;
+        }
 
-    if (mentorDataState === 'error') {
-      grid.innerHTML = `
+        if (mentorDataState === "error") {
+          grid.innerHTML = `
         <div class="col-span-full mentor-empty">
           <p class="font-bold text-zinc-900 mb-2">Mentor data unavailable right now.</p>
           <p class="text-sm text-zinc-600">The cached mentor snapshot could not be loaded. Please try again later.</p>
         </div>
       `;
-      if (lastUpdatedEl?.textContent !== undefined) lastUpdatedEl.textContent = 'Last updated: unavailable';
-      return;
-    }
+          if (lastUpdatedEl?.textContent !== undefined)
+            lastUpdatedEl.textContent = "Last updated: unavailable";
+          return;
+        }
 
-    const search = (document.getElementById('mentorSearchInput')?.value || '').trim().toLowerCase();
-    const channelFilter = document.getElementById('mentorChannelFilter')?.value || 'all';
-    const records = getMentorFinderRecords();
-    const lastFetched = records.map((record) => record.entry.lastFetched).find(Boolean);
-    if (lastUpdatedEl?.textContent !== undefined) {
-      lastUpdatedEl.textContent = formatRelativeRefresh(lastFetched);
-    }
+        const search = (
+          document.getElementById("mentorSearchInput")?.value || ""
+        )
+          .trim()
+          .toLowerCase();
+        const channelFilter =
+          document.getElementById("mentorChannelFilter")?.value || "all";
+        const records = getMentorFinderRecords();
+        const lastFetched = records
+          .map((record) => record.entry.lastFetched)
+          .find(Boolean);
+        if (lastUpdatedEl?.textContent !== undefined) {
+          lastUpdatedEl.textContent = formatRelativeRefresh(lastFetched);
+        }
 
-    const filteredRecords = records.filter(({ org, entry }) => {
-      const searchHaystack = [
-        org.name,
-        ...(entry.mentors || []).flatMap((mentor) => [mentor.name || '', mentor.github || ''])
-      ].join(' ').toLowerCase();
+        const filteredRecords = records.filter(({ org, entry }) => {
+          const searchHaystack = [
+            org.name,
+            ...(entry.mentors || []).flatMap((mentor) => [
+              mentor.name || "",
+              mentor.github || "",
+            ]),
+          ]
+            .join(" ")
+            .toLowerCase();
 
-      const matchesSearch = !search || searchHaystack.includes(search);
-      const allContacts = [...(entry.channels || []), ...(entry.mailingLists || []).map((list) => ({ ...list, type: 'Mailing list' }))];
-      const matchesChannel = channelFilter === 'all' || allContacts.some((contact) => contact.type === channelFilter);
+          const matchesSearch = !search || searchHaystack.includes(search);
+          const allContacts = [
+            ...(entry.channels || []),
+            ...(entry.mailingLists || []).map((list) => ({
+              ...list,
+              type: "Mailing list",
+            })),
+          ];
+          const matchesChannel =
+            channelFilter === "all" ||
+            allContacts.some((contact) => contact.type === channelFilter);
 
-      return matchesSearch && matchesChannel;
-    });
+          return matchesSearch && matchesChannel;
+        });
 
-    if (filteredRecords.length === 0) {
-      grid.innerHTML = `
+        if (filteredRecords.length === 0) {
+          grid.innerHTML = `
         <div class="col-span-full mentor-empty">
           <p class="font-bold text-zinc-900 mb-2">No mentor matches found.</p>
           <p class="text-sm text-zinc-600">Try a different org name, GitHub handle, or channel filter.</p>
         </div>
       `;
-      const loadMoreContainer = document.getElementById('loadMoreMentorContainer');
-      if (loadMoreContainer) {
-        loadMoreContainer.style.display = 'none';
-      }
-      return;
-    }
+          const loadMoreContainer = document.getElementById(
+            "loadMoreMentorContainer",
+          );
+          if (loadMoreContainer) {
+            loadMoreContainer.style.display = "none";
+          }
+          return;
+        }
 
-    const slice = filteredRecords.slice(visibleMentorCount - 12, visibleMentorCount);
-    slice.forEach(({ org, entry }) => {
-      const primary = getPrimaryMentorContact(entry);
-      const mentorPreview = entry.mentors
-        .slice(0, 3)
-        .filter((mentor) => mentor.github || mentor.name)
-        .map((mentor) => ({
-          ...mentor,
-          displayLabel: mentor.github ? `@${mentor.github}` : mentor.name
-        }));
-      const mentorPreviewHtml = buildMentorPreviewChips(mentorPreview);
-      const primaryType = primary?.type || 'Not specified';
-      let statusClass = 'bg-red-100 text-red-700';
-      if (entry.status === 'ok') {
-        statusClass = 'bg-green-100 text-green-700';
-      } else if (entry.status === 'no-contact-found') {
-        statusClass = 'bg-zinc-100 text-zinc-600';
-      }
+        const slice = filteredRecords.slice(
+          visibleMentorCount - 12,
+          visibleMentorCount,
+        );
+        slice.forEach(({ org, entry }) => {
+          const primary = getPrimaryMentorContact(entry);
+          const mentorPreview = entry.mentors
+            .slice(0, 3)
+            .filter((mentor) => mentor.github || mentor.name)
+            .map((mentor) => ({
+              ...mentor,
+              displayLabel: mentor.github ? `@${mentor.github}` : mentor.name,
+            }));
+          const mentorPreviewHtml = buildMentorPreviewChips(mentorPreview);
+          const primaryType = primary?.type || "Not specified";
+          let statusClass = "bg-red-100 text-red-700";
+          if (entry.status === "ok") {
+            statusClass = "bg-green-100 text-green-700";
+          } else if (entry.status === "no-contact-found") {
+            statusClass = "bg-zinc-100 text-zinc-600";
+          }
 
-      const contactLabel = entry.status === 'ok' ? 'Contact' : 'Ideas page';
-      const helperText = entry.status === 'ok'
-        ? 'Ideas page remains available from the org modal.'
-        : 'Use the ideas page to find the latest contact guidance.';
+          const contactLabel = entry.status === "ok" ? "Contact" : "Ideas page";
+          const helperText =
+            entry.status === "ok"
+              ? "Ideas page remains available from the org modal."
+              : "Use the ideas page to find the latest contact guidance.";
 
-      let bodyHtml = '';
-      if (entry.status === 'ok') {
-        const channelLinks = [
-          ...(entry.channels || []),
-          ...(entry.mailingLists || []).map((list) => ({ ...list, type: 'Mailing list' }))
-        ];
-        bodyHtml = `
+          let bodyHtml = "";
+          if (entry.status === "ok") {
+            const channelLinks = [
+              ...(entry.channels || []),
+              ...(entry.mailingLists || []).map((list) => ({
+                ...list,
+                type: "Mailing list",
+              })),
+            ];
+            bodyHtml = `
           <div class="space-y-3">
             <div class="flex flex-wrap gap-2">${buildChannelChips(channelLinks.slice(0, 2))}</div>
             ${mentorPreviewHtml}
             <div class="text-sm text-zinc-600">
               <p><strong class="text-zinc-900">Primary channel:</strong> ${escapeHtml(primaryType)}</p>
             </div>
-            ${entry.tip ? `<p class="text-sm text-zinc-600 line-clamp-3">${escapeHtml(entry.tip)}</p>` : ''}
+            ${entry.tip ? `<p class="text-sm text-zinc-600 line-clamp-3">${escapeHtml(entry.tip)}</p>` : ""}
           </div>
         `;
-      } else if (entry.status === 'no-contact-found') {
-        bodyHtml = '<p class="text-sm text-zinc-600">No mentor contact info parsed yet for this org.</p>';
-      } else {
-        bodyHtml = '<p class="text-sm text-zinc-600">Mentor data unavailable right now.</p>';
-      }
+          } else if (entry.status === "no-contact-found") {
+            bodyHtml =
+              '<p class="text-sm text-zinc-600">No mentor contact info parsed yet for this org.</p>';
+          } else {
+            bodyHtml =
+              '<p class="text-sm text-zinc-600">Mentor data unavailable right now.</p>';
+          }
 
-      const contactHref = primary?.url || org.ideas || githubUrlFromValue(org.github);
-      const safeContactHref = sanitizeHrefUrl(contactHref);
+          const contactHref =
+            primary?.url || org.ideas || githubUrlFromValue(org.github);
+          const safeContactHref = sanitizeHrefUrl(contactHref);
 
-      const article = document.createElement('article');
-      article.className = 'mentor-card';
-      article.innerHTML = `
+          const article = document.createElement("article");
+          article.className = "mentor-card";
+          article.innerHTML = `
         <div class="flex items-start justify-between gap-3 mb-4">
           <div>
             <p class="text-[10px] font-label uppercase tracking-widest text-primary mb-1">${escapeHtml(org.cat)}</p>
@@ -2415,257 +4482,343 @@ sections.forEach(sectionId => {
           <p class="text-xs text-zinc-500 mt-3">${helperText}</p>
         </div>
       `;
-      grid.appendChild(article);
-    });
+          grid.appendChild(article);
+        });
 
-    const loadMoreContainer = document.getElementById('loadMoreMentorContainer');
-    if (loadMoreContainer) {
-      if (visibleMentorCount < filteredRecords.length) {
-        loadMoreContainer.style.display = 'flex';
-      } else {
-        loadMoreContainer.style.display = 'none';
+        const loadMoreContainer = document.getElementById(
+          "loadMoreMentorContainer",
+        );
+        if (loadMoreContainer) {
+          if (visibleMentorCount < filteredRecords.length) {
+            loadMoreContainer.style.display = "flex";
+          } else {
+            loadMoreContainer.style.display = "none";
+          }
+        }
+        attachOrgCardListeners(grid);
       }
-    }
-    attachOrgCardListeners(grid);
-  }
 
-  async function loadMentorData() {
-    mentorDataState = 'loading';
-    renderMentorFinder();
+      async function loadMentorData() {
+        mentorDataState = "loading";
+        renderMentorFinder();
 
-    try {
-      const res = await fetch(`/data/mentors.json?v=${Date.now()}`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      if (!data || typeof data !== 'object' || Array.isArray(data)) {
-        throw new Error('Invalid mentors.json payload');
-      }
-      MENTOR_DATA = data;
-      mentorDataState = 'loaded';
-    } catch (error) {
-      console.error('Mentor data load failed:', error);
-      MENTOR_DATA = {};
-      mentorDataState = 'error';
-    }
-
-    renderMentorFinder();
-    const openModalEl = document.getElementById('orgModal');
-    if (openModalEl?.classList.contains('open')) {
-      const orgName = document.querySelector('#mHeader h2')?.textContent;
-      if (orgName) {
-        const org = ORGS.find((item) => item.name === orgName);
-        if (org) renderMentorContactSection(org);
-      }
-    }
-  }
-
-  // GSoC contributor selection completion date (Accepted Projects Announced)
-  const GSOC_SELECTION_DATE = new Date('2026-04-30T23:59:59Z');
-
-  /** Returns true if GSoC selection is complete (i.e. today is past the announcement date). */
-  function isPostSelection() {
-    return Date.now() > GSOC_SELECTION_DATE.getTime();
-  }
-
-  /** Applies the post-selection stale-data UI treatment to both banners. */
-  function applyStaleDataNotice() {
-    if (!isPostSelection()) return;
-
-    // --- Good First Issues banner ---
-    const issuesStaleNote = document.getElementById('issuesStaleNote');
-    const issuesBannerSubtitle = document.getElementById('issuesBannerSubtitle');
-    const issuesBannerDot = document.getElementById('issuesBannerDot');
-    const issuesBanner = document.getElementById('issuesBanner');
-    if (issuesStaleNote) issuesStaleNote.classList.remove('hidden');
-    // Soften the "Updated every 6 hours" claim so it no longer contradicts the stale timestamp
-    if (issuesBannerSubtitle) {
-      issuesBannerSubtitle.textContent = 'Data is cached. Updates may be infrequent post-selection.';
-    }
-    // Switch dot from pulsing green to steady grey
-    if (issuesBannerDot) {
-      issuesBannerDot.classList.remove('pulse-dot', 'bg-green-500');
-      issuesBannerDot.classList.add('bg-zinc-400');
-    }
-    // Soften banner background to neutral
-    if (issuesBanner) {
-      issuesBanner.classList.remove('bg-green-50', 'border-green-200');
-      issuesBanner.classList.add('bg-zinc-50', 'border-zinc-200');
-      const title = document.getElementById('issuesBannerTitle');
-      if (title) { title.classList.remove('text-green-800'); title.classList.add('text-zinc-800'); }
-      const subtitle = document.getElementById('issuesBannerSubtitle');
-      if (subtitle) { subtitle.classList.remove('text-green-600'); subtitle.classList.add('text-zinc-500'); }
-      const lastUpdated = document.getElementById('issuesLastUpdated');
-      if (lastUpdated) { lastUpdated.classList.remove('text-green-600'); lastUpdated.classList.add('text-zinc-500'); }
-    }
-
-    // --- Mentor Finder banner ---
-    const mentorStaleNote = document.getElementById('mentorStaleNote');
-    const mentorBannerDot = document.getElementById('mentorBannerDot');
-    if (mentorStaleNote) mentorStaleNote.classList.remove('hidden');
-    // Replace amber warning dot with a calm neutral dot (no pulse)
-    if (mentorBannerDot) {
-      mentorBannerDot.classList.remove('pulse-dot');
-      mentorBannerDot.style.backgroundColor = '#a1a1aa'; // zinc-400
-    }
-  }
-
-  // Dynamic timeline milestones
-  const MILESTONES = [
-    { date: new Date('2026-02-19T00:00:00Z'), label: 'Accepted Orgs Announced', note: null },
-    { date: new Date('2026-03-16T00:00:00Z'), label: 'Contributor Proposals Open', note: null },
-    { date: new Date('2026-03-31T23:30:00+05:30'), label: 'Proposal Submission Deadline', note: 'Submit your project proposals by 11:30 PM!' },
-    { date: GSOC_SELECTION_DATE, label: 'Accepted Projects Announced', note: null },
-    { date: new Date('2026-05-25T00:00:00Z'), label: 'Coding Officially Begins', note: 'Start working on your GSoC project!' },
-    { date: new Date('2026-07-06T18:00:00Z'), label: 'Midterm Evaluations Begin', note: 'Mentors and contributors submit midterm evaluations.' },
-    { date: new Date('2026-07-10T18:00:00Z'), label: 'Midterm Evaluation Deadline', note: null },
-    { date: new Date('2026-08-17T00:00:00Z'), label: 'Final Submissions Begin', note: 'Submit your final work product and evaluation.' },
-    { date: new Date('2026-08-24T18:00:00Z'), label: 'Final Submission Deadline (Standard)', note: 'Standard 12-week projects: submit final work product and evaluation.' },
-    { date: new Date('2026-08-31T18:00:00Z'), label: 'Mentor Final Evaluations Due (Standard)', note: null },
-    { date: new Date('2026-11-02T18:00:00Z'), label: 'Extended Timeline Final Deadline', note: 'Last date for all contributors on extended timelines to submit final work.' },
-    { date: new Date('2026-11-09T18:00:00Z'), label: 'Extended Mentor Evaluations Due', note: 'Final date for mentors to submit evaluations for extended projects.' },
-  ].filter(m => !isNaN(m.date.getTime()));
-
-  function renderTimeline() {
-    const container = document.getElementById('timeline-milestones');
-    if (!container || MILESTONES.length === 0) return;
-
-    try {
-      const now = new Date();
-      if (isNaN(now.getTime())) return;
-
-      let activeIdx = MILESTONES.findIndex(m => m.date > now);
-      if (activeIdx === -1) activeIdx = MILESTONES.length - 1;
-
-      const allPast = MILESTONES[MILESTONES.length - 1].date <= now;
-
-      container.innerHTML = MILESTONES.map((m, i) => {
-        const isActive = i === activeIdx;
-        const isLast = i === MILESTONES.length - 1;
-        const connector = !isLast ? `<div class="w-0.5 h-10 bg-zinc-200"></div>` : '';
-        let dateStr;
         try {
-          dateStr = m.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).toUpperCase();
-        } catch (_) {
-          dateStr = m.date.toISOString().slice(0, 10);
+          const res = await fetch(`/data/mentors.json?v=${Date.now()}`);
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const data = await res.json();
+          if (!data || typeof data !== "object" || Array.isArray(data)) {
+            throw new Error("Invalid mentors.json payload");
+          }
+          MENTOR_DATA = data;
+          mentorDataState = "loaded";
+        } catch (error) {
+          console.error("Mentor data load failed:", error);
+          MENTOR_DATA = {};
+          mentorDataState = "error";
         }
 
-          if (isActive && !allPast) {
-            return `<div class="flex gap-3 sm:gap-4">
+        renderMentorFinder();
+        const openModalEl = document.getElementById("orgModal");
+        if (openModalEl?.classList.contains("open")) {
+          const orgName = document.querySelector("#mHeader h2")?.textContent;
+          if (orgName) {
+            const org = ORGS.find((item) => item.name === orgName);
+            if (org) renderMentorContactSection(org);
+          }
+        }
+      }
+
+      // GSoC contributor selection completion date (Accepted Projects Announced)
+      const GSOC_SELECTION_DATE = new Date("2026-04-30T23:59:59Z");
+
+      /** Returns true if GSoC selection is complete (i.e. today is past the announcement date). */
+      function isPostSelection() {
+        return Date.now() > GSOC_SELECTION_DATE.getTime();
+      }
+
+      /** Applies the post-selection stale-data UI treatment to both banners. */
+      function applyStaleDataNotice() {
+        if (!isPostSelection()) return;
+
+        // --- Good First Issues banner ---
+        const issuesStaleNote = document.getElementById("issuesStaleNote");
+        const issuesBannerSubtitle = document.getElementById(
+          "issuesBannerSubtitle",
+        );
+        const issuesBannerDot = document.getElementById("issuesBannerDot");
+        const issuesBanner = document.getElementById("issuesBanner");
+        if (issuesStaleNote) issuesStaleNote.classList.remove("hidden");
+        // Soften the "Updated every 6 hours" claim so it no longer contradicts the stale timestamp
+        if (issuesBannerSubtitle) {
+          issuesBannerSubtitle.textContent =
+            "Data is cached. Updates may be infrequent post-selection.";
+        }
+        // Switch dot from pulsing green to steady grey
+        if (issuesBannerDot) {
+          issuesBannerDot.classList.remove("pulse-dot", "bg-green-500");
+          issuesBannerDot.classList.add("bg-zinc-400");
+        }
+        // Soften banner background to neutral
+        if (issuesBanner) {
+          issuesBanner.classList.remove("bg-green-50", "border-green-200");
+          issuesBanner.classList.add("bg-zinc-50", "border-zinc-200");
+          const title = document.getElementById("issuesBannerTitle");
+          if (title) {
+            title.classList.remove("text-green-800");
+            title.classList.add("text-zinc-800");
+          }
+          const subtitle = document.getElementById("issuesBannerSubtitle");
+          if (subtitle) {
+            subtitle.classList.remove("text-green-600");
+            subtitle.classList.add("text-zinc-500");
+          }
+          const lastUpdated = document.getElementById("issuesLastUpdated");
+          if (lastUpdated) {
+            lastUpdated.classList.remove("text-green-600");
+            lastUpdated.classList.add("text-zinc-500");
+          }
+        }
+
+        // --- Mentor Finder banner ---
+        const mentorStaleNote = document.getElementById("mentorStaleNote");
+        const mentorBannerDot = document.getElementById("mentorBannerDot");
+        if (mentorStaleNote) mentorStaleNote.classList.remove("hidden");
+        // Replace amber warning dot with a calm neutral dot (no pulse)
+        if (mentorBannerDot) {
+          mentorBannerDot.classList.remove("pulse-dot");
+          mentorBannerDot.style.backgroundColor = "#a1a1aa"; // zinc-400
+        }
+      }
+
+      // Dynamic timeline milestones
+      const MILESTONES = [
+        {
+          date: new Date("2026-02-19T00:00:00Z"),
+          label: "Accepted Orgs Announced",
+          note: null,
+        },
+        {
+          date: new Date("2026-03-16T00:00:00Z"),
+          label: "Contributor Proposals Open",
+          note: null,
+        },
+        {
+          date: new Date("2026-03-31T23:30:00+05:30"),
+          label: "Proposal Submission Deadline",
+          note: "Submit your project proposals by 11:30 PM!",
+        },
+        {
+          date: GSOC_SELECTION_DATE,
+          label: "Accepted Projects Announced",
+          note: null,
+        },
+        {
+          date: new Date("2026-05-25T00:00:00Z"),
+          label: "Coding Officially Begins",
+          note: "Start working on your GSoC project!",
+        },
+        {
+          date: new Date("2026-07-06T18:00:00Z"),
+          label: "Midterm Evaluations Begin",
+          note: "Mentors and contributors submit midterm evaluations.",
+        },
+        {
+          date: new Date("2026-07-10T18:00:00Z"),
+          label: "Midterm Evaluation Deadline",
+          note: null,
+        },
+        {
+          date: new Date("2026-08-17T00:00:00Z"),
+          label: "Final Submissions Begin",
+          note: "Submit your final work product and evaluation.",
+        },
+        {
+          date: new Date("2026-08-24T18:00:00Z"),
+          label: "Final Submission Deadline (Standard)",
+          note: "Standard 12-week projects: submit final work product and evaluation.",
+        },
+        {
+          date: new Date("2026-08-31T18:00:00Z"),
+          label: "Mentor Final Evaluations Due (Standard)",
+          note: null,
+        },
+        {
+          date: new Date("2026-11-02T18:00:00Z"),
+          label: "Extended Timeline Final Deadline",
+          note: "Last date for all contributors on extended timelines to submit final work.",
+        },
+        {
+          date: new Date("2026-11-09T18:00:00Z"),
+          label: "Extended Mentor Evaluations Due",
+          note: "Final date for mentors to submit evaluations for extended projects.",
+        },
+      ].filter((m) => !isNaN(m.date.getTime()));
+
+      function renderTimeline() {
+        const container = document.getElementById("timeline-milestones");
+        if (!container || MILESTONES.length === 0) return;
+
+        try {
+          const now = new Date();
+          if (isNaN(now.getTime())) return;
+
+          let activeIdx = MILESTONES.findIndex((m) => m.date > now);
+          if (activeIdx === -1) activeIdx = MILESTONES.length - 1;
+
+          const allPast = MILESTONES[MILESTONES.length - 1].date <= now;
+
+          container.innerHTML = MILESTONES.map((m, i) => {
+            const isActive = i === activeIdx;
+            const isLast = i === MILESTONES.length - 1;
+            const connector = !isLast
+              ? `<div class="w-0.5 h-10 bg-zinc-200"></div>`
+              : "";
+            let dateStr;
+            try {
+              dateStr = m.date
+                .toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })
+                .toUpperCase();
+            } catch (_) {
+              dateStr = m.date.toISOString().slice(0, 10);
+            }
+
+            if (isActive && !allPast) {
+              return `<div class="flex gap-3 sm:gap-4">
               <div class="flex flex-col items-center"><div class="w-3 h-3 rounded-full bg-primary ring-4 ring-orange-100 pulse-dot"></div>${connector}</div>
               <div><p class="text-[10px] font-bold text-primary">${escapeHtml(dateStr)}</p>
               <p class="text-sm sm:text-base font-extrabold text-zinc-900 leading-tight">${escapeHtml(m.label)}</p>
-              ${m.note ? `<p class="text-xs text-zinc-500 mt-1">${escapeHtml(m.note)}</p>` : ''}</div>
+              ${m.note ? `<p class="text-xs text-zinc-500 mt-1">${escapeHtml(m.note)}</p>` : ""}</div>
             </div>`;
-          } else if (isActive && allPast) {
-            return `<div class="flex gap-3 sm:gap-4">
+            } else if (isActive && allPast) {
+              return `<div class="flex gap-3 sm:gap-4">
               <div class="flex flex-col items-center"><div class="w-3 h-3 rounded-full bg-green-500 ring-4 ring-green-100"></div>${connector}</div>
               <div><p class="text-[10px] font-bold text-green-600">${escapeHtml(dateStr)}</p>
               <p class="text-sm sm:text-base font-extrabold text-zinc-900 leading-tight">${escapeHtml(m.label)}</p>
               <p class="text-xs text-green-600 mt-1">✓ Completed</p></div>
             </div>`;
-          } else {
-            return `<div class="flex gap-3 sm:gap-4 opacity-40">
+            } else {
+              return `<div class="flex gap-3 sm:gap-4 opacity-40">
               <div class="flex flex-col items-center"><div class="w-2 h-2 rounded-full bg-zinc-300"></div>${connector}</div>
               <div><p class="text-[10px] font-bold text-zinc-400">${escapeHtml(dateStr)}</p>
               <p class="text-sm font-bold text-zinc-500">${escapeHtml(m.label)}</p></div>
             </div>`;
+            }
+          }).join("");
+        } catch (err) {
+          console.warn("[Timeline] renderTimeline failed:", err);
+        }
+      }
+
+      // Countdown to the next upcoming milestone
+      function updateCountdown() {
+        const countdownEl = document.getElementById("countdown");
+        const labelEl = document.getElementById("countdown-label");
+        if (!countdownEl || !labelEl || MILESTONES.length === 0) return;
+
+        try {
+          const now = new Date();
+          if (isNaN(now.getTime())) return;
+
+          const next = MILESTONES.find((m) => m.date > now);
+
+          if (!next) {
+            labelEl.textContent = "GSoC 2026 selection complete";
+            countdownEl.textContent = "🎉 All done!";
+            countdownEl.classList.remove("text-primary");
+            countdownEl.classList.add("text-green-600");
+            return;
           }
-      }).join('');
-    } catch (err) {
-      console.warn('[Timeline] renderTimeline failed:', err);
-    }
-  }
 
-  // Countdown to the next upcoming milestone
-  function updateCountdown() {
-    const countdownEl = document.getElementById('countdown');
-    const labelEl = document.getElementById('countdown-label');
-    if (!countdownEl || !labelEl || MILESTONES.length === 0) return;
-
-    try {
-      const now = new Date();
-      if (isNaN(now.getTime())) return;
-
-      const next = MILESTONES.find(m => m.date > now);
-
-      if (!next) {
-        labelEl.textContent = 'GSoC 2026 selection complete';
-        countdownEl.textContent = '🎉 All done!';
-        countdownEl.classList.remove('text-primary');
-        countdownEl.classList.add('text-green-600');
-        return;
+          labelEl.textContent = `Until: ${next.label}`;
+          countdownEl.classList.remove("text-green-600");
+          countdownEl.classList.add("text-primary");
+          const diff = next.date - now;
+          if (diff <= 0) {
+            renderTimeline();
+            updateCountdown();
+            return;
+          }
+          const d = Math.floor(diff / 864e5),
+            h = Math.floor((diff % 864e5) / 36e5),
+            m = Math.floor((diff % 36e5) / 6e4);
+          countdownEl.textContent = `${d}d ${h}h ${m}m`;
+        } catch (err) {
+          console.warn("[Timeline] updateCountdown failed:", err);
+        }
       }
 
-      labelEl.textContent = `Until: ${next.label}`;
-      countdownEl.classList.remove('text-green-600');
-      countdownEl.classList.add('text-primary');
-      const diff = next.date - now;
-      if (diff <= 0) { renderTimeline(); updateCountdown(); return; }
-      const d = Math.floor(diff / 864e5), h = Math.floor((diff % 864e5) / 36e5), m = Math.floor((diff % 36e5) / 6e4);
-      countdownEl.textContent = `${d}d ${h}h ${m}m`;
-    } catch (err) {
-      console.warn('[Timeline] updateCountdown failed:', err);
-    }
-  }
+      // Organizational Logo Fallbacks
+      window.handleImgError = function (img, orgName) {
+        if (!img.dataset.triedClearbit) {
+          img.dataset.triedClearbit = "true";
+          const domain =
+            orgName.toLowerCase().replace(/[^a-z0-9]/g, "") + ".org";
+          img.src = `https://logo.clearbit.com/${domain}`;
+        } else {
+          img.style.display = "none";
+          const placeholder =
+            img.parentElement.querySelector(".logo-placeholder");
+          if (placeholder) {
+            placeholder.style.display = "flex";
+            placeholder.textContent = orgName
+              .split(" ")
+              .map((n) => n[0])
+              .join("")
+              .substring(0, 2)
+              .toUpperCase();
+          }
+        }
+      };
 
-  // Organizational Logo Fallbacks
-  window.handleImgError = function(img, orgName) {
-    if (!img.dataset.triedClearbit) {
-      img.dataset.triedClearbit = 'true';
-      const domain = orgName.toLowerCase().replace(/[^a-z0-9]/g, '') + '.org';
-      img.src = `https://logo.clearbit.com/${domain}`;
-    } else {
-      img.style.display = 'none';
-      const placeholder = img.parentElement.querySelector('.logo-placeholder');
-      if (placeholder) {
-        placeholder.style.display = 'flex';
-        placeholder.textContent = orgName.split(' ').map(n => n[0]).join('').substring(0,2).toUpperCase();
-      }
-    }
-  };
+      function renderOrgs(reset = true) {
+        const grid = document.getElementById("orgGrid");
 
-  function renderOrgs(reset = true) {
-    const grid = document.getElementById('orgGrid');
+        const emptyState = document.getElementById("emptyState");
+        if (reset) {
+          grid.innerHTML = "";
+          visibleCount = 12;
+        }
 
-    const emptyState = document.getElementById('emptyState');
-    if (reset) {
-      grid.innerHTML = '';
-      visibleCount = 12;
-    }
+        if (filteredOrgs.length === 0) {
+          grid.classList.add("hidden");
+          if (emptyState) emptyState.classList.remove("hidden");
+          document.getElementById("orgCount").textContent = "0";
+          document.getElementById("loadMoreContainer").style.display = "none";
+          return;
+        } else {
+          grid.classList.remove("hidden");
+          if (emptyState) emptyState.classList.add("hidden");
+        }
 
-    if (filteredOrgs.length === 0) {
-      grid.classList.add('hidden');
-      if (emptyState) emptyState.classList.remove('hidden');
-      document.getElementById('orgCount').textContent = '0';
-      document.getElementById('loadMoreContainer').style.display = 'none';
-      return;
-    } else {
-      grid.classList.remove('hidden');
-      if (emptyState) emptyState.classList.add('hidden');
-    }
-    
-    const slice = filteredOrgs.slice(visibleCount - 12, visibleCount);
-    slice.forEach(org => {
-      const isBookmarked = bookmarkedSet.has(org.name);
-      const isComparing = compareList.includes(org.name);
-      const card = document.createElement('article');
-      card.className = 'group bg-white rounded-2xl p-6 border border-zinc-100 transition-all hover:shadow-xl hover:border-primary/20 animate-fade-up';
-      card.dataset.org = org.name;
-      
-      const githubOwner = githubOwnerFromValue(org.github);
-      const logoUrl = githubOwner ? `https://github.com/${githubOwner}.png?size=80` : '';
-      
-      card.innerHTML = `
+        const slice = filteredOrgs.slice(visibleCount - 12, visibleCount);
+        slice.forEach((org) => {
+          const isBookmarked = bookmarkedSet.has(org.name);
+          const isComparing = compareList.includes(org.name);
+          const card = document.createElement("article");
+          card.className =
+            "group bg-white rounded-2xl p-6 border border-zinc-100 transition-all hover:shadow-xl hover:border-primary/20 animate-fade-up";
+          card.dataset.org = org.name;
+
+          const githubOwner = githubOwnerFromValue(org.github);
+          const logoUrl = githubOwner
+            ? `https://github.com/${githubOwner}.png?size=80`
+            : "";
+
+          card.innerHTML = `
         <div class="flex justify-between items-start mb-4">
           <div class="w-14 h-14 rounded-xl bg-surface-container-low flex items-center justify-center p-2 overflow-hidden">
-            <img src="${escapeHtml(logoUrl)}" data-org-name="${escapeHtml(org.name)}" alt="${escapeHtml(org.name + ' logo')}" class="w-full h-full object-contain rounded-lg" />
+            <img src="${escapeHtml(logoUrl)}" data-org-name="${escapeHtml(org.name)}" alt="${escapeHtml(org.name + " logo")}" class="w-full h-full object-contain rounded-lg" />
             <div class="logo-placeholder hidden w-full h-full items-center justify-center text-primary font-bold text-xl bg-primary/5"></div>
           </div>
           <div class="flex items-center gap-2">
             <span class="bg-primary/10 text-primary text-[10px] font-label uppercase tracking-widest px-2 py-1 rounded-full font-bold">${escapeHtml(String(org.years))}y Veteran</span>
             <span class="complexity-badge ${escapeHtml(org.codebase)}">${escapeHtml(org.codebase)}</span>
-            <button class="bookmark-btn ${isBookmarked ? 'active' : 'text-zinc-300'}" data-bookmark-org="${escapeHtml(org.name)}" title="${isBookmarked ? 'Remove bookmark' : 'Add bookmark'}">
-              <span class="material-symbols-outlined text-lg ${isBookmarked ? 'icon-fill' : ''}">star</span>
+            <button class="bookmark-btn ${isBookmarked ? "active" : "text-zinc-300"}" data-bookmark-org="${escapeHtml(org.name)}" title="${isBookmarked ? "Remove bookmark" : "Add bookmark"}">
+              <span class="material-symbols-outlined text-lg ${isBookmarked ? "icon-fill" : ""}">star</span>
             </button>
           </div>
         </div>
@@ -2673,95 +4826,121 @@ sections.forEach(sectionId => {
         <span class="category-tag">${escapeHtml(org.cat.toUpperCase())}</span>
         <p class="text-on-surface-variant text-sm leading-relaxed mb-4 line-clamp-2">${escapeHtml(org.desc)}</p>
         <div class="flex flex-wrap gap-1.5 mb-4">
-          ${org.tags.slice(0, 3).map(t => `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded">${escapeHtml(t)}</span>`).join('')}
-          ${org.tags.length > 3 ? `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded">+${escapeHtml(String(org.tags.length - 3))}</span>` : ''}
+          ${org.tags
+            .slice(0, 3)
+            .map(
+              (t) =>
+                `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded">${escapeHtml(t)}</span>`,
+            )
+            .join("")}
+          ${org.tags.length > 3 ? `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded">+${escapeHtml(String(org.tags.length - 3))}</span>` : ""}
         </div>
 
         <div class="flex items-center justify-between pt-4 border-t border-zinc-100">
           <div class="flex items-center gap-3">
-             <button data-compare-org="${escapeHtml(org.name)}" class="text-[10px] font-bold uppercase tracking-widest ${isComparing ? 'text-primary' : 'text-zinc-400'} hover:text-primary flex items-center gap-1">
-                <span class="material-symbols-outlined text-sm">${isComparing ? 'check_circle' : 'compare_arrows'}</span> ${isComparing ? 'Comparing' : 'Compare'}
+             <button data-compare-org="${escapeHtml(org.name)}" class="text-[10px] font-bold uppercase tracking-widest ${isComparing ? "text-primary" : "text-zinc-400"} hover:text-primary flex items-center gap-1">
+                <span class="material-symbols-outlined text-sm">${isComparing ? "check_circle" : "compare_arrows"}</span> ${isComparing ? "Comparing" : "Compare"}
              </button>
           </div>
            <button data-open-org="${org.name}" class="text-primary font-bold text-xs uppercase tracking-widest flex items-center gap-1 group-hover:gap-2 transition-all">View <span class="material-symbols-outlined text-sm">arrow_forward</span></button>
         </div>
        `;
-    card.querySelector('[data-compare-org]').dataset.compareOrg = org.name;
+          card.querySelector("[data-compare-org]").dataset.compareOrg =
+            org.name;
 
-   grid.appendChild(card);
-   attachOrgCardListeners(card);
-    });
+          grid.appendChild(card);
+          attachOrgCardListeners(card);
+        });
 
-    document.getElementById('orgCount').textContent = filteredOrgs.length;
-    document.getElementById('loadMoreContainer').style.display = (visibleCount < filteredOrgs.length) ? 'flex' : 'none';
-  }
-
-  // Attach listeners to elements created from org templates.
-  // Uses data-* attributes to avoid injecting user data into inline JS handlers.
-  function attachOrgCardListeners(root = document) {
-    // image error fallback (error doesn't bubble reliably)
-    (root.querySelectorAll ? root.querySelectorAll('img[data-org-name]') : []).forEach(img => {
-      if (img.__orgListenerAttached) return;
-      img.addEventListener('error', (e) => {
-        handleImgError(e.target, e.target.dataset.orgName);
-      });
-      img.__orgListenerAttached = true;
-    });
-
-    // bookmark buttons
-    (root.querySelectorAll ? root.querySelectorAll('.bookmark-btn[data-bookmark-org]') : []).forEach(btn => {
-      if (btn.__orgListenerAttached) return;
-      btn.addEventListener('click', (e) => toggleBookmark(e, btn.dataset.bookmarkOrg));
-      btn.__orgListenerAttached = true;
-    });
-
-    // compare buttons
-    (root.querySelectorAll ? root.querySelectorAll('[data-compare-org]') : []).forEach(btn => {
-      if (btn.__orgListenerAttached) return;
-      btn.addEventListener('click', (e) => toggleCompare(e, btn.dataset.compareOrg));
-      btn.__orgListenerAttached = true;
-    });
-
-    // open modal buttons
-    (root.querySelectorAll ? root.querySelectorAll('[data-open-org]') : []).forEach(btn => {
-      if (btn.__orgListenerAttached) return;
-      btn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        openModal(btn.dataset.openOrg);
-      });
-btn.__orgListenerAttached = true;
-    });
-  }
-
-  function toggleCompare(e, name) {
-    if (e) e.stopPropagation();
-    const idx = compareList.indexOf(name);
-    if (idx > -1) {
-      compareList.splice(idx, 1);
-    } else {
-      if (compareList.length >= 3) {
-        alert("You can only compare up to 3 organizations at a time.");
-        return;
+        document.getElementById("orgCount").textContent = filteredOrgs.length;
+        document.getElementById("loadMoreContainer").style.display =
+          visibleCount < filteredOrgs.length ? "flex" : "none";
       }
-      compareList.push(name);
-    }
-    renderOrgs(true);
-    renderCompare();
-  }
 
-  function renderCompare() {
-    const container = document.querySelector('#compare .grid');
-    if (!container) return;
-    container.innerHTML = '';
-    
-    compareList.forEach(name => {
-      const org = ORGS.find(o => o.name === name);
-      const githubOwner = githubOwnerFromValue(org.github);
-      const logoUrl = githubOwner ? `https://github.com/${githubOwner}.png?size=80` : '';
-      
-      const item = document.createElement('div');
-      item.className = 'bg-white rounded-xl p-4 border border-zinc-100';
-      item.innerHTML = `
+      // Attach listeners to elements created from org templates.
+      // Uses data-* attributes to avoid injecting user data into inline JS handlers.
+      function attachOrgCardListeners(root = document) {
+        // image error fallback (error doesn't bubble reliably)
+        (root.querySelectorAll
+          ? root.querySelectorAll("img[data-org-name]")
+          : []
+        ).forEach((img) => {
+          if (img.__orgListenerAttached) return;
+          img.addEventListener("error", (e) => {
+            handleImgError(e.target, e.target.dataset.orgName);
+          });
+          img.__orgListenerAttached = true;
+        });
+
+        // bookmark buttons
+        (root.querySelectorAll
+          ? root.querySelectorAll(".bookmark-btn[data-bookmark-org]")
+          : []
+        ).forEach((btn) => {
+          if (btn.__orgListenerAttached) return;
+          btn.addEventListener("click", (e) =>
+            toggleBookmark(e, btn.dataset.bookmarkOrg),
+          );
+          btn.__orgListenerAttached = true;
+        });
+
+        // compare buttons
+        (root.querySelectorAll
+          ? root.querySelectorAll("[data-compare-org]")
+          : []
+        ).forEach((btn) => {
+          if (btn.__orgListenerAttached) return;
+          btn.addEventListener("click", (e) =>
+            toggleCompare(e, btn.dataset.compareOrg),
+          );
+          btn.__orgListenerAttached = true;
+        });
+
+        // open modal buttons
+        (root.querySelectorAll
+          ? root.querySelectorAll("[data-open-org]")
+          : []
+        ).forEach((btn) => {
+          if (btn.__orgListenerAttached) return;
+          btn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            openModal(btn.dataset.openOrg);
+          });
+          btn.__orgListenerAttached = true;
+        });
+      }
+
+      function toggleCompare(e, name) {
+        if (e) e.stopPropagation();
+        const idx = compareList.indexOf(name);
+        if (idx > -1) {
+          compareList.splice(idx, 1);
+        } else {
+          if (compareList.length >= 3) {
+            alert("You can only compare up to 3 organizations at a time.");
+            return;
+          }
+          compareList.push(name);
+        }
+        renderOrgs(true);
+        renderCompare();
+      }
+
+      function renderCompare() {
+        const container = document.querySelector("#compare .grid");
+        if (!container) return;
+        container.innerHTML = "";
+
+        compareList.forEach((name) => {
+          const org = ORGS.find((o) => o.name === name);
+          const githubOwner = githubOwnerFromValue(org.github);
+          const logoUrl = githubOwner
+            ? `https://github.com/${githubOwner}.png?size=80`
+            : "";
+
+          const item = document.createElement("div");
+          item.className = "bg-white rounded-xl p-4 border border-zinc-100";
+          item.innerHTML = `
         <div class="w-10 h-10 rounded-lg bg-orange-100 flex items-center justify-center mx-auto mb-3 overflow-hidden">
           <img src="${escapeHtml(logoUrl)}" data-org-name="${escapeHtml(org.name)}" class="w-full h-full object-contain" />
         </div>
@@ -2769,340 +4948,384 @@ btn.__orgListenerAttached = true;
         <p class="text-[10px] text-zinc-500 font-label uppercase mt-1">${escapeHtml(String(org.years))}y · ${escapeHtml(org.competition)}</p>
         <button data-compare-org="${escapeHtml(org.name)}" class="text-[9px] text-red-500 font-bold uppercase mt-2 hover:underline">Remove</button>
       `;
-      container.appendChild(item);
-      attachOrgCardListeners(item);
-    });
+          container.appendChild(item);
+          attachOrgCardListeners(item);
+        });
 
-    // Add empty slots
-    for (let i = compareList.length; i < 3; i++) {
-      const empty = document.createElement('div');
-      empty.className = 'bg-white rounded-xl p-4 border border-zinc-100 border-dashed border-zinc-300 flex flex-col items-center justify-center opacity-50';
-      empty.innerHTML = `
+        // Add empty slots
+        for (let i = compareList.length; i < 3; i++) {
+          const empty = document.createElement("div");
+          empty.className =
+            "bg-white rounded-xl p-4 border border-zinc-100 border-dashed border-zinc-300 flex flex-col items-center justify-center opacity-50";
+          empty.innerHTML = `
         <div class="w-10 h-10 rounded-lg bg-zinc-100 flex items-center justify-center mb-3"><span class="material-symbols-outlined text-zinc-400">add</span></div>
         <p class="font-bold text-sm text-zinc-400">Add org</p>
-        <p class="text-[10px] text-zinc-400 font-label uppercase mt-1">Slot ${i+1}</p>
+        <p class="text-[10px] text-zinc-400 font-label uppercase mt-1">Slot ${i + 1}</p>
       `;
-      container.appendChild(empty);
-    }
-  }
+          container.appendChild(empty);
+        }
+      }
 
-  function renderCompareModal() {
-    const body = document.getElementById('compareModalBody');
-    if (!body) return;
-    const escapeHtml = (value) => String(value)
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;')
-      .replaceAll('"', '&quot;')
-      .replaceAll("'", '&#39;');
+      function renderCompareModal() {
+        const body = document.getElementById("compareModalBody");
+        if (!body) return;
+        const escapeHtml = (value) =>
+          String(value)
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', "&quot;")
+            .replaceAll("'", "&#39;");
 
-    const selectedOrgs = compareList.map(name => ORGS.find(o => o.name === name)).filter(Boolean);
-    if (selectedOrgs.length < 2) {
-      body.innerHTML = `
+        const selectedOrgs = compareList
+          .map((name) => ORGS.find((o) => o.name === name))
+          .filter(Boolean);
+        if (selectedOrgs.length < 2) {
+          body.innerHTML = `
         <div class="py-12 text-center border-2 border-dashed border-zinc-200 rounded-2xl">
           <span class="material-symbols-outlined text-4xl text-zinc-300 mb-3">compare_arrows</span>
           <p class="font-bold text-zinc-700">Select at least 2 organizations to compare.</p>
           <p class="text-sm text-zinc-500 mt-2">Use the Compare button on organization cards, then open this tool again.</p>
         </div>
       `;
-      return;
-    }
+          return;
+        }
 
-    const rows = [
-      ['Category', org => org.cat],
-      ['GSoC Years', org => org.years],
-      ['First Year', org => org.firstYear],
-      ['Competition', org => org.competition],
-      ['Codebase', org => org.codebase],
-      ['Tech Stack', org => org.tags.join(', ')],
-      ['Best Fit', org => org.fit.join(', ')],
-      ['Repository', org => org.github],
-    ];
+        const rows = [
+          ["Category", (org) => org.cat],
+          ["GSoC Years", (org) => org.years],
+          ["First Year", (org) => org.firstYear],
+          ["Competition", (org) => org.competition],
+          ["Codebase", (org) => org.codebase],
+          ["Tech Stack", (org) => org.tags.join(", ")],
+          ["Best Fit", (org) => org.fit.join(", ")],
+          ["Repository", (org) => org.github],
+        ];
 
-    body.innerHTML = `
+        body.innerHTML = `
       <table class="w-full min-w-[720px] text-sm">
         <thead>
           <tr class="border-b border-zinc-200">
             <th class="text-left py-3 px-4 text-xs uppercase tracking-widest text-zinc-400">Metric</th>
-            ${selectedOrgs.map(org => `<th class="text-left py-3 px-4 font-bold">${escapeHtml(org.name)}</th>`).join('')}
+            ${selectedOrgs.map((org) => `<th class="text-left py-3 px-4 font-bold">${escapeHtml(org.name)}</th>`).join("")}
           </tr>
         </thead>
         <tbody>
-          ${rows.map(([label, getValue]) => `
+          ${rows
+            .map(
+              ([label, getValue]) => `
             <tr class="border-b border-zinc-100 last:border-0">
               <td class="py-3 px-4 font-bold text-zinc-500">${label}</td>
-              ${selectedOrgs.map(org => `<td class="py-3 px-4 text-zinc-700">${escapeHtml(getValue(org))}</td>`).join('')}
+              ${selectedOrgs.map((org) => `<td class="py-3 px-4 text-zinc-700">${escapeHtml(getValue(org))}</td>`).join("")}
             </tr>
-          `).join('')}
+          `,
+            )
+            .join("")}
         </tbody>
       </table>
     `;
-  }
+      }
 
-  function openCompareModal() {
-    renderCompare();
-    renderCompareModal();
-    document.getElementById('compareModal')?.classList.add('open');
-    document.body.style.overflow = 'hidden';
+      function openCompareModal() {
+        renderCompare();
+        renderCompareModal();
+        document.getElementById("compareModal")?.classList.add("open");
+        document.body.style.overflow = "hidden";
 
-    // Track badge progress only when comparison is actually opened with 2+ orgs
-    if (typeof BadgeSystem !== 'undefined' && compareList.length >= 2) {
-      BadgeSystem.trackComparison();
-    }
-  }
+        // Track badge progress only when comparison is actually opened with 2+ orgs
+        if (typeof BadgeSystem !== "undefined" && compareList.length >= 2) {
+          BadgeSystem.trackComparison();
+        }
+      }
 
-  function closeCompareModal() {
-    document.getElementById('compareModal')?.classList.remove('open');
-    document.body.style.overflow = 'auto';
-  }
+      function closeCompareModal() {
+        document.getElementById("compareModal")?.classList.remove("open");
+        document.body.style.overflow = "auto";
+      }
 
-  // ══════════════════════════════════════════════
-  // ANALYTICS PANEL
-  // ══════════════════════════════════════════════
-  let prevFocusBeforeAnalytics = null;
+      // ══════════════════════════════════════════════
+      // ANALYTICS PANEL
+      // ══════════════════════════════════════════════
+      let prevFocusBeforeAnalytics = null;
 
-  window.openAnalytics = function() {
-    // Save current focus
-    prevFocusBeforeAnalytics = document.activeElement;
+      window.openAnalytics = function () {
+        // Save current focus
+        prevFocusBeforeAnalytics = document.activeElement;
 
-    // Render badges if BadgeSystem is available
-    if (typeof BadgeSystem !== 'undefined') {
-      renderBadges();
-    }
-    
-    const modal = document.getElementById('anBg');
-    modal?.classList.add('open');
-    document.body.style.overflow = 'hidden';
+        // Render badges if BadgeSystem is available
+        if (typeof BadgeSystem !== "undefined") {
+          renderBadges();
+        }
 
-    // Focus the close button for keyboard accessibility
-    setTimeout(() => {
-      const closeBtn = modal?.querySelector('.close-btn');
-      closeBtn?.focus();
-    }, 100);
-  };
+        const modal = document.getElementById("anBg");
+        modal?.classList.add("open");
+        document.body.style.overflow = "hidden";
 
-  window.closeAn = function() {
-    document.getElementById('anBg')?.classList.remove('open');
-    document.body.style.overflow = 'auto';
+        // Focus the close button for keyboard accessibility
+        setTimeout(() => {
+          const closeBtn = modal?.querySelector(".close-btn");
+          closeBtn?.focus();
+        }, 100);
+      };
 
-    // Restore focus to the element that opened the modal
-    if (prevFocusBeforeAnalytics && document.contains(prevFocusBeforeAnalytics)) {
-      prevFocusBeforeAnalytics.focus();
-    }
-    prevFocusBeforeAnalytics = null;
-  };
+      window.closeAn = function () {
+        document.getElementById("anBg")?.classList.remove("open");
+        document.body.style.overflow = "auto";
 
-  window.closeAnEvent = function(e) {
-    if (e.target.id === 'anBg') {
-      closeAn();
-    }
-  };
+        // Restore focus to the element that opened the modal
+        if (
+          prevFocusBeforeAnalytics &&
+          document.contains(prevFocusBeforeAnalytics)
+        ) {
+          prevFocusBeforeAnalytics.focus();
+        }
+        prevFocusBeforeAnalytics = null;
+      };
 
-  function renderBadges() {
-    const badgesContainer = document.getElementById('badgesContainer');
-    if (!badgesContainer || typeof BadgeSystem === 'undefined') return;
-    
-    const stats = BadgeSystem.getBadgeStats();
-    const unlockedCount = BadgeSystem.getUnlockedCount();
-    const totalCount = BadgeSystem.getTotalBadgesCount();
-    
-    let html = '<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-top:12px">';
-    
-    Object.keys(stats).forEach(badgeType => {
-      const badge = stats[badgeType];
-      const isLocked = !badge.level;
-      const icon = badge.name.split(' ')[0];
-      const levelName = badge.level ? badge.level.levelName : 'Locked';
-      const progress = badge.progress;
-      
-      html += `
-        <div class="badge-card ${isLocked ? 'badge-locked' : ''}">
+      window.closeAnEvent = function (e) {
+        if (e.target.id === "anBg") {
+          closeAn();
+        }
+      };
+
+      function renderBadges() {
+        const badgesContainer = document.getElementById("badgesContainer");
+        if (!badgesContainer || typeof BadgeSystem === "undefined") return;
+
+        const stats = BadgeSystem.getBadgeStats();
+        const unlockedCount = BadgeSystem.getUnlockedCount();
+        const totalCount = BadgeSystem.getTotalBadgesCount();
+
+        let html =
+          '<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-top:12px">';
+
+        Object.keys(stats).forEach((badgeType) => {
+          const badge = stats[badgeType];
+          const isLocked = !badge.level;
+          const icon = badge.name.split(" ")[0];
+          const levelName = badge.level ? badge.level.levelName : "Locked";
+          const progress = badge.progress;
+
+          html += `
+        <div class="badge-card ${isLocked ? "badge-locked" : ""}">
           <span class="badge-icon">${icon}</span>
           <div class="badge-name">${escapeHtml(badge.name.substring(2))}</div>
           <div class="badge-level">${escapeHtml(levelName)}</div>
-          <div class="badge-count">${badge.count}${badge.nextThreshold ? ' / ' + badge.nextThreshold : ''}</div>
+          <div class="badge-count">${badge.count}${badge.nextThreshold ? " / " + badge.nextThreshold : ""}</div>
           <div class="badge-progress">
             <div class="badge-progress-fill" style="width:${progress}%"></div>
           </div>
         </div>
       `;
-    });
-    
-    html += '</div>';
-    badgesContainer.innerHTML = html;
-    
-    // Update badge indicator in header
-    const badgeIndicator = document.getElementById('badgeIndicator');
-    if (badgeIndicator) {
-      badgeIndicator.innerHTML = `<span class="material-symbols-outlined" style="font-size:16px">emoji_events</span> ${unlockedCount}/${totalCount}`;
-    }
-  }
+        });
 
-  // Listen for badge reset event
-  document.addEventListener('badgesReset', () => {
-    if (document.getElementById('anBg')?.classList.contains('open')) {
-      renderBadges();
-    }
-  });
+        html += "</div>";
+        badgesContainer.innerHTML = html;
 
-  document.getElementById('compareModal')?.addEventListener('click', (e) => {
-    if (e.target.id === 'compareModal') closeCompareModal();
-  });
+        // Update badge indicator in header
+        const badgeIndicator = document.getElementById("badgeIndicator");
+        if (badgeIndicator) {
+          badgeIndicator.innerHTML = `<span class="material-symbols-outlined" style="font-size:16px">emoji_events</span> ${unlockedCount}/${totalCount}`;
+        }
+      }
 
-  document.getElementById('orgModal')?.addEventListener('click', (e) => {
-    if (e.target.id === 'orgModal') closeOrgModal();
-  });
+      // Listen for badge reset event
+      document.addEventListener("badgesReset", () => {
+        if (document.getElementById("anBg")?.classList.contains("open")) {
+          renderBadges();
+        }
+      });
 
-  document.addEventListener('keydown', (e) => {
-    if (e.key !== 'Escape') return;
-    if (document.getElementById('proposalModal')?.classList.contains('open')) {
-      closeProposalBuilder();
-    } else if (document.getElementById('compareModal')?.classList.contains('open')) {
-      closeCompareModal();
-    } else if (document.getElementById('orgModal')?.classList.contains('open')) {
-      closeOrgModal();
-    } else if (document.getElementById('anBg')?.classList.contains('open')) {
-      closeAn();
-    }
-  });
-  
+      document
+        .getElementById("compareModal")
+        ?.addEventListener("click", (e) => {
+          if (e.target.id === "compareModal") closeCompareModal();
+        });
 
-  function applyFiltersPreservingVisibleCount() {
-    const savedCount = visibleCount;
-    const grid = document.getElementById('orgGrid');
-    if (!grid) return;
-    // applyFilters() updates the filteredOrgs list and calls renderOrgs(true)
-    // which resets visibleCount to 12. We then keep appending subsequent pages
-    // until we reach the count the user had previously scrolled to.
-    applyFilters();
-    while (visibleCount < savedCount && visibleCount < filteredOrgs.length) {
-      visibleCount += 12;
-      renderOrgs(false);
-    }
-  }
+      document.getElementById("orgModal")?.addEventListener("click", (e) => {
+        if (e.target.id === "orgModal") closeOrgModal();
+      });
 
-  // ══════════════════════════════════════════════
-  // WATCHLIST — centralised bookmark sync helper
-  // ══════════════════════════════════════════════
-  function refreshVisibleBookmarkButtons() {
-    document.querySelectorAll('#orgGrid .bookmark-btn[data-bookmark-org]').forEach(btn => {
-      const isBookmarked = bookmarkedSet.has(btn.dataset.bookmarkOrg);
-      btn.classList.toggle('active', isBookmarked);
-      btn.classList.toggle('text-zinc-300', !isBookmarked);
-      btn.title = isBookmarked ? 'Remove bookmark' : 'Add bookmark';
-      btn.querySelector('.material-symbols-outlined')?.classList.toggle('icon-fill', isBookmarked);
-    });
-  }
+      document.addEventListener("keydown", (e) => {
+        if (e.key !== "Escape") return;
+        if (
+          document.getElementById("proposalModal")?.classList.contains("open")
+        ) {
+          closeProposalBuilder();
+        } else if (
+          document.getElementById("compareModal")?.classList.contains("open")
+        ) {
+          closeCompareModal();
+        } else if (
+          document.getElementById("orgModal")?.classList.contains("open")
+        ) {
+          closeOrgModal();
+        } else if (
+          document.getElementById("anBg")?.classList.contains("open")
+        ) {
+          closeAn();
+        }
+      });
 
-  function refreshOrgGridAfterBookmarkChange() {
-    if (activeChip === 'bookmarked') {
-      applyFiltersPreservingVisibleCount();
-      return;
-    }
-    refreshVisibleBookmarkButtons();
-  }
+      function applyFiltersPreservingVisibleCount() {
+        const savedCount = visibleCount;
+        const grid = document.getElementById("orgGrid");
+        if (!grid) return;
+        // applyFilters() updates the filteredOrgs list and calls renderOrgs(true)
+        // which resets visibleCount to 12. We then keep appending subsequent pages
+        // until we reach the count the user had previously scrolled to.
+        applyFilters();
+        while (
+          visibleCount < savedCount &&
+          visibleCount < filteredOrgs.length
+        ) {
+          visibleCount += 12;
+          renderOrgs(false);
+        }
+      }
 
-  /**
-   * Single source-of-truth writer for bookmarks.
-   * Always keeps bookmarkedSet (in-memory) + localStorage in lock-step.
-   * Re-filters only when the active filter depends on bookmark state.
-   */
-  function syncBookmark(name, shouldAdd) {
-    const orgName = typeof name === 'number' ? ORGS[name]?.name : name;
-    if (!orgName) return;
-    if (shouldAdd) bookmarkedSet.add(orgName);
-    else           bookmarkedSet.delete(orgName);
-    localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
-    refreshOrgGridAfterBookmarkChange();
-    renderWatchlist();
-    updateAIInsights();
-  }
+      // ══════════════════════════════════════════════
+      // WATCHLIST — centralised bookmark sync helper
+      // ══════════════════════════════════════════════
+      function refreshVisibleBookmarkButtons() {
+        document
+          .querySelectorAll("#orgGrid .bookmark-btn[data-bookmark-org]")
+          .forEach((btn) => {
+            const isBookmarked = bookmarkedSet.has(btn.dataset.bookmarkOrg);
+            btn.classList.toggle("active", isBookmarked);
+            btn.classList.toggle("text-zinc-300", !isBookmarked);
+            btn.title = isBookmarked ? "Remove bookmark" : "Add bookmark";
+            btn
+              .querySelector(".material-symbols-outlined")
+              ?.classList.toggle("icon-fill", isBookmarked);
+          });
+      }
 
-  function toggleBookmark(e, name) {
-    if (e) e.stopPropagation();
-    const orgName = typeof name === 'number' ? ORGS[name]?.name : name;
-    if (!orgName) return;
-    syncBookmark(orgName, !bookmarkedSet.has(orgName));
-  }
+      function refreshOrgGridAfterBookmarkChange() {
+        if (activeChip === "bookmarked") {
+          applyFiltersPreservingVisibleCount();
+          return;
+        }
+        refreshVisibleBookmarkButtons();
+      }
 
-  // Listen for bookmarks toggled by app.js (the other org-grid script).
-  // When app.js fires 'bookmarkChanged', we re-read localStorage so
-  // bookmarkedSet stays in sync, then refresh the Watchlist panel.
-  document.addEventListener('bookmarkChanged', () => {
-    const fresh = new Set(parseStoredBookmarks());
-    // Diff: add new entries, remove stale ones — no full replacement so
-    // any in-memory state from index.html toggles is also preserved.
-    fresh.forEach(n => bookmarkedSet.add(n));
-    [...bookmarkedSet].forEach(n => { if (!fresh.has(n)) bookmarkedSet.delete(n); });
-    refreshOrgGridAfterBookmarkChange();
-    renderWatchlist();
-    updateAIInsights();
-  });
+      /**
+       * Single source-of-truth writer for bookmarks.
+       * Always keeps bookmarkedSet (in-memory) + localStorage in lock-step.
+       * Re-filters only when the active filter depends on bookmark state.
+       */
+      function syncBookmark(name, shouldAdd) {
+        const orgName = typeof name === "number" ? ORGS[name]?.name : name;
+        if (!orgName) return;
+        if (shouldAdd) bookmarkedSet.add(orgName);
+        else bookmarkedSet.delete(orgName);
+        localStorage.setItem("bookmarks", JSON.stringify([...bookmarkedSet]));
+        refreshOrgGridAfterBookmarkChange();
+        renderWatchlist();
+        updateAIInsights();
+      }
 
-  // Wire up "Clear All" button
-  document.getElementById('clearAllBookmarksBtn')?.addEventListener('click', clearAllBookmarks);
+      function toggleBookmark(e, name) {
+        if (e) e.stopPropagation();
+        const orgName = typeof name === "number" ? ORGS[name]?.name : name;
+        if (!orgName) return;
+        syncBookmark(orgName, !bookmarkedSet.has(orgName));
+      }
 
-  function clearAllBookmarks() {
-    if (!bookmarkedSet.size) return;
-    if (!confirm(`Remove all ${bookmarkedSet.size} bookmarked organization(s)? This cannot be undone.`)) return;
-    bookmarkedSet.clear();
-    localStorage.setItem('bookmarks', JSON.stringify([]));
-    applyFilters();
-    renderWatchlist();
-    updateAIInsights();
-  }
+      // Listen for bookmarks toggled by app.js (the other org-grid script).
+      // When app.js fires 'bookmarkChanged', we re-read localStorage so
+      // bookmarkedSet stays in sync, then refresh the Watchlist panel.
+      document.addEventListener("bookmarkChanged", () => {
+        const fresh = new Set(parseStoredBookmarks());
+        // Diff: add new entries, remove stale ones — no full replacement so
+        // any in-memory state from index.html toggles is also preserved.
+        fresh.forEach((n) => bookmarkedSet.add(n));
+        [...bookmarkedSet].forEach((n) => {
+          if (!fresh.has(n)) bookmarkedSet.delete(n);
+        });
+        refreshOrgGridAfterBookmarkChange();
+        renderWatchlist();
+        updateAIInsights();
+      });
 
-  // ── renderWatchlist ─────────────────────────────────────────────────────────
-  function renderWatchlist() {
-    const container = document.getElementById('watchlistContainer');
-    const clearBtn  = document.getElementById('clearAllBookmarksBtn');
-    if (!container) return;
+      // Wire up "Clear All" button
+      document
+        .getElementById("clearAllBookmarksBtn")
+        ?.addEventListener("click", clearAllBookmarks);
 
-    container.innerHTML = '';
+      function clearAllBookmarks() {
+        if (!bookmarkedSet.size) return;
+        if (
+          !confirm(
+            `Remove all ${bookmarkedSet.size} bookmarked organization(s)? This cannot be undone.`,
+          )
+        )
+          return;
+        bookmarkedSet.clear();
+        localStorage.setItem("bookmarks", JSON.stringify([]));
+        applyFilters();
+        renderWatchlist();
+        updateAIInsights();
+      }
 
-    const bookmarks = [...bookmarkedSet]
-      .map(name => ORGS.find(o => o.name === name))
-      .filter(Boolean);
+      // ── renderWatchlist ─────────────────────────────────────────────────────────
+      function renderWatchlist() {
+        const container = document.getElementById("watchlistContainer");
+        const clearBtn = document.getElementById("clearAllBookmarksBtn");
+        if (!container) return;
 
-    // Show / hide "Clear All" button
-    if (clearBtn) clearBtn.classList.toggle('hidden', bookmarks.length === 0);
+        container.innerHTML = "";
 
-    // ── Empty state ───────────────────────────────────────────────────────────
-    if (bookmarks.length === 0) {
-      container.innerHTML = `
+        const bookmarks = [...bookmarkedSet]
+          .map((name) => ORGS.find((o) => o.name === name))
+          .filter(Boolean);
+
+        // Show / hide "Clear All" button
+        if (clearBtn)
+          clearBtn.classList.toggle("hidden", bookmarks.length === 0);
+
+        // ── Empty state ───────────────────────────────────────────────────────────
+        if (bookmarks.length === 0) {
+          container.innerHTML = `
         <div class="py-16 text-center border-2 border-dashed border-zinc-200 rounded-2xl">
           <span class="material-symbols-outlined text-4xl text-zinc-300 mb-4 block">bookmark_border</span>
           <p class="font-bold text-zinc-500 mb-1">Your Watchlist is Empty</p>
           <p class="text-sm text-zinc-400">Click the ★ on any organization card to start tracking it here.</p>
         </div>`;
-      return;
-    }
+          return;
+        }
 
-    // ── Render one card per bookmarked org ────────────────────────────────────
-    bookmarks.forEach(org => {
-      const githubOwner = githubOwnerFromValue(org.github);
-      const logoUrl     = githubOwner
-        ? `https://github.com/${githubOwner}.png?size=80`
-        : '';
-      const category = getCategoryMeta(org.cat);
+        // ── Render one card per bookmarked org ────────────────────────────────────
+        bookmarks.forEach((org) => {
+          const githubOwner = githubOwnerFromValue(org.github);
+          const logoUrl = githubOwner
+            ? `https://github.com/${githubOwner}.png?size=80`
+            : "";
+          const category = getCategoryMeta(org.cat);
 
-      const topTags = (org.tags || []).slice(0, 4)
-        .map(t => `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded text-zinc-600">${escapeHtml(t)}</span>`)
-        .join('');
+          const topTags = (org.tags || [])
+            .slice(0, 4)
+            .map(
+              (t) =>
+                `<span class="px-2 py-0.5 bg-surface-container-low text-[10px] font-mono rounded text-zinc-600">${escapeHtml(t)}</span>`,
+            )
+            .join("");
 
-      const item = document.createElement('div');
-      item.className = 'bg-white rounded-2xl p-5 border border-zinc-100 flex gap-4 items-start hover:shadow-lg hover:border-primary/20 transition-all animate-fade-up';
-      item.dataset.watchlistOrg = org.name;
+          const item = document.createElement("div");
+          item.className =
+            "bg-white rounded-2xl p-5 border border-zinc-100 flex gap-4 items-start hover:shadow-lg hover:border-primary/20 transition-all animate-fade-up";
+          item.dataset.watchlistOrg = org.name;
 
-      item.innerHTML = `
+          item.innerHTML = `
         <!-- Logo -->
         <div class="w-12 h-12 rounded-xl bg-surface-container-low flex items-center justify-center flex-shrink-0 overflow-hidden border border-zinc-100">
-          ${logoUrl
-            ? `<img src="${escapeHtml(logoUrl)}"
+          ${
+            logoUrl
+              ? `<img src="${escapeHtml(logoUrl)}"
                     data-org-name="${escapeHtml(org.name)}"
                     alt="${escapeHtml(org.name)} logo"
                     class="w-full h-full object-contain">`
-            : `<span class="material-symbols-outlined text-primary text-xl">corporate_fare</span>`
+              : `<span class="material-symbols-outlined text-primary text-xl">corporate_fare</span>`
           }
         </div>
         <!-- Body -->
@@ -3114,7 +5337,7 @@ btn.__orgListenerAttached = true;
               <span class="text-[10px] font-label font-bold uppercase tracking-wider text-white bg-primary px-2 py-0.5 rounded-full">★ Saved</span>
             </div>
           </div>
-          <p class="text-sm text-zinc-500 mb-3 line-clamp-1">${escapeHtml(org.desc || '')}</p>
+          <p class="text-sm text-zinc-500 mb-3 line-clamp-1">${escapeHtml(org.desc || "")}</p>
           <div class="flex flex-wrap gap-1.5 mb-3">${topTags}</div>
           <div class="flex items-center justify-between pt-3 border-t border-zinc-100">
             <div class="flex items-center gap-3 text-xs text-zinc-400">
@@ -3124,7 +5347,7 @@ btn.__orgListenerAttached = true;
               </span>
               <span class="flex items-center gap-1">
                 <span class="material-symbols-outlined text-xs">bar_chart</span>
-                ${escapeHtml(org.competition || '—')}
+                ${escapeHtml(org.competition || "—")}
               </span>
             </div>
             <button data-bookmark-org="${escapeHtml(org.name)}"
@@ -3135,93 +5358,152 @@ btn.__orgListenerAttached = true;
           </div>
         </div>`;
 
-      container.appendChild(item);
-      attachOrgCardListeners(item);
-    });
-  }
+          container.appendChild(item);
+          attachOrgCardListeners(item);
+        });
+      }
 
-  // ── updateAIInsights ─────────────────────────────────────────────────────────
-  /**
-   * Analyses the bookmarked orgs across three dimensions:
-   *   1. Most frequent category  → domain-specific advice
-   *   2. Top 3 tags (tech stack) → technology-specific tool recommendations
-   *   3. Competition level blend → acceptance-strategy advice
-   *
-   * Updates #aiInsightText with a rich, personalised HTML message.
-   */
-  function updateAIInsights() {
-    const el = document.getElementById('aiInsightText');
-    if (!el) return;
+      // ── updateAIInsights ─────────────────────────────────────────────────────────
+      /**
+       * Analyses the bookmarked orgs across three dimensions:
+       *   1. Most frequent category  → domain-specific advice
+       *   2. Top 3 tags (tech stack) → technology-specific tool recommendations
+       *   3. Competition level blend → acceptance-strategy advice
+       *
+       * Updates #aiInsightText with a rich, personalised HTML message.
+       */
+      function updateAIInsights() {
+        const el = document.getElementById("aiInsightText");
+        if (!el) return;
 
-    const bookmarks = [...bookmarkedSet]
-      .map(name => ORGS.find(o => o.name === name))
-      .filter(Boolean);
+        const bookmarks = [...bookmarkedSet]
+          .map((name) => ORGS.find((o) => o.name === name))
+          .filter(Boolean);
 
-    if (bookmarks.length === 0) {
-      el.textContent = 'Star organizations to get personalized contribution advice.';
-      return;
-    }
+        if (bookmarks.length === 0) {
+          el.textContent =
+            "Star organizations to get personalized contribution advice.";
+          return;
+        }
 
-    // ── 1. Category frequency ────────────────────────────────────────────────
-    const catCount = {};
-    bookmarks.forEach(o => { catCount[o.cat] = (catCount[o.cat] || 0) + 1; });
-    const topCat = Object.entries(catCount).sort((a, b) => b[1] - a[1])[0]?.[0] || 'other';
+        // ── 1. Category frequency ────────────────────────────────────────────────
+        const catCount = {};
+        bookmarks.forEach((o) => {
+          catCount[o.cat] = (catCount[o.cat] || 0) + 1;
+        });
+        const topCat =
+          Object.entries(catCount).sort((a, b) => b[1] - a[1])[0]?.[0] ||
+          "other";
 
-    // ── 2. Tag frequency (top 3) ─────────────────────────────────────────────
-    const tagCount = {};
-    bookmarks.flatMap(o => o.tags || []).forEach(t => {
-      const key = t.toLowerCase().trim();
-      tagCount[key] = (tagCount[key] || 0) + 1;
-    });
-    const topTags = Object.entries(tagCount)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 3)
-      .map(([t]) => t);
+        // ── 2. Tag frequency (top 3) ─────────────────────────────────────────────
+        const tagCount = {};
+        bookmarks
+          .flatMap((o) => o.tags || [])
+          .forEach((t) => {
+            const key = t.toLowerCase().trim();
+            tagCount[key] = (tagCount[key] || 0) + 1;
+          });
+        const topTags = Object.entries(tagCount)
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 3)
+          .map(([t]) => t);
 
-    // ── 3. Competition blend ─────────────────────────────────────────────────
-    const compCount = { hot: 0, moderate: 0, chill: 0 };
-    bookmarks.forEach(o => { if (compCount[o.competition] !== undefined) compCount[o.competition]++; });
-    const highComp    = compCount.hot   >= bookmarks.length * 0.5;
-    const lowComp     = compCount.chill >= bookmarks.length * 0.5;
+        // ── 3. Competition blend ─────────────────────────────────────────────────
+        const compCount = { hot: 0, moderate: 0, chill: 0 };
+        bookmarks.forEach((o) => {
+          if (compCount[o.competition] !== undefined)
+            compCount[o.competition]++;
+        });
+        const highComp = compCount.hot >= bookmarks.length * 0.5;
+        const lowComp = compCount.chill >= bookmarks.length * 0.5;
 
-    // ── Domain-specific tool recommendations ─────────────────────────────────
-    const DOMAIN_ADVICE = {
-      ai:          { tools: 'PyTorch, TensorFlow, Hugging Face, or scikit-learn',        action: 'contribute to model training pipelines or evaluation utilities' },
-      data:        { tools: 'Pandas, Apache Spark, DuckDB, or dbt',                      action: 'look for data pipeline, ETL, or visualisation issues' },
-      science:     { tools: 'NumPy, SciPy, Astropy, or ROOT',                            action: 'explore numerical computation or simulation-related tickets' },
-      security:    { tools: 'Metasploit, Wireshark, OpenSSL, or OWASP tooling',          action: 'hunt for documentation or testing improvements in security repos' },
-      infra:       { tools: 'Kubernetes, Terraform, Prometheus, or Ansible',             action: 'target CI/CD configuration, observability, or deployment issues' },
-      web:         { tools: 'React, Vue, Svelte, or Node.js ecosystem libraries',        action: 'focus on accessibility fixes, UI components, or API improvements' },
-      programming: { tools: 'LLVM, GCC, rustc, or language toolchain packages',          action: 'dive into compiler warnings, test coverage, or RFC implementations' },
-      os:          { tools: 'Linux kernel toolchain, QEMU, or POSIX libraries',          action: 'start with documentation, porting, or driver-level good-first issues' },
-      dev:         { tools: 'LSP plugins, tree-sitter grammars, or CLI tooling',         action: 'pick up linter rules, editor extensions, or test-suite tasks' },
-      media:       { tools: 'FFmpeg, GStreamer, VLC plugin SDK, or libav',               action: 'explore codec, subtitle, or format compatibility tickets' },
-      other:       { tools: 'the project\'s primary language ecosystem',                 action: 'read the CONTRIBUTING guide and tackle labelled good-first issues' },
-    };
-    const advice = DOMAIN_ADVICE[topCat] || DOMAIN_ADVICE.other;
+        // ── Domain-specific tool recommendations ─────────────────────────────────
+        const DOMAIN_ADVICE = {
+          ai: {
+            tools: "PyTorch, TensorFlow, Hugging Face, or scikit-learn",
+            action:
+              "contribute to model training pipelines or evaluation utilities",
+          },
+          data: {
+            tools: "Pandas, Apache Spark, DuckDB, or dbt",
+            action: "look for data pipeline, ETL, or visualisation issues",
+          },
+          science: {
+            tools: "NumPy, SciPy, Astropy, or ROOT",
+            action:
+              "explore numerical computation or simulation-related tickets",
+          },
+          security: {
+            tools: "Metasploit, Wireshark, OpenSSL, or OWASP tooling",
+            action:
+              "hunt for documentation or testing improvements in security repos",
+          },
+          infra: {
+            tools: "Kubernetes, Terraform, Prometheus, or Ansible",
+            action:
+              "target CI/CD configuration, observability, or deployment issues",
+          },
+          web: {
+            tools: "React, Vue, Svelte, or Node.js ecosystem libraries",
+            action:
+              "focus on accessibility fixes, UI components, or API improvements",
+          },
+          programming: {
+            tools: "LLVM, GCC, rustc, or language toolchain packages",
+            action:
+              "dive into compiler warnings, test coverage, or RFC implementations",
+          },
+          os: {
+            tools: "Linux kernel toolchain, QEMU, or POSIX libraries",
+            action:
+              "start with documentation, porting, or driver-level good-first issues",
+          },
+          dev: {
+            tools: "LSP plugins, tree-sitter grammars, or CLI tooling",
+            action:
+              "pick up linter rules, editor extensions, or test-suite tasks",
+          },
+          media: {
+            tools: "FFmpeg, GStreamer, VLC plugin SDK, or libav",
+            action: "explore codec, subtitle, or format compatibility tickets",
+          },
+          other: {
+            tools: "the project's primary language ecosystem",
+            action:
+              "read the CONTRIBUTING guide and tackle labelled good-first issues",
+          },
+        };
+        const advice = DOMAIN_ADVICE[topCat] || DOMAIN_ADVICE.other;
 
-    // ── Competition strategy ──────────────────────────────────────────────────
-    const strategyMsg = highComp
-      ? '⚠️ Your watchlist skews towards <strong>high-competition</strong> orgs — consider adding a few <em>Chill</em> orgs to diversify your odds.'
-      : lowComp
-        ? '✅ Smart move — your watchlist is weighted towards <strong>lower-competition</strong> orgs, which improves acceptance probability.'
-        : '📊 Your watchlist has a <strong>balanced mix</strong> of competition levels — a solid hedging strategy.';
+        // ── Competition strategy ──────────────────────────────────────────────────
+        const strategyMsg = highComp
+          ? "⚠️ Your watchlist skews towards <strong>high-competition</strong> orgs — consider adding a few <em>Chill</em> orgs to diversify your odds."
+          : lowComp
+            ? "✅ Smart move — your watchlist is weighted towards <strong>lower-competition</strong> orgs, which improves acceptance probability."
+            : "📊 Your watchlist has a <strong>balanced mix</strong> of competition levels — a solid hedging strategy.";
 
-    // ── Stack summary line ────────────────────────────────────────────────────
-    const stackLine = topTags.length
-      ? `Your saved orgs centre on <strong>${topTags.map(t => escapeHtml(t)).join(', ')}</strong>.`
-      : 'Your saved orgs span a diverse set of technologies.';
+        // ── Stack summary line ────────────────────────────────────────────────────
+        const stackLine = topTags.length
+          ? `Your saved orgs centre on <strong>${topTags.map((t) => escapeHtml(t)).join(", ")}</strong>.`
+          : "Your saved orgs span a diverse set of technologies.";
 
-    // ── Category label ────────────────────────────────────────────────────────
-    const CAT_LABELS = {
-      ai:'AI / ML', data:'Data Science', science:'Scientific Computing',
-      security:'Security', infra:'Infrastructure', web:'Web Development',
-      programming:'Programming Languages', os:'OS / Systems', dev:'Dev Tools',
-      media:'Media / Multimedia', other:'Open Source',
-    };
-    const catLabel = CAT_LABELS[topCat] || 'Open Source';
+        // ── Category label ────────────────────────────────────────────────────────
+        const CAT_LABELS = {
+          ai: "AI / ML",
+          data: "Data Science",
+          science: "Scientific Computing",
+          security: "Security",
+          infra: "Infrastructure",
+          web: "Web Development",
+          programming: "Programming Languages",
+          os: "OS / Systems",
+          dev: "Dev Tools",
+          media: "Media / Multimedia",
+          other: "Open Source",
+        };
+        const catLabel = CAT_LABELS[topCat] || "Open Source";
 
-    el.innerHTML = `
+        el.innerHTML = `
       <div class="space-y-3 text-sm leading-relaxed">
         <p>
           <span class="font-bold">📌 Stack Focus:</span>
@@ -3234,82 +5516,92 @@ btn.__orgListenerAttached = true;
         </p>
         <p>${strategyMsg}</p>
         <p class="text-orange-200 text-[10px] font-label uppercase tracking-widest pt-1 border-t border-white/20">
-          Based on ${bookmarks.length} saved org${bookmarks.length !== 1 ? 's' : ''} · Automated insight
+          Based on ${bookmarks.length} saved org${bookmarks.length !== 1 ? "s" : ""} · Automated insight
         </p>
       </div>`;
-  }
+      }
 
-  function addRecentlyViewed(name) {
-    if (!name) return;
-    try {
-      // Remove if already exists, then add to front
-      recentlyViewed = recentlyViewed.filter(n => n !== name);
-      recentlyViewed.unshift(name);
-      persistRecentlyViewed();
-      renderRecentlyViewed();
-    } catch (e) {
-      console.warn('Failed to add to recently viewed:', e);
-    }
-  }
+      function addRecentlyViewed(name) {
+        if (!name) return;
+        try {
+          // Remove if already exists, then add to front
+          recentlyViewed = recentlyViewed.filter((n) => n !== name);
+          recentlyViewed.unshift(name);
+          persistRecentlyViewed();
+          renderRecentlyViewed();
+        } catch (e) {
+          console.warn("Failed to add to recently viewed:", e);
+        }
+      }
 
-  function persistRecentlyViewed() {
-    try {
-      localStorage.setItem(RECENTLY_VIEWED_KEY, JSON.stringify(recentlyViewed));
-    } catch (error) {
-      console.warn('Recently viewed persistence failed:', error);
-    }
-  }
+      function persistRecentlyViewed() {
+        try {
+          localStorage.setItem(
+            RECENTLY_VIEWED_KEY,
+            JSON.stringify(recentlyViewed),
+          );
+        } catch (error) {
+          console.warn("Recently viewed persistence failed:", error);
+        }
+      }
 
-  function removeRecentlyViewed(name) {
-    try {
-      recentlyViewed = recentlyViewed.filter(n => n !== name);
-      persistRecentlyViewed();
-      renderRecentlyViewed();
-    } catch (e) {
-      console.warn('Failed to remove from recently viewed:', e);
-    }
-  }
+      function removeRecentlyViewed(name) {
+        try {
+          recentlyViewed = recentlyViewed.filter((n) => n !== name);
+          persistRecentlyViewed();
+          renderRecentlyViewed();
+        } catch (e) {
+          console.warn("Failed to remove from recently viewed:", e);
+        }
+      }
 
-  function clearRecentlyViewed() {
-    try {
-      recentlyViewed = [];
-      persistRecentlyViewed();
-      renderRecentlyViewed();
-    } catch (e) {
-      console.warn('Failed to clear recently viewed:', e);
-    }
-  }
+      function clearRecentlyViewed() {
+        try {
+          recentlyViewed = [];
+          persistRecentlyViewed();
+          renderRecentlyViewed();
+        } catch (e) {
+          console.warn("Failed to clear recently viewed:", e);
+        }
+      }
 
-  function renderRecentlyViewed() {
-    const section = document.getElementById('recentlyViewedSection');
-    const container = document.getElementById('recentlyViewedContainer');
-    const overflowBadge = document.getElementById('recentlyViewedOverflowBadge');
-    if (!section || !container) return;
+      function renderRecentlyViewed() {
+        const section = document.getElementById("recentlyViewedSection");
+        const container = document.getElementById("recentlyViewedContainer");
+        const overflowBadge = document.getElementById(
+          "recentlyViewedOverflowBadge",
+        );
+        if (!section || !container) return;
 
-    // Hide section if empty
-    if (recentlyViewed.length === 0) {
-      section.classList.add('hidden');
-      overflowBadge?.classList.add('hidden');
-      return;
-    }
+        // Hide section if empty
+        if (recentlyViewed.length === 0) {
+          section.classList.add("hidden");
+          overflowBadge?.classList.add("hidden");
+          return;
+        }
 
-    section.classList.remove('hidden');
-    container.innerHTML = '';
+        section.classList.remove("hidden");
+        container.innerHTML = "";
 
-    const overflowCount = Math.max(recentlyViewed.length - RECENTLY_VIEWED_LIMIT, 0);
-    if (overflowBadge) {
-      overflowBadge.textContent = overflowCount > 0 ? `+${overflowCount}` : '';
-      overflowBadge.classList.toggle('hidden', overflowCount === 0);
-    }
+        const overflowCount = Math.max(
+          recentlyViewed.length - RECENTLY_VIEWED_LIMIT,
+          0,
+        );
+        if (overflowBadge) {
+          overflowBadge.textContent =
+            overflowCount > 0 ? `+${overflowCount}` : "";
+          overflowBadge.classList.toggle("hidden", overflowCount === 0);
+        }
 
-    recentlyViewed.slice(0, RECENTLY_VIEWED_LIMIT).forEach(name => {
-      const org = ORGS.find(o => o.name === name);
-      if (!org) return;
-      const category = getCategoryMeta(org.cat);
+        recentlyViewed.slice(0, RECENTLY_VIEWED_LIMIT).forEach((name) => {
+          const org = ORGS.find((o) => o.name === name);
+          if (!org) return;
+          const category = getCategoryMeta(org.cat);
 
-      const card = document.createElement('div');
-      card.className = 'bg-white rounded-lg p-4 border border-zinc-100 hover:border-primary transition-colors cursor-pointer flex items-center justify-between';
-      card.innerHTML = `
+          const card = document.createElement("div");
+          card.className =
+            "bg-white rounded-lg p-4 border border-zinc-100 hover:border-primary transition-colors cursor-pointer flex items-center justify-between";
+          card.innerHTML = `
         <div class="flex-1 min-w-0">
           <h4 class="font-bold text-sm mb-1">${escapeHtml(org.name)}</h4>
           <div class="flex items-center gap-2 flex-wrap">
@@ -3323,324 +5615,384 @@ btn.__orgListenerAttached = true;
           </button>
         </div>
       `;
-      card.onclick = () => openModal(org.name);
-      container.appendChild(card);
-    });
+          card.onclick = () => openModal(org.name);
+          container.appendChild(card);
+        });
 
-    // Wire up remove buttons
-    container.querySelectorAll('[data-remove-recent]').forEach(btn => {
-      btn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        removeRecentlyViewed(btn.dataset.removeRecent);
-      });
-    });
-  }
+        // Wire up remove buttons
+        container.querySelectorAll("[data-remove-recent]").forEach((btn) => {
+          btn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            removeRecentlyViewed(btn.dataset.removeRecent);
+          });
+        });
+      }
 
-  function openModal(name) {
-    const org = ORGS.find(o => o.name === name);
-    if (!org) return;
-    addRecentlyViewed(name);
+      function openModal(name) {
+        const org = ORGS.find((o) => o.name === name);
+        if (!org) return;
+        addRecentlyViewed(name);
 
-    // Track badge progress for org views
-    if (typeof BadgeSystem !== 'undefined') {
-      BadgeSystem.trackOrgView();
-    }
+        // Track badge progress for org views
+        if (typeof BadgeSystem !== "undefined") {
+          BadgeSystem.trackOrgView();
+        }
 
-    document.getElementById('mHeader').innerHTML = `
+        document.getElementById("mHeader").innerHTML = `
       <span class="category-tag">${escapeHtml(String(org.cat).toUpperCase())}</span>
       <h2>${escapeHtml(org.name)}</h2>
       <p class="text-zinc-500">GSoC Partner for ${escapeHtml(String(org.years))} Years</p>
     `;
 
-    document.getElementById('mMetrics').innerHTML = `
+        document.getElementById("mMetrics").innerHTML = `
       <div class="metric-card"><p class="metric-value">${escapeHtml(String(org.years))}</p><p class="metric-label">Years In</p></div>
       <div class="metric-card"><p class="metric-value">${escapeHtml(String(org.firstYear))}</p><p class="metric-label">First Year</p></div>
       <div class="metric-card"><p class="metric-value font-mono text-sm">${escapeHtml(String(org.competition).toUpperCase())}</p><p class="metric-label">Competition</p></div>
       <div class="metric-card"><p class="metric-value font-mono text-sm">${escapeHtml(String(org.codebase).toUpperCase())}</p><p class="metric-label">Codebase</p></div>
     `;
 
-    document.getElementById('mDesc').textContent = org.desc;
-    document.getElementById('mTech').innerHTML = org.tags.map(t => `<span class="tech-tag">${escapeHtml(t)}</span>`).join('');
-    document.getElementById('mFit').innerHTML = org.fit.map(f => `<span class="fit-tag">${escapeHtml(f)}</span>`).join('');
+        document.getElementById("mDesc").textContent = org.desc;
+        document.getElementById("mTech").innerHTML = org.tags
+          .map((t) => `<span class="tech-tag">${escapeHtml(t)}</span>`)
+          .join("");
+        document.getElementById("mFit").innerHTML = org.fit
+          .map((f) => `<span class="fit-tag">${escapeHtml(f)}</span>`)
+          .join("");
 
-    // Timeline
-    let timelineHtml = '';
-    for(let y=2020; y<=2026; y++) {
-       const active = (y >= org.firstYear);
-       timelineHtml += `<span class="${y===2026?'current-year':''} ${active?'opacity-100':'opacity-30'}">${y}</span>`;
-    }
-    document.getElementById('mTimeline').innerHTML = timelineHtml;
+        // Timeline
+        let timelineHtml = "";
+        for (let y = 2020; y <= 2026; y++) {
+          const active = y >= org.firstYear;
+          timelineHtml += `<span class="${y === 2026 ? "current-year" : ""} ${active ? "opacity-100" : "opacity-30"}">${y}</span>`;
+        }
+        document.getElementById("mTimeline").innerHTML = timelineHtml;
 
-    // Sanitize and set idea/repo links
-    const ideasUrl = sanitizeHrefUrl(org.ideas);
-    const repoUrl = sanitizeHrefUrl(githubUrlFromValue(org.github));
-    const ideasBtn = document.getElementById('mIdeasBtn');
-    const repoBtn = document.getElementById('mRepoBtn');
-    if (ideasBtn) {
-      if (ideasUrl) ideasBtn.href = ideasUrl; else ideasBtn.removeAttribute('href');
-    }
-    if (repoBtn) {
-      if (repoUrl) repoBtn.href = repoUrl; else repoBtn.removeAttribute('href');
-    }
+        // Sanitize and set idea/repo links
+        const ideasUrl = sanitizeHrefUrl(org.ideas);
+        const repoUrl = sanitizeHrefUrl(githubUrlFromValue(org.github));
+        const ideasBtn = document.getElementById("mIdeasBtn");
+        const repoBtn = document.getElementById("mRepoBtn");
+        if (ideasBtn) {
+          if (ideasUrl) ideasBtn.href = ideasUrl;
+          else ideasBtn.removeAttribute("href");
+        }
+        if (repoBtn) {
+          if (repoUrl) repoBtn.href = repoUrl;
+          else repoBtn.removeAttribute("href");
+        }
 
-// Copy link button
-const oldCopy = document.getElementById('mIdeasCopyBtn');
-if(oldCopy) oldCopy.remove();
-if(org.ideas){
-  const copyBtn = document.createElement('button');
-  copyBtn.id = 'mIdeasCopyBtn';
-  copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">content_copy</span> Copy Link';
-  copyBtn.className = 'modal-cta modal-repo-link flex items-center justify-center gap-2';
-  copyBtn.onclick = function(){
-    navigator.clipboard.writeText(org.ideas).then(()=>{
-      copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">check_circle</span> Copied!';
-      copyBtn.style.background = '#dcfce7';
-      copyBtn.style.color = '#166534';
-      setTimeout(()=>{
-        copyBtn.innerHTML = '<span class="material-symbols-outlined text-lg">content_copy</span> Copy Link';
-        copyBtn.style.background = '';
-        copyBtn.style.color = '';
-      }, 2000);
-    });
-  };
-  document.getElementById('mIdeasBtn').after(copyBtn);
-}
-    renderMentorContactSection(org);
+        // Copy link button
+        const oldCopy = document.getElementById("mIdeasCopyBtn");
+        if (oldCopy) oldCopy.remove();
+        if (org.ideas) {
+          const copyBtn = document.createElement("button");
+          copyBtn.id = "mIdeasCopyBtn";
+          copyBtn.innerHTML =
+            '<span class="material-symbols-outlined text-lg">content_copy</span> Copy Link';
+          copyBtn.className =
+            "modal-cta modal-repo-link flex items-center justify-center gap-2";
+          copyBtn.onclick = function () {
+            navigator.clipboard.writeText(org.ideas).then(() => {
+              copyBtn.innerHTML =
+                '<span class="material-symbols-outlined text-lg">check_circle</span> Copied!';
+              copyBtn.style.background = "#dcfce7";
+              copyBtn.style.color = "#166534";
+              setTimeout(() => {
+                copyBtn.innerHTML =
+                  '<span class="material-symbols-outlined text-lg">content_copy</span> Copy Link';
+                copyBtn.style.background = "";
+                copyBtn.style.color = "";
+              }, 2000);
+            });
+          };
+          document.getElementById("mIdeasBtn").after(copyBtn);
+        }
+        renderMentorContactSection(org);
 
-    const draftBtn = document.getElementById('mDraftBtn');
-    if (draftBtn) {
-      draftBtn.onclick = () => ProposalBuilder.open(org.name);
-    }
-     
-    document.getElementById('orgModal').classList.add('open');
-    document.body.classList.add('modal-open');
-    document.documentElement.style.overflow = 'hidden';
-    document.body.style.overflow = 'hidden';
-  }
+        const draftBtn = document.getElementById("mDraftBtn");
+        if (draftBtn) {
+          draftBtn.onclick = () => ProposalBuilder.open(org.name);
+        }
 
-  function closeOrgModal() {
-    document.getElementById('orgModal').classList.remove('open');
-    document.body.classList.remove('modal-open');
-    document.documentElement.style.overflow = '';
-    document.body.style.overflow = '';
-  }
-
-  function openRandomOrg() {
-    const orgsToUse = filteredOrgs.length > 0 ? filteredOrgs : ORGS;
-    
-    if (!orgsToUse.length) {
-      alert('No organizations match your filters — try clearing some!');
-      return;
-    }
-
-    const randomIdx = Math.floor(Math.random() * orgsToUse.length);
-    const randomOrg = orgsToUse[randomIdx];
-    
-    openModal(randomOrg.name);
-  }
-
-  // Filters — all conditions are additive (chip + language pills + search + dropdowns compose)
-  function applyFilters() {
-    const query = document.getElementById('searchInput').value.trim().toLowerCase();
-    const categoryValue = document.getElementById('categoryFilter')?.value || 'all';
-    const cat = categoryValue === 'all' ? '' : categoryValue;
-    const comp = document.getElementById('complexityFilter').value;
-    const sort = document.getElementById('sortSelect')?.value || 'alpha';
-
-    filteredOrgs = ORGS.filter(o => {
-      const matchSearch = o.name.toLowerCase().includes(query);
-      const matchCat = !cat || o.cat === cat;
-      const matchComp = comp === 'all' || o.codebase === comp;
-      const tags = (o.tags || []).map(t => String(t).toLowerCase());
-      const matchLang = selectedLanguages.size === 0
-        || (matchAllLanguages
-          ? [...selectedLanguages].every(lang => languageMatchesSelection(tags, lang))
-          : [...selectedLanguages].some(lang => languageMatchesSelection(tags, lang)));
-
-      let matchChip = true;
-      if (activeChip === 'bookmarked')  matchChip = bookmarkedSet.has(o.name);
-      else if (activeChip === 'veterans')         matchChip = o.years >= 10;
-      else if (activeChip === 'newcomers')   matchChip = o.years <= 3;
-      else if (activeChip === 'low-competition')  matchChip = o.competition === 'chill';
-      else if (activeChip === 'high-competition') matchChip = o.competition === 'hot';
-
-      return matchSearch && matchCat && matchComp && matchLang && matchChip;
-    });
-
-    if(query){
-      filteredOrgs.sort((a,b)=>{
-        const nameA=a.name.toLowerCase();
-        const nameB=b.name.toLowerCase();
-        if(nameA===query && nameB!==query) return -1;
-        if(nameB===query && nameA!==query) return 1;
-        if(nameA.startsWith(query) && !nameB.startsWith(query)) return -1;
-        if(nameB.startsWith(query) && !nameA.startsWith(query)) return 1;
-        return applySecondarySort(a, b, sort);
-      });
-    } else {
-      filteredOrgs.sort((a, b) => applySecondarySort(a, b, sort));
-    }
-
-    renderOrgs(true);
-
-    // Persist filter state to URL so it survives page refresh
-    const params = new URLSearchParams();
-    if (query)                              params.set('q', query);
-    if (cat)                               params.set('cat', cat);
-    if (comp && comp !== 'all')            params.set('comp', comp);
-    if (sort && sort !== 'alpha')          params.set('sort', sort);
-    if (selectedLanguages.size)            params.set('lang', [...selectedLanguages].join(','));
-    if (activeChip)                        params.set('chip', activeChip);
-    history.replaceState(null, '', params.toString() ? '?' + params.toString() : location.pathname);
-  }
-
-  function applySecondarySort(a, b, sortType) {
-    if(sortType==='years-desc') return b.years - a.years;
-    if(sortType==='years-asc') return a.years - b.years;
-    if(sortType==='comp-low') return ['chill','moderate','hot'].indexOf(a.competition) - ['chill','moderate','hot'].indexOf(b.competition);
-    if(sortType==='stars') return (b._gh?.stars||0) - (a._gh?.stars||0);
-    if(sortType==='gfi') return (b._gh?.gfi||0) - (a._gh?.gfi||0);
-    return a.name.localeCompare(b.name);
-  }
-
-  window.clearAllFilters = function() {
-    document.getElementById('searchInput').value = '';
-    document.getElementById('categoryFilter').value = 'all';
-    document.getElementById('complexityFilter').value = 'all';
-    if (document.getElementById('sortSelect')) document.getElementById('sortSelect').value = 'alpha';
-    const heroSearch = document.getElementById('hero-search');
-    if (heroSearch) heroSearch.value = '';
-  
-    // Reset chips
-    document.querySelectorAll('.filter-chip').forEach(chip => {
-      chip.classList.remove('bg-orange-600', 'text-white');
-      chip.classList.add('bg-surface-container-highest');
-    });
-
-    filteredOrgs = [...ORGS];
-    renderOrgs(true);
-  };
-
-  document.getElementById('searchInput').addEventListener('input', () => {
-    // Track search badge when user types a search query
-    const query = document.getElementById('searchInput').value.trim();
-    if (typeof BadgeSystem !== 'undefined' && query.length > 0) {
-      BadgeSystem.trackSearch();
-    }
-    applyFilters();
-  });
-  document.getElementById('categoryFilter').addEventListener('change', () => {
-    // Track filter badge when user changes category
-    if (typeof BadgeSystem !== 'undefined') {
-      BadgeSystem.trackFilter();
-    }
-    applyFilters();
-  });
-  document.getElementById('complexityFilter').addEventListener('change', () => {
-    // Track filter badge when user changes complexity
-    if (typeof BadgeSystem !== 'undefined') {
-      BadgeSystem.trackFilter();
-    }
-    applyFilters();
-  });
-  document.getElementById('sortSelect')?.addEventListener('change', applyFilters);
-  document.getElementById('mentorSearchInput')?.addEventListener('input', renderMentorFinder);
-  document.getElementById('mentorChannelFilter')?.addEventListener('change', renderMentorFinder);
-  document.getElementById('matchAllLanguagesToggle')?.addEventListener('change', (e) => {
-    matchAllLanguages = e.target.checked;
-    // keep global in sync for any external code expecting `matchAllLanguages`
-    globalThis.matchAllLanguages = matchAllLanguages;
-    applyFilters();
-    updateLanguageModeHint();
-  });
-  document.getElementById('loadMoreBtn').addEventListener('click', () => {
-    visibleCount += 12;
-    renderOrgs(false);
-  });
-
-  document.getElementById('loadMoreMentorBtn')?.addEventListener('click', () => {
-    visibleMentorCount += 12;
-    renderMentorFinder(false);
-  });
-
-  // Surprise button event listener
-  document.getElementById('surpriseBtn')?.addEventListener('click', openRandomOrg);
-
-  // Hero Search Link
-  const heroSearch = document.getElementById('hero-search');
-  if (heroSearch) {
-    heroSearch.value = document.getElementById('searchInput')?.value || new URLSearchParams(location.search).get('q') || '';
-    heroSearch.addEventListener('input', (e) => {
-      document.getElementById('searchInput').value = e.target.value;
-      document.getElementById('orgs').scrollIntoView({ behavior: 'smooth' });
-      
-      // Track search badge when user types in hero search
-      const query = e.target.value.trim();
-      if (typeof BadgeSystem !== 'undefined' && query.length > 0) {
-        BadgeSystem.trackSearch();
-      }
-      applyFilters();
-    });
-  }
-
-  // Quick-filter chips — mutually exclusive with each other, but additive with
-  // language pills, search, and dropdown filters. applyFilters() reads activeChip.
-  document.querySelectorAll('.filter-chip').forEach(chip => {
-    chip.addEventListener('click', () => {
-      const text = chip.textContent.trim().toLowerCase();
-      const isCurrentlyActive = chip.classList.contains('bg-orange-600');
-
-      // Reset all chips to inactive state
-      document.querySelectorAll('.filter-chip').forEach(c => {
-        c.classList.remove('bg-orange-600', 'text-white');
-        c.classList.add('bg-surface-container-highest');
-      });
-
-      if (!isCurrentlyActive) {
-        // Activate the clicked chip
-        chip.classList.add('bg-orange-600', 'text-white');
-        chip.classList.remove('bg-surface-container-highest');
-
-        // Map chip text → activeChip key used by applyFilters()
-        if (text.includes('bookmarked'))         activeChip = 'bookmarked';
-        else if (text.includes('veteran'))       activeChip = 'veterans';
-        else if (text.includes('newcomer'))      activeChip = 'newcomers';
-        else if (text.includes('low competition'))  activeChip = 'low-competition';
-        else if (text.includes('high competition')) activeChip = 'high-competition';
-        else if (text.includes('actively'))      activeChip = 'active';
-        else                                     activeChip = null;
-      } else {
-        // Chip was active — clicking again deactivates it
-        activeChip = null;
+        document.getElementById("orgModal").classList.add("open");
+        document.body.classList.add("modal-open");
+        document.documentElement.style.overflow = "hidden";
+        document.body.style.overflow = "hidden";
       }
 
-      applyFilters();
-    });
-  });
+      function closeOrgModal() {
+        document.getElementById("orgModal").classList.remove("open");
+        document.body.classList.remove("modal-open");
+        document.documentElement.style.overflow = "";
+        document.body.style.overflow = "";
+      }
 
-  function buildGfiSearchUrl(github) {
-    const query = github.includes('/')
-      ? `repo:${github} is:issue is:open label:\"good first issue\"`
-      : `user:${github} is:issue is:open label:\"good first issue\"`;
-    return `https://github.com/issues?q=${encodeURIComponent(query)}`;
-  }
+      function openRandomOrg() {
+        const orgsToUse = filteredOrgs.length > 0 ? filteredOrgs : ORGS;
 
-  function renderFallbackOrgSearchCards(container) {
-    const orgsWithGithub = ORGS.filter(o => typeof o.github === 'string' && o.github.trim());
-    container.innerHTML = '';
+        if (!orgsToUse.length) {
+          alert("No organizations match your filters — try clearing some!");
+          return;
+        }
 
-    const notice = document.createElement('p');
-    notice.className = 'col-span-full text-sm text-zinc-500';
-    notice.textContent = 'Live pre-fetched issues are still syncing. Browse open Good First Issues for all organizations below.';
-    container.appendChild(notice);
+        const randomIdx = Math.floor(Math.random() * orgsToUse.length);
+        const randomOrg = orgsToUse[randomIdx];
 
-    orgsWithGithub.forEach(org => {
-      const card = document.createElement('a');
-      card.href = buildGfiSearchUrl(org.github.trim());
-      card.target = '_blank';
-      card.rel = 'noopener noreferrer';
-      card.className = 'bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer block';
-      card.innerHTML = `
+        openModal(randomOrg.name);
+      }
+
+      // Filters — all conditions are additive (chip + language pills + search + dropdowns compose)
+      function applyFilters() {
+        const query = document
+          .getElementById("searchInput")
+          .value.trim()
+          .toLowerCase();
+        const categoryValue =
+          document.getElementById("categoryFilter")?.value || "all";
+        const cat = categoryValue === "all" ? "" : categoryValue;
+        const comp = document.getElementById("complexityFilter").value;
+        const sort = document.getElementById("sortSelect")?.value || "alpha";
+
+        filteredOrgs = ORGS.filter((o) => {
+          const matchSearch = o.name.toLowerCase().includes(query);
+          const matchCat = !cat || o.cat === cat;
+          const matchComp = comp === "all" || o.codebase === comp;
+          const tags = (o.tags || []).map((t) => String(t).toLowerCase());
+          const matchLang =
+            selectedLanguages.size === 0 ||
+            (matchAllLanguages
+              ? [...selectedLanguages].every((lang) =>
+                  languageMatchesSelection(tags, lang),
+                )
+              : [...selectedLanguages].some((lang) =>
+                  languageMatchesSelection(tags, lang),
+                ));
+
+          let matchChip = true;
+          if (activeChip === "bookmarked")
+            matchChip = bookmarkedSet.has(o.name);
+          else if (activeChip === "veterans") matchChip = o.years >= 10;
+          else if (activeChip === "newcomers") matchChip = o.years <= 3;
+          else if (activeChip === "low-competition")
+            matchChip = o.competition === "chill";
+          else if (activeChip === "high-competition")
+            matchChip = o.competition === "hot";
+
+          return matchSearch && matchCat && matchComp && matchLang && matchChip;
+        });
+
+        if (query) {
+          filteredOrgs.sort((a, b) => {
+            const nameA = a.name.toLowerCase();
+            const nameB = b.name.toLowerCase();
+            if (nameA === query && nameB !== query) return -1;
+            if (nameB === query && nameA !== query) return 1;
+            if (nameA.startsWith(query) && !nameB.startsWith(query)) return -1;
+            if (nameB.startsWith(query) && !nameA.startsWith(query)) return 1;
+            return applySecondarySort(a, b, sort);
+          });
+        } else {
+          filteredOrgs.sort((a, b) => applySecondarySort(a, b, sort));
+        }
+
+        renderOrgs(true);
+
+        // Persist filter state to URL so it survives page refresh
+        const params = new URLSearchParams();
+        if (query) params.set("q", query);
+        if (cat) params.set("cat", cat);
+        if (comp && comp !== "all") params.set("comp", comp);
+        if (sort && sort !== "alpha") params.set("sort", sort);
+        if (selectedLanguages.size)
+          params.set("lang", [...selectedLanguages].join(","));
+        if (activeChip) params.set("chip", activeChip);
+        history.replaceState(
+          null,
+          "",
+          params.toString() ? "?" + params.toString() : location.pathname,
+        );
+      }
+
+      function applySecondarySort(a, b, sortType) {
+        if (sortType === "years-desc") return b.years - a.years;
+        if (sortType === "years-asc") return a.years - b.years;
+        if (sortType === "comp-low")
+          return (
+            ["chill", "moderate", "hot"].indexOf(a.competition) -
+            ["chill", "moderate", "hot"].indexOf(b.competition)
+          );
+        if (sortType === "stars")
+          return (b._gh?.stars || 0) - (a._gh?.stars || 0);
+        if (sortType === "gfi") return (b._gh?.gfi || 0) - (a._gh?.gfi || 0);
+        return a.name.localeCompare(b.name);
+      }
+
+      window.clearAllFilters = function () {
+        document.getElementById("searchInput").value = "";
+        document.getElementById("categoryFilter").value = "all";
+        document.getElementById("complexityFilter").value = "all";
+        if (document.getElementById("sortSelect"))
+          document.getElementById("sortSelect").value = "alpha";
+        const heroSearch = document.getElementById("hero-search");
+        if (heroSearch) heroSearch.value = "";
+
+        // Reset chips
+        document.querySelectorAll(".filter-chip").forEach((chip) => {
+          chip.classList.remove("bg-orange-600", "text-white");
+          chip.classList.add("bg-surface-container-highest");
+        });
+
+        filteredOrgs = [...ORGS];
+        renderOrgs(true);
+      };
+
+      document.getElementById("searchInput").addEventListener("input", () => {
+        // Track search badge when user types a search query
+        const query = document.getElementById("searchInput").value.trim();
+        if (typeof BadgeSystem !== "undefined" && query.length > 0) {
+          BadgeSystem.trackSearch();
+        }
+        applyFilters();
+      });
+      document
+        .getElementById("categoryFilter")
+        .addEventListener("change", () => {
+          // Track filter badge when user changes category
+          if (typeof BadgeSystem !== "undefined") {
+            BadgeSystem.trackFilter();
+          }
+          applyFilters();
+        });
+      document
+        .getElementById("complexityFilter")
+        .addEventListener("change", () => {
+          // Track filter badge when user changes complexity
+          if (typeof BadgeSystem !== "undefined") {
+            BadgeSystem.trackFilter();
+          }
+          applyFilters();
+        });
+      document
+        .getElementById("sortSelect")
+        ?.addEventListener("change", applyFilters);
+      document
+        .getElementById("mentorSearchInput")
+        ?.addEventListener("input", renderMentorFinder);
+      document
+        .getElementById("mentorChannelFilter")
+        ?.addEventListener("change", renderMentorFinder);
+      document
+        .getElementById("matchAllLanguagesToggle")
+        ?.addEventListener("change", (e) => {
+          matchAllLanguages = e.target.checked;
+          // keep global in sync for any external code expecting `matchAllLanguages`
+          globalThis.matchAllLanguages = matchAllLanguages;
+          applyFilters();
+          updateLanguageModeHint();
+        });
+      document.getElementById("loadMoreBtn").addEventListener("click", () => {
+        visibleCount += 12;
+        renderOrgs(false);
+      });
+
+      document
+        .getElementById("loadMoreMentorBtn")
+        ?.addEventListener("click", () => {
+          visibleMentorCount += 12;
+          renderMentorFinder(false);
+        });
+
+      // Surprise button event listener
+      document
+        .getElementById("surpriseBtn")
+        ?.addEventListener("click", openRandomOrg);
+
+      // Hero Search Link
+      const heroSearch = document.getElementById("hero-search");
+      if (heroSearch) {
+        heroSearch.value =
+          document.getElementById("searchInput")?.value ||
+          new URLSearchParams(location.search).get("q") ||
+          "";
+        heroSearch.addEventListener("input", (e) => {
+          document.getElementById("searchInput").value = e.target.value;
+          document
+            .getElementById("orgs")
+            .scrollIntoView({ behavior: "smooth" });
+
+          // Track search badge when user types in hero search
+          const query = e.target.value.trim();
+          if (typeof BadgeSystem !== "undefined" && query.length > 0) {
+            BadgeSystem.trackSearch();
+          }
+          applyFilters();
+        });
+      }
+
+      // Quick-filter chips — mutually exclusive with each other, but additive with
+      // language pills, search, and dropdown filters. applyFilters() reads activeChip.
+      document.querySelectorAll(".filter-chip").forEach((chip) => {
+        chip.addEventListener("click", () => {
+          const text = chip.textContent.trim().toLowerCase();
+          const isCurrentlyActive = chip.classList.contains("bg-orange-600");
+
+          // Reset all chips to inactive state
+          document.querySelectorAll(".filter-chip").forEach((c) => {
+            c.classList.remove("bg-orange-600", "text-white");
+            c.classList.add("bg-surface-container-highest");
+          });
+
+          if (!isCurrentlyActive) {
+            // Activate the clicked chip
+            chip.classList.add("bg-orange-600", "text-white");
+            chip.classList.remove("bg-surface-container-highest");
+
+            // Map chip text → activeChip key used by applyFilters()
+            if (text.includes("bookmarked")) activeChip = "bookmarked";
+            else if (text.includes("veteran")) activeChip = "veterans";
+            else if (text.includes("newcomer")) activeChip = "newcomers";
+            else if (text.includes("low competition"))
+              activeChip = "low-competition";
+            else if (text.includes("high competition"))
+              activeChip = "high-competition";
+            else if (text.includes("actively")) activeChip = "active";
+            else activeChip = null;
+          } else {
+            // Chip was active — clicking again deactivates it
+            activeChip = null;
+          }
+
+          applyFilters();
+        });
+      });
+
+      function buildGfiSearchUrl(github) {
+        const query = github.includes("/")
+          ? `repo:${github} is:issue is:open label:\"good first issue\"`
+          : `user:${github} is:issue is:open label:\"good first issue\"`;
+        return `https://github.com/issues?q=${encodeURIComponent(query)}`;
+      }
+
+      function renderFallbackOrgSearchCards(container) {
+        const orgsWithGithub = ORGS.filter(
+          (o) => typeof o.github === "string" && o.github.trim(),
+        );
+        container.innerHTML = "";
+
+        const notice = document.createElement("p");
+        notice.className = "col-span-full text-sm text-zinc-500";
+        notice.textContent =
+          "Live pre-fetched issues are still syncing. Browse open Good First Issues for all organizations below.";
+        container.appendChild(notice);
+
+        orgsWithGithub.forEach((org) => {
+          const card = document.createElement("a");
+          card.href = buildGfiSearchUrl(org.github.trim());
+          card.target = "_blank";
+          card.rel = "noopener noreferrer";
+          card.className =
+            "bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer block";
+          card.innerHTML = `
         <div class="flex items-start justify-between mb-3">
           <h4 class="font-bold text-sm group-hover:text-primary transition-colors line-clamp-1">Browse open Good First Issues</h4>
           <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
@@ -3651,45 +6003,60 @@ if(org.ideas){
           <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">Label: good first issue</span>
         </div>
       `;
-      container.appendChild(card);
-    });
-  }
-
-  // Dynamic GFIs
-  async function renderGoodFirstIssues() {
-    try {
-      const res = await fetch('/data/issues.json?v=' + Date.now());
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      const container = document.querySelector('#issues .grid');
-      if (!container) return;
-      const issues = Array.isArray(data.issues) ? data.issues : [];
-      const lastUpdatedEl = document.getElementById('issuesLastUpdated');
-      if (lastUpdatedEl) {
-        if (data.updated_at) {
-          const mins = Math.max(1, Math.floor((Date.now() - new Date(data.updated_at).getTime()) / 60000));
-          const relative = mins < 60 ? `${mins} min ago` : `${Math.floor(mins / 60)} hours ago`;
-          lastUpdatedEl.textContent = `Last updated: ${relative}`;
-        } else {
-          lastUpdatedEl.textContent = 'Last updated: unavailable';
-        }
+          container.appendChild(card);
+        });
       }
 
-      if (!issues.length) {
-        renderFallbackOrgSearchCards(container);
-        return;
-      }
+      // Dynamic GFIs
+      async function renderGoodFirstIssues() {
+        try {
+          const res = await fetch("/data/issues.json?v=" + Date.now());
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const data = await res.json();
+          const container = document.querySelector("#issues .grid");
+          if (!container) return;
+          const issues = Array.isArray(data.issues) ? data.issues : [];
+          const lastUpdatedEl = document.getElementById("issuesLastUpdated");
+          if (lastUpdatedEl) {
+            if (data.updated_at) {
+              const mins = Math.max(
+                1,
+                Math.floor(
+                  (Date.now() - new Date(data.updated_at).getTime()) / 60000,
+                ),
+              );
+              const relative =
+                mins < 60
+                  ? `${mins} min ago`
+                  : `${Math.floor(mins / 60)} hours ago`;
+              lastUpdatedEl.textContent = `Last updated: ${relative}`;
+            } else {
+              lastUpdatedEl.textContent = "Last updated: unavailable";
+            }
+          }
 
-      container.innerHTML = '';
-      issues.slice(0, 6).forEach(issue => {
-        const card = document.createElement('div');
-        card.className = 'bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer';
-        const safeUrl = sanitizeHrefUrl(issue.url);
-        if (safeUrl) card.onclick = () => window.open(safeUrl, '_blank');
-        const safeRepo = escapeHtml(issue.repo || '');
-        const safeTitle = escapeHtml(issue.title || '');
-        const labelsHtml = (issue.labels || []).slice(0,2).map(l => `<span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">${escapeHtml(l)}</span>`).join('');
-        card.innerHTML = `
+          if (!issues.length) {
+            renderFallbackOrgSearchCards(container);
+            return;
+          }
+
+          container.innerHTML = "";
+          issues.slice(0, 6).forEach((issue) => {
+            const card = document.createElement("div");
+            card.className =
+              "bg-white rounded-xl p-5 border border-zinc-100 hover:shadow-lg transition-all group cursor-pointer";
+            const safeUrl = sanitizeHrefUrl(issue.url);
+            if (safeUrl) card.onclick = () => window.open(safeUrl, "_blank");
+            const safeRepo = escapeHtml(issue.repo || "");
+            const safeTitle = escapeHtml(issue.title || "");
+            const labelsHtml = (issue.labels || [])
+              .slice(0, 2)
+              .map(
+                (l) =>
+                  `<span class="text-[10px] px-2 py-0.5 bg-green-100 text-green-700 rounded font-bold">${escapeHtml(l)}</span>`,
+              )
+              .join("");
+            card.innerHTML = `
           <div class="flex items-start justify-between mb-3">
             <h4 class="font-bold text-sm group-hover:text-primary transition-colors line-clamp-1">${safeTitle}</h4>
             <span class="material-symbols-outlined text-zinc-300 group-hover:text-primary text-lg">open_in_new</span>
@@ -3700,72 +6067,76 @@ if(org.ideas){
             <span class="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 rounded">${escapeHtml(String(issue.comments || 0))} comments</span>
           </div>
         `;
-        container.appendChild(card);
-      });
-    } catch (e) {
-      console.error("GFI render failed:", e);
-      const container = document.querySelector('#issues .grid');
-      if (container) {
-        container.innerHTML = `
+            container.appendChild(card);
+          });
+        } catch (e) {
+          console.error("GFI render failed:", e);
+          const container = document.querySelector("#issues .grid");
+          if (container) {
+            container.innerHTML = `
           <div class="col-span-full bg-white rounded-xl p-8 border border-zinc-100 text-center">
             <p class="text-sm font-bold text-zinc-900 mb-2">Unable to load pre-fetched issues</p>
             <p class="text-sm text-zinc-600 max-w-xl mx-auto">Cached issue data could not be retrieved at this time. Please refresh the page or try again later.</p>
           </div>`;
+          }
+          const lastUpdatedEl = document.getElementById("issuesLastUpdated");
+          if (lastUpdatedEl) {
+            lastUpdatedEl.textContent = "Last updated: unavailable";
+          }
+        }
       }
-      const lastUpdatedEl = document.getElementById('issuesLastUpdated');
-      if (lastUpdatedEl) {
-        lastUpdatedEl.textContent = 'Last updated: unavailable';
+
+      // Live GitHub Stats Mock/Fetch
+      async function fetchStats() {
+        const btn = document.getElementById("mFetchBtn");
+        const orgName = document.querySelector("#mHeader h2").textContent;
+        const org = ORGS.find((o) => o.name === orgName);
+        if (!org) return;
+
+        btn.textContent = "Fetching...";
+        btn.disabled = true;
+
+        try {
+          // Simulate real fetch delay
+          await new Promise((r) => setTimeout(r, 1200));
+
+          // Since no token, we simulate random but realistic growth
+          const stars = (Math.random() * 5000 + 1000).toFixed(0);
+          const forks = (stars * 0.2).toFixed(0);
+          const issues = (Math.random() * 50 + 10).toFixed(0);
+
+          document.getElementById("mStars").textContent =
+            `${(stars / 1000).toFixed(1)}k`;
+          document.getElementById("mForks").textContent = forks;
+          document.getElementById("mIssues").textContent = issues;
+          document.getElementById("mActivity").textContent = "High";
+          document.getElementById("mActivity").className =
+            "gh-stat-item text-green-400";
+
+          btn.textContent = "Stats Updated!";
+        } catch (e) {
+          btn.textContent = "Error";
+        } finally {
+          setTimeout(() => {
+            btn.textContent = "Fetch Live Stats";
+            btn.disabled = false;
+          }, 3000);
+        }
       }
-    }
-  }
 
-  // Live GitHub Stats Mock/Fetch
-  async function fetchStats() {
-    const btn = document.getElementById('mFetchBtn');
-    const orgName = document.querySelector('#mHeader h2').textContent;
-    const org = ORGS.find(o => o.name === orgName);
-    if (!org) return;
+      document
+        .getElementById("mFetchBtn")
+        .addEventListener("click", fetchStats);
 
-    btn.textContent = 'Fetching...';
-    btn.disabled = true;
+      // Proposal
+      let currentProposalOrg = "";
+      let proposalFocusReturn = null;
+      let proposalAutosaveTimer = null;
+      const inMemoryDrafts = {};
+      let localStorageAvailable = true;
+      const PROPOSAL_AUTOSAVE_KEY = "gaf_proposal_autosave";
 
-    try {
-      // Simulate real fetch delay
-      await new Promise(r => setTimeout(r, 1200));
-      
-      // Since no token, we simulate random but realistic growth
-      const stars = (Math.random() * 5000 + 1000).toFixed(0);
-      const forks = (stars * 0.2).toFixed(0);
-      const issues = (Math.random() * 50 + 10).toFixed(0);
-      
-      document.getElementById('mStars').textContent = `${(stars/1000).toFixed(1)}k`;
-      document.getElementById('mForks').textContent = forks;
-      document.getElementById('mIssues').textContent = issues;
-      document.getElementById('mActivity').textContent = 'High';
-      document.getElementById('mActivity').className = 'gh-stat-item text-green-400';
-      
-      btn.textContent = 'Stats Updated!';
-    } catch (e) {
-      btn.textContent = 'Error';
-    } finally {
-      setTimeout(() => {
-        btn.textContent = 'Fetch Live Stats';
-        btn.disabled = false;
-      }, 3000);
-    }
-  }
-
-  document.getElementById('mFetchBtn').addEventListener('click', fetchStats);
-
-  // Proposal
-  let currentProposalOrg = '';
-  let proposalFocusReturn = null;
-  let proposalAutosaveTimer = null;
-  const inMemoryDrafts = {};
-  let localStorageAvailable = true;
-  const PROPOSAL_AUTOSAVE_KEY = 'gaf_proposal_autosave';
-
-  const GSOC_TEMPLATE = `# GSoC 2026 Proposal: [Project Title]
+      const GSOC_TEMPLATE = `# GSoC 2026 Proposal: [Project Title]
 **Organization:** [Organization Name]
 **Applicant:** [Your Name]
 
@@ -3796,518 +6167,554 @@ if(org.ideas){
 [Your background, relevant skills, and past contributions to open source.]
 `;
 
-  function proposalStorageKey(orgName) {
-    return 'gaf_proposal_' + orgName;
-  }
-
-  function isAutosaveEnabled() {
-    if (!localStorageAvailable) return false;
-    try {
-      return localStorage.getItem(PROPOSAL_AUTOSAVE_KEY) === 'true';
-    } catch {
-      localStorageAvailable = false;
-      return false;
-    }
-  }
-
-  function syncAutosaveToggle() {
-    const toggle = document.getElementById('pwAutosaveToggle');
-    if (toggle) toggle.checked = isAutosaveEnabled();
-  }
-
-  function setAutosaveEnabled(enabled) {
-    if (localStorageAvailable) {
-      try {
-        localStorage.setItem(PROPOSAL_AUTOSAVE_KEY, enabled ? 'true' : 'false');
-      } catch {
-        localStorageAvailable = false;
+      function proposalStorageKey(orgName) {
+        return "gaf_proposal_" + orgName;
       }
-    }
-    syncAutosaveToggle();
-  }
 
-  function getDraft(orgName) {
-    if (Object.hasOwn(inMemoryDrafts, orgName)) {
-      return inMemoryDrafts[orgName];
-    }
-    if (!localStorageAvailable) return null;
-    try {
-      const stored = localStorage.getItem(proposalStorageKey(orgName));
-      if (stored !== null) {
-        inMemoryDrafts[orgName] = stored;
-        return stored;
-      }
-    } catch {
-      localStorageAvailable = false;
-    }
-    return null;
-  }
-
-  function saveDraft(orgName, content) {
-    inMemoryDrafts[orgName] = content;
-    if (!localStorageAvailable) return;
-    try {
-      localStorage.setItem(proposalStorageKey(orgName), content);
-    } catch {
-      localStorageAvailable = false;
-    }
-  }
-
-  function clearDraft(orgName) {
-    delete inMemoryDrafts[orgName];
-    if (!localStorageAvailable) return;
-    try {
-      localStorage.removeItem(proposalStorageKey(orgName));
-    } catch {
-      localStorageAvailable = false;
-    }
-  }
-
-  function getTemplateForOrg(orgName) {
-    return GSOC_TEMPLATE.replaceAll('[Organization Name]', orgName);
-  }
-
-  function renderPreview() {
-    const editor = document.getElementById('pwEditor');
-    const preview = document.getElementById('pwPreview');
-    if (!editor || !preview) return;
-    if (typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined') {
-      preview.innerHTML = DOMPurify.sanitize(marked.parse(editor.value));
-    } else {
-      preview.innerHTML = '<p class="proposal-preview-error">Markdown preview unavailable. Check your connection and reload the page.</p>';
-    }
-  }
-
-  function openProposalBuilder(orgName) {
-    currentProposalOrg = orgName;
-    const modal = document.getElementById('proposalModal');
-    const orgModal = document.getElementById('orgModal');
-    const editor = document.getElementById('pwEditor');
-    if (!modal || !editor) return;
-
-    document.getElementById('pwOrgName').textContent = orgName + ' Proposal';
-    syncAutosaveToggle();
-
-    const saved = getDraft(orgName);
-    if (saved === null) {
-      editor.value = getTemplateForOrg(orgName);
-    } else {
-      editor.value = saved;
-    }
-    renderPreview();
-
-    proposalFocusReturn = document.getElementById('mDraftBtn');
-    if (orgModal) orgModal.setAttribute('aria-hidden', 'true');
-
-    modal.classList.add('open');
-    modal.setAttribute('open', '');
-    document.body.classList.add('modal-open');
-    document.documentElement.style.overflow = 'hidden';
-    document.body.style.overflow = 'hidden';
-
-    const closeBtn = document.getElementById('pwCloseBtn');
-    if (closeBtn) closeBtn.focus();
-  }
-
-  function closeProposalBuilder() {
-    const modal = document.getElementById('proposalModal');
-    const orgModal = document.getElementById('orgModal');
-    if (!modal) return;
-
-    modal.classList.remove('open');
-    modal.removeAttribute('open');
-    if (orgModal) orgModal.removeAttribute('aria-hidden');
-
-    if (!orgModal?.classList.contains('open')) {
-      document.body.classList.remove('modal-open');
-      document.documentElement.style.overflow = '';
-      document.body.style.overflow = '';
-    }
-
-    if (proposalFocusReturn) {
-      proposalFocusReturn.focus();
-      proposalFocusReturn = null;
-    }
-  }
-
-  function clearProposalDraft() {
-    if (!currentProposalOrg) return;
-    if (!confirm('Clear this proposal draft? This removes the saved copy from this device.')) return;
-    clearDraft(currentProposalOrg);
-    const editor = document.getElementById('pwEditor');
-    if (editor) {
-      editor.value = getTemplateForOrg(currentProposalOrg);
-      renderPreview();
-    }
-  }
-
-  function exportProposalMD() {
-    if (!currentProposalOrg) return;
-    const content = document.getElementById('pwEditor')?.value || '';
-    const blob = new Blob([content], { type: 'text/markdown' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'GSoC_Proposal_' + currentProposalOrg.replace(/\s+/g, '_') + '.md';
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-  }
-
-  function exportProposalPDF() {
-    if (!currentProposalOrg) return;
-    if (typeof html2pdf !== 'function') {
-      alert('PDF export is unavailable. Check your connection and reload the page.');
-      return;
-    }
-    const element = document.getElementById('pwPreview');
-    if (!element) return;
-
-    const printElement = element.cloneNode(true);
-    printElement.style.padding = '40px';
-    printElement.style.background = 'white';
-    printElement.style.color = 'black';
-    printElement.style.width = '800px';
-    printElement.querySelectorAll('code, pre').forEach((node) => {
-      node.style.background = '#f4f4f4';
-      node.style.color = '#333';
-    });
-    document.body.appendChild(printElement);
-
-    const opt = {
-      margin: 15,
-      filename: 'GSoC_Proposal_' + currentProposalOrg.replace(/\s+/g, '_') + '.pdf',
-      image: { type: 'jpeg', quality: 0.98 },
-      html2canvas: { scale: 2, useCORS: true },
-      jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
-    };
-
-    html2pdf()
-      .set(opt)
-      .from(printElement)
-      .save()
-      .then(() => printElement.remove())
-      .catch((err) => {
-        console.error('PDF export failed:', err);
-        printElement.remove();
-        alert('PDF export failed. Try exporting Markdown instead.');
-      });
-  }
-
-  document.getElementById('pwEditor')?.addEventListener('input', (e) => {
-    renderPreview();
-    if (!currentProposalOrg || !isAutosaveEnabled()) return;
-    clearTimeout(proposalAutosaveTimer);
-    proposalAutosaveTimer = setTimeout(() => {
-      saveDraft(currentProposalOrg, e.target.value);
-    }, 300);
-  });
-
-  document.getElementById('pwAutosaveToggle')?.addEventListener('change', (e) => {
-    setAutosaveEnabled(e.target.checked);
-    if (e.target.checked && currentProposalOrg) {
-      const editor = document.getElementById('pwEditor');
-      if (editor) saveDraft(currentProposalOrg, editor.value);
-    }
-  });
-
-  document.getElementById('proposalModal')?.addEventListener('keydown', (e) => {
-    if (e.key !== 'Tab' || !document.getElementById('proposalModal')?.classList.contains('open')) return;
-    const modal = document.getElementById('proposalModal');
-    const focusable = modal.querySelectorAll(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    );
-    const list = [...focusable].filter((el) => !el.disabled && el.offsetParent !== null);
-    if (list.length === 0) return;
-    const first = list[0];
-    const last = list[list.length - 1];
-    if (e.shiftKey && document.activeElement === first) {
-      e.preventDefault();
-      last.focus();
-    } else if (!e.shiftKey && document.activeElement === last) {
-      e.preventDefault();
-      first.focus();
-    }
-  });
-
-  document.getElementById('pwClearBtn')?.addEventListener('click', clearProposalDraft);
-  document.getElementById('pwExportMDBtn')?.addEventListener('click', exportProposalMD);
-  document.getElementById('pwExportPDFBtn')?.addEventListener('click', exportProposalPDF);
-  document.getElementById('pwCloseBtn')?.addEventListener('click', closeProposalBuilder);
-
-  globalThis.ProposalBuilder = {
-    open: openProposalBuilder,
-    close: closeProposalBuilder
-  };
-
-  // Initialize
-  updateLanguageModeHint();
-  renderTimeline();        // populate #timeline-milestones on first load
-  applyStaleDataNotice(); // show post-selection message if GSoC selection is complete
-  updateCountdown();
-  setInterval(updateCountdown, 60000);
-  renderSelectedLanguages();
-
-  // Restore filter state from URL params on page load/refresh
-  (function restoreFiltersFromURL() {
-    const params = new URLSearchParams(location.search);
-
-    function setElValue(id, value) {
-      const el = document.getElementById(id);
-      if (el && value) el.value = value;
-    }
-
-    function getChipKey(text) {
-      if (text.includes('bookmarked'))            return 'bookmarked';
-      if (text.includes('veteran'))               return 'veterans';
-      if (text.includes('newcomer'))              return 'newcomers';
-      if (text.includes('low competition'))       return 'low-competition';
-      if (text.includes('high competition'))      return 'high-competition';
-      if (text.includes('actively'))              return 'active';
-      return null;
-    }
-
-    setElValue('searchInput', params.get('q'));
-    setElValue('hero-search', params.get('q'));
-    setElValue('categoryFilter', params.get('cat'));
-    setElValue('complexityFilter', params.get('comp'));
-    setElValue('sortSelect', params.get('sort'));
-
-    const lang = params.get('lang');
-    if (lang) {
-      lang.split(',').map(s => s.trim()).filter(Boolean).forEach(l => {
-        selectedLanguages.add(l);
-        const pillBtn = document.querySelector(`.pill[data-lang="${l}"]`);
-        if (pillBtn) {
-          pillBtn.classList.add('active');
-          pillBtn.setAttribute('aria-pressed', 'true');
+      function isAutosaveEnabled() {
+        if (!localStorageAvailable) return false;
+        try {
+          return localStorage.getItem(PROPOSAL_AUTOSAVE_KEY) === "true";
+        } catch {
+          localStorageAvailable = false;
+          return false;
         }
+      }
+
+      function syncAutosaveToggle() {
+        const toggle = document.getElementById("pwAutosaveToggle");
+        if (toggle) toggle.checked = isAutosaveEnabled();
+      }
+
+      function setAutosaveEnabled(enabled) {
+        if (localStorageAvailable) {
+          try {
+            localStorage.setItem(
+              PROPOSAL_AUTOSAVE_KEY,
+              enabled ? "true" : "false",
+            );
+          } catch {
+            localStorageAvailable = false;
+          }
+        }
+        syncAutosaveToggle();
+      }
+
+      function getDraft(orgName) {
+        if (Object.hasOwn(inMemoryDrafts, orgName)) {
+          return inMemoryDrafts[orgName];
+        }
+        if (!localStorageAvailable) return null;
+        try {
+          const stored = localStorage.getItem(proposalStorageKey(orgName));
+          if (stored !== null) {
+            inMemoryDrafts[orgName] = stored;
+            return stored;
+          }
+        } catch {
+          localStorageAvailable = false;
+        }
+        return null;
+      }
+
+      function saveDraft(orgName, content) {
+        inMemoryDrafts[orgName] = content;
+        if (!localStorageAvailable) return;
+        try {
+          localStorage.setItem(proposalStorageKey(orgName), content);
+        } catch {
+          localStorageAvailable = false;
+        }
+      }
+
+      function clearDraft(orgName) {
+        delete inMemoryDrafts[orgName];
+        if (!localStorageAvailable) return;
+        try {
+          localStorage.removeItem(proposalStorageKey(orgName));
+        } catch {
+          localStorageAvailable = false;
+        }
+      }
+
+      function getTemplateForOrg(orgName) {
+        return GSOC_TEMPLATE.replaceAll("[Organization Name]", orgName);
+      }
+
+      function renderPreview() {
+        const editor = document.getElementById("pwEditor");
+        const preview = document.getElementById("pwPreview");
+        if (!editor || !preview) return;
+        if (typeof marked !== "undefined" && typeof DOMPurify !== "undefined") {
+          preview.innerHTML = DOMPurify.sanitize(marked.parse(editor.value));
+        } else {
+          preview.innerHTML =
+            '<p class="proposal-preview-error">Markdown preview unavailable. Check your connection and reload the page.</p>';
+        }
+      }
+
+      function openProposalBuilder(orgName) {
+        currentProposalOrg = orgName;
+        const modal = document.getElementById("proposalModal");
+        const orgModal = document.getElementById("orgModal");
+        const editor = document.getElementById("pwEditor");
+        if (!modal || !editor) return;
+
+        document.getElementById("pwOrgName").textContent =
+          orgName + " Proposal";
+        syncAutosaveToggle();
+
+        const saved = getDraft(orgName);
+        if (saved === null) {
+          editor.value = getTemplateForOrg(orgName);
+        } else {
+          editor.value = saved;
+        }
+        renderPreview();
+
+        proposalFocusReturn = document.getElementById("mDraftBtn");
+        if (orgModal) orgModal.setAttribute("aria-hidden", "true");
+
+        modal.classList.add("open");
+        modal.setAttribute("open", "");
+        document.body.classList.add("modal-open");
+        document.documentElement.style.overflow = "hidden";
+        document.body.style.overflow = "hidden";
+
+        const closeBtn = document.getElementById("pwCloseBtn");
+        if (closeBtn) closeBtn.focus();
+      }
+
+      function closeProposalBuilder() {
+        const modal = document.getElementById("proposalModal");
+        const orgModal = document.getElementById("orgModal");
+        if (!modal) return;
+
+        modal.classList.remove("open");
+        modal.removeAttribute("open");
+        if (orgModal) orgModal.removeAttribute("aria-hidden");
+
+        if (!orgModal?.classList.contains("open")) {
+          document.body.classList.remove("modal-open");
+          document.documentElement.style.overflow = "";
+          document.body.style.overflow = "";
+        }
+
+        if (proposalFocusReturn) {
+          proposalFocusReturn.focus();
+          proposalFocusReturn = null;
+        }
+      }
+
+      function clearProposalDraft() {
+        if (!currentProposalOrg) return;
+        if (
+          !confirm(
+            "Clear this proposal draft? This removes the saved copy from this device.",
+          )
+        )
+          return;
+        clearDraft(currentProposalOrg);
+        const editor = document.getElementById("pwEditor");
+        if (editor) {
+          editor.value = getTemplateForOrg(currentProposalOrg);
+          renderPreview();
+        }
+      }
+
+      function exportProposalMD() {
+        if (!currentProposalOrg) return;
+        const content = document.getElementById("pwEditor")?.value || "";
+        const blob = new Blob([content], { type: "text/markdown" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download =
+          "GSoC_Proposal_" + currentProposalOrg.replace(/\s+/g, "_") + ".md";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+      }
+
+      function exportProposalPDF() {
+        if (!currentProposalOrg) return;
+        if (typeof html2pdf !== "function") {
+          alert(
+            "PDF export is unavailable. Check your connection and reload the page.",
+          );
+          return;
+        }
+        const element = document.getElementById("pwPreview");
+        if (!element) return;
+
+        const printElement = element.cloneNode(true);
+        printElement.style.padding = "40px";
+        printElement.style.background = "white";
+        printElement.style.color = "black";
+        printElement.style.width = "800px";
+        printElement.querySelectorAll("code, pre").forEach((node) => {
+          node.style.background = "#f4f4f4";
+          node.style.color = "#333";
+        });
+        document.body.appendChild(printElement);
+
+        const opt = {
+          margin: 15,
+          filename:
+            "GSoC_Proposal_" + currentProposalOrg.replace(/\s+/g, "_") + ".pdf",
+          image: { type: "jpeg", quality: 0.98 },
+          html2canvas: { scale: 2, useCORS: true },
+          jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
+        };
+
+        html2pdf()
+          .set(opt)
+          .from(printElement)
+          .save()
+          .then(() => printElement.remove())
+          .catch((err) => {
+            console.error("PDF export failed:", err);
+            printElement.remove();
+            alert("PDF export failed. Try exporting Markdown instead.");
+          });
+      }
+
+      document.getElementById("pwEditor")?.addEventListener("input", (e) => {
+        renderPreview();
+        if (!currentProposalOrg || !isAutosaveEnabled()) return;
+        clearTimeout(proposalAutosaveTimer);
+        proposalAutosaveTimer = setTimeout(() => {
+          saveDraft(currentProposalOrg, e.target.value);
+        }, 300);
       });
+
+      document
+        .getElementById("pwAutosaveToggle")
+        ?.addEventListener("change", (e) => {
+          setAutosaveEnabled(e.target.checked);
+          if (e.target.checked && currentProposalOrg) {
+            const editor = document.getElementById("pwEditor");
+            if (editor) saveDraft(currentProposalOrg, editor.value);
+          }
+        });
+
+      document
+        .getElementById("proposalModal")
+        ?.addEventListener("keydown", (e) => {
+          if (
+            e.key !== "Tab" ||
+            !document
+              .getElementById("proposalModal")
+              ?.classList.contains("open")
+          )
+            return;
+          const modal = document.getElementById("proposalModal");
+          const focusable = modal.querySelectorAll(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+          );
+          const list = [...focusable].filter(
+            (el) => !el.disabled && el.offsetParent !== null,
+          );
+          if (list.length === 0) return;
+          const first = list[0];
+          const last = list[list.length - 1];
+          if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        });
+
+      document
+        .getElementById("pwClearBtn")
+        ?.addEventListener("click", clearProposalDraft);
+      document
+        .getElementById("pwExportMDBtn")
+        ?.addEventListener("click", exportProposalMD);
+      document
+        .getElementById("pwExportPDFBtn")
+        ?.addEventListener("click", exportProposalPDF);
+      document
+        .getElementById("pwCloseBtn")
+        ?.addEventListener("click", closeProposalBuilder);
+
+      globalThis.ProposalBuilder = {
+        open: openProposalBuilder,
+        close: closeProposalBuilder,
+      };
+
+      // Initialize
+      updateLanguageModeHint();
+      renderTimeline(); // populate #timeline-milestones on first load
+      applyStaleDataNotice(); // show post-selection message if GSoC selection is complete
+      updateCountdown();
+      setInterval(updateCountdown, 60000);
       renderSelectedLanguages();
-    }
 
-    const chip = params.get('chip');
-    if (chip) {
-      activeChip = chip;
-      document.querySelectorAll('.filter-chip').forEach(el => {
-        const key = getChipKey(el.textContent.trim().toLowerCase());
-        if (key === chip) {
-          el.classList.add('bg-orange-600', 'text-white');
-          el.classList.remove('bg-surface-container-highest');
+      // Restore filter state from URL params on page load/refresh
+      (function restoreFiltersFromURL() {
+        const params = new URLSearchParams(location.search);
+
+        function setElValue(id, value) {
+          const el = document.getElementById(id);
+          if (el && value) el.value = value;
         }
-      });
-    }
 
-    applyFilters();
-  })();
-  renderOrgs();
-  renderWatchlist();
-  renderRecentlyViewed();
-  updateAIInsights();   // populate AI insight panel on page load
-  loadMentorData();
-  renderGoodFirstIssues();
-  renderCompare();
-  // Wire up Recently Viewed clear button
-  document.getElementById('clearRecentlyViewedBtn')?.addEventListener('click', clearRecentlyViewed);
+        function getChipKey(text) {
+          if (text.includes("bookmarked")) return "bookmarked";
+          if (text.includes("veteran")) return "veterans";
+          if (text.includes("newcomer")) return "newcomers";
+          if (text.includes("low competition")) return "low-competition";
+          if (text.includes("high competition")) return "high-competition";
+          if (text.includes("actively")) return "active";
+          return null;
+        }
 
-  // Export helpers to global scope
-  globalThis.toggleCompare = toggleCompare;
-  globalThis.toggleBookmark = toggleBookmark;
-  globalThis.openModal = openModal;
-</script>
+        setElValue("searchInput", params.get("q"));
+        setElValue("hero-search", params.get("q"));
+        setElValue("categoryFilter", params.get("cat"));
+        setElValue("complexityFilter", params.get("comp"));
+        setElValue("sortSelect", params.get("sort"));
 
-<!-- Vercel Speed Insights -->
-<script type="module" src="agent/scripts/speed-insights.js"></script>
-<script>
-  if ('serviceWorker' in navigator) {
-    window.addEventListener('load', () => {
-      navigator.serviceWorker.register('sw.js').catch(err => console.log('SW error:', err));
-    });
-  }
-</script>
+        const lang = params.get("lang");
+        if (lang) {
+          lang
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .forEach((l) => {
+              selectedLanguages.add(l);
+              const pillBtn = document.querySelector(`.pill[data-lang="${l}"]`);
+              if (pillBtn) {
+                pillBtn.classList.add("active");
+                pillBtn.setAttribute("aria-pressed", "true");
+              }
+            });
+          renderSelectedLanguages();
+        }
 
-<div class="modal-bg" id="helpModal">
-  <div class="modal">
-    
-    <button class="close-btn" onclick="closeHelpModal()">
-      <span class="material-symbols-outlined">close</span>
-    </button>
+        const chip = params.get("chip");
+        if (chip) {
+          activeChip = chip;
+          document.querySelectorAll(".filter-chip").forEach((el) => {
+            const key = getChipKey(el.textContent.trim().toLowerCase());
+            if (key === chip) {
+              el.classList.add("bg-orange-600", "text-white");
+              el.classList.remove("bg-surface-container-highest");
+            }
+          });
+        }
 
-    <div class="modal-header">
-      <h2>Keyboard Shortcuts</h2>
-      <p>Quick shortcuts for navigation</p>
-    </div>
+        applyFilters();
+      })();
+      renderOrgs();
+      renderWatchlist();
+      renderRecentlyViewed();
+      updateAIInsights(); // populate AI insight panel on page load
+      loadMentorData();
+      renderGoodFirstIssues();
+      renderCompare();
+      // Wire up Recently Viewed clear button
+      document
+        .getElementById("clearRecentlyViewedBtn")
+        ?.addEventListener("click", clearRecentlyViewed);
 
-    <div class="modal-body">
-      <div class="section-title">Keyboard Shortcuts</div>
+      // Export helpers to global scope
+      globalThis.toggleCompare = toggleCompare;
+      globalThis.toggleBookmark = toggleBookmark;
+      globalThis.openModal = openModal;
+    </script>
 
-<table class="w-full text-sm">
-  <thead>
-    <tr class="border-b text-left">
-      <th class="py-2">Key</th>
-      <th class="py-2">Action</th>
-    </tr>
-  </thead>
+    <!-- Vercel Speed Insights -->
+    <script type="module" src="agent/scripts/speed-insights.js"></script>
+    <script>
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker
+            .register("sw.js")
+            .catch((err) => console.log("SW error:", err));
+        });
+      }
+    </script>
 
-  <tbody>
-    <tr>
-      <td class="py-2">↑ ↓ ← →</td>
-      <td class="py-2">Move focus between cards</td>
-    </tr>
+    <div class="modal-bg" id="helpModal">
+      <div class="modal">
+        <button class="close-btn" onclick="closeHelpModal()">
+          <span class="material-symbols-outlined">close</span>
+        </button>
 
-    <tr>
-      <td class="py-2">Enter</td>
-      <td class="py-2">Open focused card</td>
-    </tr>
+        <div class="modal-header">
+          <h2>Keyboard Shortcuts</h2>
+          <p>Quick shortcuts for navigation</p>
+        </div>
 
-    <tr>
-      <td class="py-2">C</td>
-      <td class="py-2">Toggle compare</td>
-    </tr>
+        <div class="modal-body">
+          <div class="section-title">Keyboard Shortcuts</div>
 
-    <tr>
-      <td class="py-2">Esc</td>
-      <td class="py-2">Close panel</td>
-    </tr>
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b text-left">
+                <th class="py-2">Key</th>
+                <th class="py-2">Action</th>
+              </tr>
+            </thead>
 
-    <tr>
-      <td class="py-2">?</td>
-      <td class="py-2">Toggle help dialog</td>
-    </tr>
-  </tbody>
-</table>
+            <tbody>
+              <tr>
+                <td class="py-2">↑ ↓ ← →</td>
+                <td class="py-2">Move focus between cards</td>
+              </tr>
 
-       
+              <tr>
+                <td class="py-2">Enter</td>
+                <td class="py-2">Open focused card</td>
+              </tr>
 
+              <tr>
+                <td class="py-2">C</td>
+                <td class="py-2">Toggle compare</td>
+              </tr>
+
+              <tr>
+                <td class="py-2">Esc</td>
+                <td class="py-2">Close panel</td>
+              </tr>
+
+              <tr>
+                <td class="py-2">?</td>
+                <td class="py-2">Toggle help dialog</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
 
-  </div>
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const helpModal = document.getElementById("helpModal");
+        const helpBtn = document.getElementById("helpBtn");
 
-<script>
-document.addEventListener('DOMContentLoaded', () => {
+        function openHelpModal() {
+          if (helpModal) {
+            helpModal.classList.add("open");
+          }
+        }
 
-  const helpModal = document.getElementById('helpModal');
-  const helpBtn = document.getElementById('helpBtn');
+        function closeHelpModal() {
+          if (helpModal) {
+            helpModal.classList.remove("open");
+          }
+        }
 
-  function openHelpModal() {
-    if (helpModal) {
-      helpModal.classList.add('open');
-    }
-  }
+        if (helpBtn) {
+          helpBtn.addEventListener("click", openHelpModal);
+        }
 
-  function closeHelpModal() {
-    if (helpModal) {
-      helpModal.classList.remove('open');
-    }
-  }
+        document.addEventListener("keydown", (e) => {
+          if (e.key === "?") {
+            openHelpModal();
+          }
 
-  if (helpBtn) {
-    helpBtn.addEventListener('click', openHelpModal);
-  }
+          if (e.key === "Escape") {
+            if (
+              document
+                .getElementById("proposalModal")
+                ?.classList.contains("open")
+            ) {
+              globalThis.ProposalBuilder?.close?.();
+            } else {
+              closeHelpModal();
+            }
+          }
+        });
 
-  document.addEventListener('keydown', (e) => {
+        window.closeHelpModal = closeHelpModal;
+      });
+    </script>
+    <script src="src/js/badges-mvp.js"></script>
+    <script src="src/js/githubAnalyzer.js"></script>
+    <script src="src/js/skillExtractor.js"></script>
+    <script src="src/js/recommender.js"></script>
+    <script src="src/js/recommendation-ui.js"></script>
 
-    if (e.key === '?') {
-      openHelpModal();
-    }
+    <script>
+      const logoLink = document.getElementById("logoLink");
 
-    if (e.key === 'Escape') {
-      if (document.getElementById('proposalModal')?.classList.contains('open')) {
-        globalThis.ProposalBuilder?.close?.();
-      } else {
-        closeHelpModal();
+      if (logoLink) {
+        logoLink.addEventListener("click", function (e) {
+          e.preventDefault();
+
+          // Scroll to timeline section
+          document.getElementById("timeline").scrollIntoView({
+            behavior: "smooth",
+          });
+
+          // Remove active classes from desktop nav links
+          document.querySelectorAll(".desktop-nav-link").forEach((link) => {
+            link.classList.remove(
+              "text-orange-600",
+              "font-bold",
+              "border-b-2",
+              "border-orange-600",
+            );
+
+            link.classList.add("text-zinc-600", "hover:text-zinc-900");
+          });
+
+          // Activate Timeline desktop nav link
+          const timelineLink = document.querySelector(
+            '.desktop-nav-link[href="#timeline"]',
+          );
+
+          if (timelineLink) {
+            timelineLink.classList.remove("text-zinc-600");
+
+            timelineLink.classList.add(
+              "text-orange-600",
+              "font-bold",
+              "border-b-2",
+              "border-orange-600",
+            );
+          }
+
+          // Sync mobile menu links
+          document.querySelectorAll(".mobile-menu-link").forEach((link) => {
+            link.classList.remove(
+              "text-orange-600",
+              "bg-orange-50",
+              "font-bold",
+            );
+
+            link.classList.add(
+              "text-zinc-700",
+              "hover:bg-zinc-100",
+              "font-medium",
+            );
+          });
+
+          const mobileTimelineLink = document.querySelector(
+            '.mobile-menu-link[data-section="timeline"]',
+          );
+
+          if (mobileTimelineLink) {
+            mobileTimelineLink.classList.remove(
+              "text-zinc-700",
+              "hover:bg-zinc-100",
+              "font-medium",
+            );
+
+            mobileTimelineLink.classList.add(
+              "text-orange-600",
+              "bg-orange-50",
+              "font-bold",
+            );
+          }
+        });
       }
-    }
-
-  });
-
-  window.closeHelpModal = closeHelpModal;
-
-});
-</script>
-<script src="src/js/badges-mvp.js"></script>
-<script src="src/js/githubAnalyzer.js"></script>
-<script src="src/js/skillExtractor.js"></script>
-<script src="src/js/recommender.js"></script>
-<script src="src/js/recommendation-ui.js"></script>
-
-<script>
-const logoLink = document.getElementById("logoLink");
-
-if (logoLink) {
-  logoLink.addEventListener("click", function (e) {
-    e.preventDefault();
-
-    // Scroll to timeline section
-    document.getElementById("timeline").scrollIntoView({
-      behavior: "smooth"
-    });
-
-    // Remove active classes from desktop nav links
-    document.querySelectorAll(".desktop-nav-link").forEach(link => {
-      link.classList.remove(
-        "text-orange-600",
-        "font-bold",
-        "border-b-2",
-        "border-orange-600"
-      );
-
-      link.classList.add("text-zinc-600", "hover:text-zinc-900");
-    });
-
-    // Activate Timeline desktop nav link
-    const timelineLink = document.querySelector(
-      '.desktop-nav-link[href="#timeline"]'
-    );
-
-    if (timelineLink) {
-      timelineLink.classList.remove("text-zinc-600");
-
-      timelineLink.classList.add(
-        "text-orange-600",
-        "font-bold",
-        "border-b-2",
-        "border-orange-600"
-      );
-    }
-
-    // Sync mobile menu links
-    document.querySelectorAll(".mobile-menu-link").forEach(link => {
-      link.classList.remove(
-        "text-orange-600",
-        "bg-orange-50",
-        "font-bold"
-      );
-
-      link.classList.add(
-        "text-zinc-700",
-        "hover:bg-zinc-100",
-        "font-medium"
-      );
-    });
-
-    const mobileTimelineLink = document.querySelector(
-      '.mobile-menu-link[data-section="timeline"]'
-    );
-
-    if (mobileTimelineLink) {
-      mobileTimelineLink.classList.remove(
-        "text-zinc-700",
-        "hover:bg-zinc-100",
-        "font-medium"
-      );
-
-      mobileTimelineLink.classList.add(
-        "text-orange-600",
-        "bg-orange-50",
-        "font-bold"
-      );
-    }
-  });
-}
-</script>
-
-</body>
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
ISSUE NUMBER:#1576

## 🐛 Describe the bug
The Privacy link in the footer was broken. It used a relative path `href="privacy.html"` and was missing `target="_blank"` and `rel="noopener noreferrer"` attributes — unlike every other footer link (Community, GSoC 2026, GitHub) which all use absolute URLs and open in a new tab.

---

## 🔁 Steps to Reproduce
1. Go to https://findmygsoc.vercel.app/
2. Scroll down to the footer
3. Click on the "Privacy" link

---

## ✅ Expected Behavior
The Privacy Policy page should open at `https://findmygsoc.vercel.app/privacy.html` in a new tab — consistent with all other footer links.

---

## ❌ Actual Behavior
The link did not open or failed to load because the relative path `privacy.html` does not resolve correctly on the deployed site.

---

## 📸 Screenshots
<!-- ❌ Current (broken) -->
<a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="privacy.html">Privacy</a>

<!-- ✅ Fix -->
<a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://findmygsoc.vercel.app/privacy.html" target="_blank" rel="noopener noreferrer">Privacy</a>

---

## 🌱 Contributor Checklist
- [ ] I am participating via GSSoC
- [ ] I have read the contribution guidelines
- [ ] I checked for existing issues before creating this

---

## 💻 Environment
- Browser: Chrome
- Device: Desktop
- OS: Windows

---

## 📝 Additional Context
Fixes #444