### PR TITLE
fix(#1141): enhance search functionality to support full-text search across organization name, technology tags, categories, descriptions, and fit categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -3562,7 +3562,36 @@ if(org.ideas){
     const sort = document.getElementById('sortSelect')?.value || 'alpha';
 
     filteredOrgs = ORGS.filter(o => {
-      const matchSearch = o.name.toLowerCase().includes(query);
+      // Full-text search: organization name, technologies, description, and category
+      let matchSearch = false;
+      if (query) {
+        // Search in organization name
+        matchSearch = o.name.toLowerCase().includes(query);
+        
+        // Search in technology tags
+        if (!matchSearch && o.tags) {
+          matchSearch = o.tags.some(tag => String(tag).toLowerCase().includes(query));
+        }
+        
+        // Search in category
+        if (!matchSearch && o.cat) {
+          matchSearch = String(o.cat).toLowerCase().includes(query);
+        }
+        
+        // Search in description
+        if (!matchSearch && o.desc) {
+          matchSearch = String(o.desc).toLowerCase().includes(query);
+        }
+        
+        // Search in fit categories
+        if (!matchSearch && o.fit) {
+          matchSearch = o.fit.some(fit => String(fit).toLowerCase().includes(query));
+        }
+      } else {
+        // If query is empty, match all
+        matchSearch = true;
+      }
+      
       const matchCat = !cat || o.cat === cat;
       const matchComp = comp === 'all' || o.codebase === comp;
       const tags = (o.tags || []).map(t => String(t).toLowerCase());
@@ -3583,12 +3612,49 @@ if(org.ideas){
 
     if(query){
       filteredOrgs.sort((a,b)=>{
-        const nameA=a.name.toLowerCase();
-        const nameB=b.name.toLowerCase();
-        if(nameA===query && nameB!==query) return -1;
-        if(nameB===query && nameA!==query) return 1;
-        if(nameA.startsWith(query) && !nameB.startsWith(query)) return -1;
-        if(nameB.startsWith(query) && !nameA.startsWith(query)) return 1;
+        // Helper to calculate relevance score for an organization
+        const getRelevanceScore = (org) => {
+          let score = 0;
+          const orgName = org.name.toLowerCase();
+          
+          // Exact name match: highest priority (1000)
+          if(orgName === query) score += 1000;
+          
+          // Name starts with query (500)
+          if(orgName.startsWith(query)) score += 500;
+          
+          // Tag exact match (300)
+          if(org.tags && org.tags.some(tag => String(tag).toLowerCase() === query)) {
+            score += 300;
+          }
+          
+          // Tag contains query (200)
+          if(org.tags && org.tags.some(tag => String(tag).toLowerCase().includes(query))) {
+            score += 200;
+          }
+          
+          // Category contains query (100)
+          if(org.cat && String(org.cat).toLowerCase().includes(query)) {
+            score += 100;
+          }
+          
+          // Fit category contains query (80)
+          if(org.fit && org.fit.some(fit => String(fit).toLowerCase().includes(query))) {
+            score += 80;
+          }
+          
+          // Description contains query (50)
+          if(org.desc && String(org.desc).toLowerCase().includes(query)) {
+            score += 50;
+          }
+          
+          return score;
+        };
+        
+        const scoreA = getRelevanceScore(a);
+        const scoreB = getRelevanceScore(b);
+        
+        if(scoreA !== scoreB) return scoreB - scoreA;
         return applySecondarySort(a, b, sort);
       });
     } else {

--- a/index.html
+++ b/index.html
@@ -3617,20 +3617,24 @@ if(org.ideas){
           let score = 0;
           const orgName = org.name.toLowerCase();
           
-          // Exact name match: highest priority (1000)
-          if(orgName === query) score += 1000;
-          
-          // Name starts with query (500)
-          if(orgName.startsWith(query)) score += 500;
-          
-          // Tag exact match (300)
-          if(org.tags && org.tags.some(tag => String(tag).toLowerCase() === query)) {
-            score += 300;
+          // Exact name match: highest priority (1000) - short-circuit
+          if(orgName === query) {
+            score += 1000;
+          } else if(orgName.startsWith(query)) {
+            // Name starts with query (500)
+            score += 500;
           }
           
-          // Tag contains query (200)
-          if(org.tags && org.tags.some(tag => String(tag).toLowerCase().includes(query))) {
-            score += 200;
+          // Tag matching with short-circuit logic
+          if(org.tags) {
+            const tagExactMatch = org.tags.some(tag => String(tag).toLowerCase() === query);
+            if(tagExactMatch) {
+              // Tag exact match (300)
+              score += 300;
+            } else if(org.tags.some(tag => String(tag).toLowerCase().includes(query))) {
+              // Tag contains query (200)
+              score += 200;
+            }
           }
           
           // Category contains query (100)


### PR DESCRIPTION
program: GSSOC

## 🚀 Program
GSSOC

## 📝 Description
This PR fixes the search functionality to support full-text search across organization name, technology tags, categories, descriptions, and fit categories. Previously, the search only matched organization names despite being advertised as a comprehensive search feature. 

**Changes:**
- Enhanced `applyFilters()` function to search across multiple fields
- Implemented intelligent relevance scoring system
- Search now covers: organization names, tech stack, categories, descriptions, and target audiences

## 🔗 Related Issue
Closes #1141

## 🔄 Type of Change
<!-- Check all that apply -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Open `index.html` in a browser
2. Try searching for the following to verify full-text search works:
   - Search "python" → Should return 12+ organizations with Python in name/tags/description
   - Search "rust" → Should return 10+ organizations using Rust technology
   - Search "robotics" → Should return robotics-focused organizations (JdeRobot, Open Robotics, dora-rs, ArduPilot)
   - Search "security" → Should return security-related organizations
3. Verify that search results are ranked by relevance (exact name matches first, then tag matches, etc.)
4. Test that empty search returns all organizations

## 📸 Screenshots (if applicable)
N/A - JavaScript functionality improvement (no visual changes)

## ✅ Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above (#1141)
- [x] My PR title follows Conventional Commits format (`fix(#1141): enhance search functionality...`)
- [x] I have added DCO sign-off to my commit (`git commit -s`)
- [x] All changes are production-ready