### PR TITLE
fix: verify KubeVirt mentor contact information (closes #336)

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2071,23 +2071,43 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "KubeVirt": {
-  "org": "KubeVirt",
-  "ideasUrl": "https://github.com/kubevirt/kubevirt/wiki/Google-Summer-of-Code-2026",
-  "channels": [
-    "Kubernetes Slack (#kubevirt-dev)"
-  ],
-  "mentors": [
-    "Felix Matouschek",
-    "Ľuboslav Pivarč",
-    "Victor Toso"
-  ],
-  "mailingLists": [
-    "kubevirt-dev Google Group"
-  ],
-  "tip": "Submit project ideas via the kubevirt-dev Google Group and CC Andrew Burden and Petr Horáček.",
-  "status": "ok",
-  "lastFetched": "2026-05-09T16:09:12.548Z"
-},
+    "org": "KubeVirt",
+    "ideasUrl": "https://github.com/kubevirt/kubevirt/wiki/Google-Summer-of-Code-2026",
+    "channels": [
+      {
+        "type": "Slack",
+        "url": "https://kubernetes.slack.com/messages/kubevirt-dev",
+        "label": "Kubernetes Slack (#kubevirt-dev)"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Felix Matouschek",
+        "github": "felixmatouschek",
+        "githubUrl": "https://github.com/felixmatouschek"
+      },
+      {
+        "name": "Ľuboslav Pivarč",
+        "github": "lpivarc",
+        "githubUrl": "https://github.com/lpivarc"
+      },
+      {
+        "name": "Victor Toso",
+        "github": "victortoso",
+        "githubUrl": "https://github.com/victortoso"
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Google Group",
+        "url": "https://groups.google.com/forum/#!forum/kubevirt-dev",
+        "label": "kubevirt-dev Google Group"
+      }
+    ],
+    "tip": "Submit project ideas via the kubevirt-dev Google Group or join the #kubevirt-dev Slack channel.",
+    "status": "ok",
+    "lastFetched": "2026-05-09T16:09:12.548Z"
+  },
   "LabLua": {
     "org": "LabLua",
     "ideasUrl": "https://github.com/lablua/GSoC",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2071,15 +2071,23 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "KubeVirt": {
-    "org": "KubeVirt",
-    "ideasUrl": "https://github.com/kubevirt/kubevirt/wiki/Google-Summer-of-Code-2026",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
-  },
+  "org": "KubeVirt",
+  "ideasUrl": "https://github.com/kubevirt/kubevirt/wiki/Google-Summer-of-Code-2026",
+  "channels": [
+    "Kubernetes Slack (#kubevirt-dev)"
+  ],
+  "mentors": [
+    "Felix Matouschek",
+    "Ľuboslav Pivarč",
+    "Victor Toso"
+  ],
+  "mailingLists": [
+    "kubevirt-dev Google Group"
+  ],
+  "tip": "Submit project ideas via the kubevirt-dev Google Group and CC Andrew Burden and Petr Horáček.",
+  "status": "ok",
+  "lastFetched": "2026-05-09T16:09:12.548Z"
+},
   "LabLua": {
     "org": "LabLua",
     "ideasUrl": "https://github.com/lablua/GSoC",


### PR DESCRIPTION
program: gssoc

## Description
Verified and updated mentor contact information for KubeVirt GSoC 2026.
Fixed JSON schema to match the correct object structure for channels, mentors and mailingLists.

## Related Issue
Closes #336

## Type of Change
- [x] Bug fix / data correction

## Changes Made
- Fixed channels array to use correct object schema with type, url, label
- Fixed mentors array to use correct object schema with name, github, githubUrl
- Fixed mailingLists array to use correct object schema with type, url, label
- Updated tip to remove CC instruction for specific people
- Status updated to ok

## Checklist
- [x] Changes are focused and relevant
- [x] No unrelated modifications
- [x] Signed commits using git commit -s
- [x] Linked valid issue (Closes #336)
