### PR TITLE
feat(watchlist): add export/import functionality via JSON and Markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -3739,13 +3739,16 @@ btn.__orgListenerAttached = true;
       return;
     }
     
+    const escapeMd = (str) => str ? String(str).replace(/([\\`*_{}[\]()])/g, '\\$1') : '';
+    const escapeUrl = (str) => str ? String(str).replace(/\(/g, '%28').replace(/\)/g, '%29') : '';
+
     let md = "# My GSoC Watchlist\n\n";
     bookmarks.forEach(org => {
-      md += `## [${org.name}](${org.ideas || org.url || ''})\n\n`;
-      if (org.desc) md += `- **Description:** ${org.desc}\n`;
-      if (org.ideas) md += `- **Ideas List:** ${org.ideas}\n`;
-      if (org.years) md += `- **GSoC Years:** ${org.years}${org.firstYear ? ` (since ${org.firstYear})` : ''}\n`;
-      if (org.tags && Array.isArray(org.tags) && org.tags.length) md += `- **Tech Stack:** ${org.tags.join(', ')}\n`;
+      md += `## [${escapeMd(org.name)}](${escapeUrl(org.ideas || org.url || '')})\n\n`;
+      if (org.desc) md += `- **Description:** ${escapeMd(org.desc)}\n`;
+      if (org.ideas) md += `- **Ideas List:** ${escapeUrl(org.ideas)}\n`;
+      if (org.years) md += `- **GSoC Years:** ${escapeMd(org.years)}${org.firstYear ? ` (since ${escapeMd(org.firstYear)})` : ''}\n`;
+      if (org.tags && Array.isArray(org.tags) && org.tags.length) md += `- **Tech Stack:** ${escapeMd(org.tags.join(', '))}\n`;
       md += '\n';
     });
     

--- a/index.html
+++ b/index.html
@@ -1562,7 +1562,7 @@ kbd:hover{
           <span class="material-symbols-outlined text-sm">upload</span>
           Import
         </button>
-        <input type="file" id="importWatchlistInput" accept=".json" class="hidden">
+        <input type="file" id="importWatchlistInput" accept=".json" class="hidden" aria-label="Import Watchlist JSON">
         
         <div class="relative">
           <button onclick="document.getElementById('exportDropdownMenu').classList.toggle('hidden')" class="flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-zinc-600 border border-zinc-200 rounded-full px-4 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors" title="Export Watchlist">
@@ -3739,15 +3739,18 @@ btn.__orgListenerAttached = true;
       return;
     }
     
-    const escapeMd = (str) => str ? String(str).replace(/([\\`*_{}[\]()])/g, '\\$1') : '';
-    const escapeUrl = (str) => str ? String(str).replace(/\(/g, '%28').replace(/\)/g, '%29') : '';
+    const escapeMd = (str) => str ? String(str).replaceAll(/([\\`*_{}[\]()])/g, String.raw`\$1`) : '';
+    const escapeUrl = (str) => str ? String(str).replaceAll('(', '%28').replaceAll(')', '%29') : '';
 
     let md = "# My GSoC Watchlist\n\n";
     bookmarks.forEach(org => {
       md += `## [${escapeMd(org.name)}](${escapeUrl(org.ideas || org.url || '')})\n\n`;
       if (org.desc) md += `- **Description:** ${escapeMd(org.desc)}\n`;
       if (org.ideas) md += `- **Ideas List:** ${escapeUrl(org.ideas)}\n`;
-      if (org.years) md += `- **GSoC Years:** ${escapeMd(org.years)}${org.firstYear ? ` (since ${escapeMd(org.firstYear)})` : ''}\n`;
+      if (org.years) {
+        const firstYearStr = org.firstYear ? ' (since ' + escapeMd(org.firstYear) + ')' : '';
+        md += `- **GSoC Years:** ${escapeMd(org.years)}${firstYearStr}\n`;
+      }
       if (org.tags && Array.isArray(org.tags) && org.tags.length) md += `- **Tech Stack:** ${escapeMd(org.tags.join(', '))}\n`;
       md += '\n';
     });
@@ -3802,35 +3805,32 @@ btn.__orgListenerAttached = true;
     }, 3000);
   }
 
-  document.getElementById('importWatchlistInput')?.addEventListener('change', function(event) {
+  document.getElementById('importWatchlistInput')?.addEventListener('change', async function(event) {
     const file = event.target.files[0];
     if (!file) return;
-    const reader = new FileReader();
-    reader.onload = function(e) {
-      try {
-        const importedOrgs = JSON.parse(e.target.result);
-        if (!Array.isArray(importedOrgs)) throw new Error("Invalid format: Not an array");
-        let addedCount = 0;
-        const validOrgNames = new Set(ORGS.map(o => o.name));
-        importedOrgs.forEach(orgName => {
-          if (typeof orgName === 'string' && !bookmarkedSet.has(orgName) && validOrgNames.has(orgName)) {
-            bookmarkedSet.add(orgName);
-            addedCount++;
-          }
-        });
-        localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
-        applyFilters();
-        renderWatchlist();
-        updateAIInsights();
-        showToast("Import Successful", `Successfully imported ${addedCount} organization(s).`);
-      } catch (err) {
-        alert("Failed to parse JSON file. Ensure it's a valid watchlist export.");
-        console.error("Import error:", err);
-      } finally {
-        event.target.value = ''; // Reset input
-      }
-    };
-    reader.readAsText(file);
+    try {
+      const text = await file.text();
+      const importedOrgs = JSON.parse(text);
+      if (!Array.isArray(importedOrgs)) throw new Error("Invalid format: Not an array");
+      let addedCount = 0;
+      const validOrgNames = new Set(ORGS.map(o => o.name));
+      importedOrgs.forEach(orgName => {
+        if (typeof orgName === 'string' && !bookmarkedSet.has(orgName) && validOrgNames.has(orgName)) {
+          bookmarkedSet.add(orgName);
+          addedCount++;
+        }
+      });
+      localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
+      applyFilters();
+      renderWatchlist();
+      updateAIInsights();
+      showToast("Import Successful", `Successfully imported ${addedCount} organization(s).`);
+    } catch (err) {
+      alert("Failed to parse JSON file. Ensure it's a valid watchlist export.");
+      console.error("Import error:", err);
+    } finally {
+      event.target.value = ''; // Reset input
+    }
   });
 
   // ── renderWatchlist ─────────────────────────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -1557,12 +1557,35 @@ kbd:hover{
         <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">Watchlist.</h2>
         <p class="text-zinc-600 mt-4 max-w-2xl">Curate your open-source journey. Track organizations, monitor deadlines, and prepare your proposals for GSoC 2026.</p>
       </div>
-      <button id="clearAllBookmarksBtn"
-        class="hidden mt-8 flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-red-500 border border-red-200 rounded-full px-4 py-2 hover:bg-red-50 transition-colors"
-        title="Remove all bookmarks">
-        <span class="material-symbols-outlined text-sm">delete_sweep</span>
-        Clear All
-      </button>
+      <div class="flex items-center gap-2 mt-8 flex-wrap">
+        <label class="flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-zinc-600 border border-zinc-200 rounded-full px-4 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer" title="Import Watchlist JSON">
+          <span class="material-symbols-outlined text-sm">upload</span>
+          Import
+          <input type="file" id="importWatchlistInput" accept=".json" class="hidden">
+        </label>
+        
+        <div class="relative group">
+          <button class="flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-zinc-600 border border-zinc-200 rounded-full px-4 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors" title="Export Watchlist">
+            <span class="material-symbols-outlined text-sm">download</span>
+            Export
+          </button>
+          <div class="absolute right-0 top-full mt-2 w-48 bg-white dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800 rounded-xl shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10 flex flex-col overflow-hidden">
+            <button onclick="exportWatchlistAsMarkdown()" class="text-left px-4 py-2 text-xs font-bold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 border-b border-zinc-100 dark:border-zinc-800 flex items-center gap-2">
+              <span class="material-symbols-outlined text-sm">description</span> Markdown (.md)
+            </button>
+            <button onclick="exportWatchlistAsJSON()" class="text-left px-4 py-2 text-xs font-bold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 flex items-center gap-2">
+              <span class="material-symbols-outlined text-sm">data_object</span> JSON (.json)
+            </button>
+          </div>
+        </div>
+
+        <button id="clearAllBookmarksBtn"
+          class="hidden flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-red-500 border border-red-200 rounded-full px-4 py-2 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+          title="Remove all bookmarks">
+          <span class="material-symbols-outlined text-sm">delete_sweep</span>
+          Clear All
+        </button>
+      </div>
     </div>
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
       <div class="lg:col-span-2 space-y-6">
@@ -3690,6 +3713,105 @@ btn.__orgListenerAttached = true;
     renderWatchlist();
     updateAIInsights();
   }
+
+  // ── Import / Export Watchlist ───────────────────────────────────────────────
+  window.exportWatchlistAsJSON = function() {
+    const bookmarks = [...bookmarkedSet];
+    if (bookmarks.length === 0) {
+      alert("Watchlist is empty. Nothing to export.");
+      return;
+    }
+    const blob = new Blob([JSON.stringify(bookmarks, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'gsoc_watchlist.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  window.exportWatchlistAsMarkdown = function() {
+    const bookmarks = [...bookmarkedSet]
+      .map(name => ORGS.find(o => o.name === name))
+      .filter(Boolean);
+    if (bookmarks.length === 0) {
+      alert("Watchlist is empty. Nothing to export.");
+      return;
+    }
+    
+    let md = "# My GSoC Watchlist\n\n";
+    bookmarks.forEach(org => {
+      md += `## [${org.name}](${org.url || ''})\n\n`;
+      if (org.ideas) md += `- **Ideas List:** ${org.ideas}\n`;
+      if (org.years) md += `- **GSoC Years:** ${org.years.join(', ')}\n`;
+      if (org.tags && org.tags.length) md += `- **Tech Stack:** ${org.tags.join(', ')}\n`;
+      md += '\n';
+    });
+    
+    const blob = new Blob([md], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'gsoc_watchlist.md';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  function showToast(title, message) {
+    const toast = document.createElement('div');
+    toast.className = 'badge-notification flex items-center gap-3';
+    toast.innerHTML = `
+      <div class="badge-notification-icon bg-white/20 w-10 h-10 rounded-full flex items-center justify-center shrink-0">
+        <span class="material-symbols-outlined text-white">check_circle</span>
+      </div>
+      <div class="badge-notification-text">
+        <div class="badge-notification-title font-bold text-sm">${title}</div>
+        <div class="badge-notification-desc text-xs text-white/80">${message}</div>
+      </div>
+    `;
+    document.body.appendChild(toast);
+    
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        toast.classList.add('show');
+      });
+    });
+
+    setTimeout(() => {
+      toast.classList.remove('show');
+      setTimeout(() => toast.remove(), 400);
+    }, 3000);
+  }
+
+  document.getElementById('importWatchlistInput')?.addEventListener('change', function(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = function(e) {
+      try {
+        const importedOrgs = JSON.parse(e.target.result);
+        if (!Array.isArray(importedOrgs)) throw new Error("Invalid format: Not an array");
+        let addedCount = 0;
+        importedOrgs.forEach(orgName => {
+          if (typeof orgName === 'string' && !bookmarkedSet.has(orgName)) {
+            bookmarkedSet.add(orgName);
+            addedCount++;
+          }
+        });
+        localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
+        applyFilters();
+        renderWatchlist();
+        updateAIInsights();
+        showToast("Import Successful", `Successfully imported ${addedCount} organization(s).`);
+      } catch (err) {
+        alert("Failed to parse JSON file. Ensure it's a valid watchlist export.");
+        console.error("Import error:", err);
+      } finally {
+        event.target.value = ''; // Reset input
+      }
+    };
+    reader.readAsText(file);
+  });
 
   // ── renderWatchlist ─────────────────────────────────────────────────────────
   function renderWatchlist() {

--- a/index.html
+++ b/index.html
@@ -3741,10 +3741,11 @@ btn.__orgListenerAttached = true;
     
     let md = "# My GSoC Watchlist\n\n";
     bookmarks.forEach(org => {
-      md += `## [${org.name}](${org.url || ''})\n\n`;
+      md += `## [${org.name}](${org.ideas || org.url || ''})\n\n`;
+      if (org.desc) md += `- **Description:** ${org.desc}\n`;
       if (org.ideas) md += `- **Ideas List:** ${org.ideas}\n`;
-      if (org.years) md += `- **GSoC Years:** ${org.years.join(', ')}\n`;
-      if (org.tags && org.tags.length) md += `- **Tech Stack:** ${org.tags.join(', ')}\n`;
+      if (org.years) md += `- **GSoC Years:** ${org.years} (since ${org.firstYear})\n`;
+      if (org.tags && Array.isArray(org.tags) && org.tags.length) md += `- **Tech Stack:** ${org.tags.join(', ')}\n`;
       md += '\n';
     });
     

--- a/index.html
+++ b/index.html
@@ -1558,22 +1558,22 @@ kbd:hover{
         <p class="text-zinc-600 mt-4 max-w-2xl">Curate your open-source journey. Track organizations, monitor deadlines, and prepare your proposals for GSoC 2026.</p>
       </div>
       <div class="flex items-center gap-2 mt-8 flex-wrap">
-        <label class="flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-zinc-600 border border-zinc-200 rounded-full px-4 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer" title="Import Watchlist JSON">
+        <button onclick="document.getElementById('importWatchlistInput').click()" class="flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-zinc-600 border border-zinc-200 rounded-full px-4 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer" title="Import Watchlist JSON">
           <span class="material-symbols-outlined text-sm">upload</span>
           Import
-          <input type="file" id="importWatchlistInput" accept=".json" class="hidden">
-        </label>
+        </button>
+        <input type="file" id="importWatchlistInput" accept=".json" class="hidden">
         
-        <div class="relative group">
-          <button class="flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-zinc-600 border border-zinc-200 rounded-full px-4 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors" title="Export Watchlist">
+        <div class="relative">
+          <button onclick="document.getElementById('exportDropdownMenu').classList.toggle('hidden')" class="flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-zinc-600 border border-zinc-200 rounded-full px-4 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors" title="Export Watchlist">
             <span class="material-symbols-outlined text-sm">download</span>
             Export
           </button>
-          <div class="absolute right-0 top-full mt-2 w-48 bg-white dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800 rounded-xl shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10 flex flex-col overflow-hidden">
-            <button onclick="exportWatchlistAsMarkdown()" class="text-left px-4 py-2 text-xs font-bold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 border-b border-zinc-100 dark:border-zinc-800 flex items-center gap-2">
+          <div id="exportDropdownMenu" class="hidden absolute right-0 top-full mt-2 w-48 bg-white dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800 rounded-xl shadow-lg z-10 flex flex-col overflow-hidden">
+            <button onclick="exportWatchlistAsMarkdown(); document.getElementById('exportDropdownMenu').classList.add('hidden')" class="text-left px-4 py-2 text-xs font-bold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 border-b border-zinc-100 dark:border-zinc-800 flex items-center gap-2">
               <span class="material-symbols-outlined text-sm">description</span> Markdown (.md)
             </button>
-            <button onclick="exportWatchlistAsJSON()" class="text-left px-4 py-2 text-xs font-bold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 flex items-center gap-2">
+            <button onclick="exportWatchlistAsJSON(); document.getElementById('exportDropdownMenu').classList.add('hidden')" class="text-left px-4 py-2 text-xs font-bold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 flex items-center gap-2">
               <span class="material-symbols-outlined text-sm">data_object</span> JSON (.json)
             </button>
           </div>

--- a/index.html
+++ b/index.html
@@ -3715,7 +3715,7 @@ btn.__orgListenerAttached = true;
   }
 
   // ── Import / Export Watchlist ───────────────────────────────────────────────
-  window.exportWatchlistAsJSON = function() {
+  globalThis.exportWatchlistAsJSON = function() {
     const bookmarks = [...bookmarkedSet];
     if (bookmarks.length === 0) {
       alert("Watchlist is empty. Nothing to export.");
@@ -3730,7 +3730,7 @@ btn.__orgListenerAttached = true;
     URL.revokeObjectURL(url);
   };
 
-  window.exportWatchlistAsMarkdown = function() {
+  globalThis.exportWatchlistAsMarkdown = function() {
     const bookmarks = [...bookmarkedSet]
       .map(name => ORGS.find(o => o.name === name))
       .filter(Boolean);
@@ -3744,7 +3744,7 @@ btn.__orgListenerAttached = true;
       md += `## [${org.name}](${org.ideas || org.url || ''})\n\n`;
       if (org.desc) md += `- **Description:** ${org.desc}\n`;
       if (org.ideas) md += `- **Ideas List:** ${org.ideas}\n`;
-      if (org.years) md += `- **GSoC Years:** ${org.years} (since ${org.firstYear})\n`;
+      if (org.years) md += `- **GSoC Years:** ${org.years}${org.firstYear ? ` (since ${org.firstYear})` : ''}\n`;
       if (org.tags && Array.isArray(org.tags) && org.tags.length) md += `- **Tech Stack:** ${org.tags.join(', ')}\n`;
       md += '\n';
     });
@@ -3761,15 +3761,30 @@ btn.__orgListenerAttached = true;
   function showToast(title, message) {
     const toast = document.createElement('div');
     toast.className = 'badge-notification flex items-center gap-3';
-    toast.innerHTML = `
-      <div class="badge-notification-icon bg-white/20 w-10 h-10 rounded-full flex items-center justify-center shrink-0">
-        <span class="material-symbols-outlined text-white">check_circle</span>
-      </div>
-      <div class="badge-notification-text">
-        <div class="badge-notification-title font-bold text-sm">${title}</div>
-        <div class="badge-notification-desc text-xs text-white/80">${message}</div>
-      </div>
-    `;
+
+    const iconContainer = document.createElement('div');
+    iconContainer.className = 'badge-notification-icon bg-white/20 w-10 h-10 rounded-full flex items-center justify-center shrink-0';
+    const icon = document.createElement('span');
+    icon.className = 'material-symbols-outlined text-white';
+    icon.textContent = 'check_circle';
+    iconContainer.appendChild(icon);
+
+    const textContainer = document.createElement('div');
+    textContainer.className = 'badge-notification-text';
+
+    const titleEl = document.createElement('div');
+    titleEl.className = 'badge-notification-title font-bold text-sm';
+    titleEl.textContent = title;
+
+    const messageEl = document.createElement('div');
+    messageEl.className = 'badge-notification-desc text-xs text-white/80';
+    messageEl.textContent = message;
+
+    textContainer.appendChild(titleEl);
+    textContainer.appendChild(messageEl);
+
+    toast.appendChild(iconContainer);
+    toast.appendChild(textContainer);
     document.body.appendChild(toast);
     
     requestAnimationFrame(() => {
@@ -3793,8 +3808,9 @@ btn.__orgListenerAttached = true;
         const importedOrgs = JSON.parse(e.target.result);
         if (!Array.isArray(importedOrgs)) throw new Error("Invalid format: Not an array");
         let addedCount = 0;
+        const validOrgNames = new Set(ORGS.map(o => o.name));
         importedOrgs.forEach(orgName => {
-          if (typeof orgName === 'string' && !bookmarkedSet.has(orgName)) {
+          if (typeof orgName === 'string' && !bookmarkedSet.has(orgName) && validOrgNames.has(orgName)) {
             bookmarkedSet.add(orgName);
             addedCount++;
           }


### PR DESCRIPTION
program: gssoc

## 🚀 Program
GSSoC

## 📝 Description
Added full Export (JSON/Markdown) and Import (JSON) capabilities to the Watchlist section. This allows users to safely backup, share, and restore their bookmarked organizations. The import functionality automatically syncs the UI and prevents duplicates, and includes a toast notification for success.

## 🔗 Related Issue
Closes #1577 

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Open `index.html` in a browser.
2. Bookmark a few organizations from the directory.
3. Scroll down to the Watchlist and click **Export -> JSON (.json)** to download your list.
4. Click **Export -> Markdown (.md)** to verify the markdown structure.
5. Click **Clear All** to empty your watchlist.
6. Click **Import**, upload your previously saved `.json` file.
7. Verify that the success toast appears and the organizations instantly populate back into the watchlist without refreshing the page.

## ✅ Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)