### PR TITLE
fix: update mentor contact info for The Julia Language

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -134,7 +134,7 @@
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
- "AFLplusplus": {
+  "AFLplusplus": {
     "org": "AFLplusplus",
     "ideasUrl": "https://github.com/AFLplusplus/LibAFL/issues/3706",
     "channels": [
@@ -527,21 +527,25 @@
     "org": "CCExtractor Development",
     "ideasUrl": "https://github.com/CCExtractor/ccextractor/wiki/Google-Summer-of-Code-2026",
     "channels": [],
-    "mentors": [ {
+    "mentors": [
+      {
         "name": "Carlos Fernandez Sanz",
         "github": "cfsmp3",
         "githubUrl": "https://github.com/cfsmp3"
-      }],
-    "mailingLists": [ {
+      }
+    ],
+    "mailingLists": [
+      {
         "type": "Mailing list",
         "url": "mailto:carlos@sanz.dev",
         "label": "CCExtractor Maintainer mail list"
-      }],
+      }
+    ],
     "tip": "Carlos is the main contact for CCExtractor",
     "status": "ok",
     "lastFetched": "2026-06-30T16:45:00.000Z"
   },
-"Ceph": {
+  "Ceph": {
     "org": "Ceph",
     "ideasUrl": "https://ceph.io/en/developers/google-summer-of-code/",
     "channels": [
@@ -582,12 +586,15 @@
   "CERN-HSF": {
     "org": "CERN-HSF",
     "ideasUrl": "https://hepsoftwarefoundation.org/activities/gsoc.html",
-    "channels": [  {
+    "channels": [
+      {
         "type": "Gitter",
         "url": " https://app.gitter.im/#/room/#HSF_HSF-GSoC:gitter.im?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge",
         "label": "CERN-HSF contributors gitter channel "
-      }],
-    "mentors": [  {
+      }
+    ],
+    "mentors": [
+      {
         "name": "Maciej Szymanski ",
         "github": "",
         "githubUrl": ""
@@ -596,13 +603,15 @@
         "name": "Tatiana Ovsiannikova ",
         "github": "",
         "githubUrl": ""
-      }],
+      }
+    ],
     "mailingLists": [
       {
         "type": "Mailing list",
         "url": "mailto:hsf-gsoc-admin@googlegroups.com",
         "label": "CERN HSF GSoC Maintainers Mailing List "
-      }],
+      }
+    ],
     "tip": "Please avoid posting extended information about yourself in the chat channel and reserve this for the direct exchange with the mentors.",
     "status": "ok",
     "lastFetched": "2026-05-31T09:51:14.520Z"
@@ -611,19 +620,43 @@
     "org": "CGAL Project",
     "ideasUrl": "https://github.com/CGAL/cgal/wiki/Project-Ideas-for-GSOC-2026",
     "channels": [
-     {
-    "type": "Stack Overflow",
-    "url": "https://stackoverflow.com/questions/tagged/cgal",
-    "label": "CGAL on Stack Overflow"
-     }
+      {
+        "type": "Stack Overflow",
+        "url": "https://stackoverflow.com/questions/tagged/cgal",
+        "label": "CGAL on Stack Overflow"
+      }
     ],
     "mentors": [
-      { "name": "Sebastien Loriot", "github": "", "githubUrl": "" },
-      { "name": "Andreas Fabri", "github": "", "githubUrl": "" },
-      { "name": "Efi Fogel", "github": "", "githubUrl": "" },
-      { "name": "Jane Tournois", "github": "", "githubUrl": "" },
-      { "name": "Mael Rouxel-Labbé", "github": "", "githubUrl": "" },
-      { "name": "Sven Oesau", "github": "", "githubUrl": "" }
+      {
+        "name": "Sebastien Loriot",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Andreas Fabri",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Efi Fogel",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Jane Tournois",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Mael Rouxel-Labbé",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Sven Oesau",
+        "github": "",
+        "githubUrl": ""
+      }
     ],
     "mailingLists": [
       {
@@ -652,16 +685,56 @@
       }
     ],
     "mentors": [
-      { "name": "Roman Ivanov", "github": "romani", "githubUrl": "https://github.com/romani" },
-      { "name": "Ruslan Diachenko", "github": "", "githubUrl": "" },
-      { "name": "Mohamed Mahfouz", "github": "", "githubUrl": "" },
-      { "name": "Mauryan Kansara", "github": "", "githubUrl": "" },
-      { "name": "Baratali Izmailov", "github": "", "githubUrl": "" },
-      { "name": "Andrei Paikin", "github": "", "githubUrl": "" },
-      { "name": "Daniel Mühlbachler", "github": "", "githubUrl": "" },
-      { "name": "stoyan", "github": "", "githubUrl": "" },
-      { "name": "kkoutsilis", "github": "", "githubUrl": "" },
-      { "name": "Mohit", "github": "", "githubUrl": "" }
+      {
+        "name": "Roman Ivanov",
+        "github": "romani",
+        "githubUrl": "https://github.com/romani"
+      },
+      {
+        "name": "Ruslan Diachenko",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Mohamed Mahfouz",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Mauryan Kansara",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Baratali Izmailov",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Andrei Paikin",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Daniel Mühlbachler",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "stoyan",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "kkoutsilis",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Mohit",
+        "github": "",
+        "githubUrl": ""
+      }
     ],
     "mailingLists": [
       {
@@ -824,15 +897,14 @@
     "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/cuneiform-digital-library-initiative-cdli",
     "channels": [
       {
-        "type":"Chat",
-        "url":"https://gitlab.com/cdli/framework/-/wikis/Join-the-Community-and-GSoC-Contact",
-        "label":"CDLI Chat"
+        "type": "Chat",
+        "url": "https://gitlab.com/cdli/framework/-/wikis/Join-the-Community-and-GSoC-Contact",
+        "label": "CDLI Chat"
       },
       {
-        "type":"Blog",
-        "url":"https://www.linkedin.com/company/cuneiform-digital-library-initiative/",
-        "label":"CDLI Blog"
-
+        "type": "Blog",
+        "url": "https://www.linkedin.com/company/cuneiform-digital-library-initiative/",
+        "label": "CDLI Blog"
       }
     ],
     "mentors": [
@@ -934,19 +1006,19 @@
     "ideasUrl": "https://github.com/dbpedia/databus/wiki/GSoC-2026",
     "channels": [
       {
-        "type":"Discord",
-        "url":"https://discord.gg/fB8byAPP7e",
-        "label":"DBpedia Discord"
+        "type": "Discord",
+        "url": "https://discord.gg/fB8byAPP7e",
+        "label": "DBpedia Discord"
       },
       {
-        "type":"Forum",
-        "url":"https://forum.dbpedia.org/",
-        "label":"DBpedia Community Forum"
+        "type": "Forum",
+        "url": "https://forum.dbpedia.org/",
+        "label": "DBpedia Community Forum"
       },
       {
-        "type":"Email",
-        "url":"mailto:dbpedia@infai.org",
-        "label":"DBpedia contact Email"
+        "type": "Email",
+        "url": "mailto:dbpedia@infai.org",
+        "label": "DBpedia contact Email"
       }
     ],
     "mentors": [
@@ -1003,36 +1075,36 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "DeepChem": {
-      "org": "DeepChem",
-      "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/deepchem",
-      "channels": [
-        {
-          "type": "Discord",
-          "url": "https://discord.com/invite/RYTrUY8Ssn",
-          "label": "DeepChem Discord"
-        }
-      ],
-      "mentors": [
-        {
-          "name": "José A. Sigüenza",
-          "github": "JoseAntonioSiguenza",
-          "githubUrl": "https://github.com/JoseAntonioSiguenza"
-        },
-        {
-          "name": "Aryan Amit Barsainyan",
-          "github": "ARY2260",
-          "githubUrl": "https://github.com/ARY2260"
-        },
-        {
-          "name": "Harindhar",
-          "github": "Harindhar10",
-          "githubUrl": "https://github.com/Harindhar10"
-        }
-      ],
-      "mailingLists": [],
-      "tip": "Join the DeepChem Discord server and introduce yourself before reaching out to mentors directly.",
-      "status": "ok",
-      "lastFetched": "2026-05-28T00:00:00.000Z"
+    "org": "DeepChem",
+    "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/deepchem",
+    "channels": [
+      {
+        "type": "Discord",
+        "url": "https://discord.com/invite/RYTrUY8Ssn",
+        "label": "DeepChem Discord"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "José A. Sigüenza",
+        "github": "JoseAntonioSiguenza",
+        "githubUrl": "https://github.com/JoseAntonioSiguenza"
+      },
+      {
+        "name": "Aryan Amit Barsainyan",
+        "github": "ARY2260",
+        "githubUrl": "https://github.com/ARY2260"
+      },
+      {
+        "name": "Harindhar",
+        "github": "Harindhar10",
+        "githubUrl": "https://github.com/Harindhar10"
+      }
+    ],
+    "mailingLists": [],
+    "tip": "Join the DeepChem Discord server and introduce yourself before reaching out to mentors directly.",
+    "status": "ok",
+    "lastFetched": "2026-05-28T00:00:00.000Z"
   },
   "Django Software Foundation": {
     "org": "Django Software Foundation",
@@ -1162,7 +1234,7 @@
         "github": "",
         "githubUrl": ""
       },
-       {
+      {
         "name": "Maria Teresa Delgado",
         "github": "",
         "githubUrl": ""
@@ -1177,8 +1249,6 @@
         "github": "",
         "githubUrl": ""
       }
-
-
     ],
     "mailingLists": [
       {
@@ -1186,12 +1256,11 @@
         "url": "https://accounts.eclipse.org/mailing-list/soc-dev",
         "label": "Eclipse Foundation SoC Developer List"
       },
-       {
+      {
         "type": "Mailing list",
         "url": "mailto:emo@eclipse-foundation.org",
         "label": "Eclipse Management Organization"
       }
-
     ],
     "tip": "",
     "status": "ok",
@@ -1245,44 +1314,44 @@
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
-"FFmpeg": {
-  "org": "FFmpeg",
-  "ideasUrl": "https://trac.ffmpeg.org/wiki/SponsoringPrograms/GSoC/2026",
-  "channels": [
-    {
-      "type": "IRC",
-      "url": "https://web.libera.chat/#ffmpeg-devel",
-      "label": "#ffmpeg-devel on Libera.Chat"
-    }
-  ],
-  "mentors": [
-    {
-      "name": "Michael Niedermayer",
-      "github": "",
-      "githubUrl": ""
-    },
-    {
-      "name": "Reynaldo Verdejo",
-      "github": "",
-      "githubUrl": ""
-    },
-    {
-      "name": "Thilo Borgmann",
-      "github": "",
-      "githubUrl": ""
-    }
-  ],
-  "mailingLists": [
-    {
-      "type": "Mailing list",
-      "url": "https://lists.ffmpeg.org/mailman3/lists/ffmpeg-devel.ffmpeg.org/",
-      "label": "ffmpeg-devel@ffmpeg.org"
-    }
-  ],
-  "tip": "Read the developer documentation and introduce yourself on the mailing list before applying.",
-  "status": "ok",
-  "lastFetched": "2026-05-09T16:09:12.548Z"
-},
+  "FFmpeg": {
+    "org": "FFmpeg",
+    "ideasUrl": "https://trac.ffmpeg.org/wiki/SponsoringPrograms/GSoC/2026",
+    "channels": [
+      {
+        "type": "IRC",
+        "url": "https://web.libera.chat/#ffmpeg-devel",
+        "label": "#ffmpeg-devel on Libera.Chat"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Michael Niedermayer",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Reynaldo Verdejo",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Thilo Borgmann",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Mailing list",
+        "url": "https://lists.ffmpeg.org/mailman3/lists/ffmpeg-devel.ffmpeg.org/",
+        "label": "ffmpeg-devel@ffmpeg.org"
+      }
+    ],
+    "tip": "Read the developer documentation and introduce yourself on the mailing list before applying.",
+    "status": "ok",
+    "lastFetched": "2026-05-09T16:09:12.548Z"
+  },
   "FLARE": {
     "org": "FLARE",
     "ideasUrl": "https://github.com/mandiant/flare-vm/wiki/GSoC-2026",
@@ -1555,59 +1624,59 @@
     "status": "no-contact-found",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
-"GNU Mailman": {
-  "org": "GNU Mailman",
-  "ideasUrl": "https://wiki.list.org/DEV/Google-Summer-of-Code-2026",
-  "channels": [
-    {
-      "type": "IRC",
-      "url": "https://libera.chat/",
-      "label": "#mailman on Libera.Chat"
-    }
-  ],
-  "mentors": [
-    {
-      "name": "Abhilash Raj",
-      "github": "",
-      "githubUrl": ""
-    },
-    {
-      "name": "Stephen J. Turnbull",
-      "github": "",
-      "githubUrl": ""
-    },
-    {
-      "name": "Mark Sapiro",
-      "github": "",
-      "githubUrl": ""
-    },
-    {
-      "name": "Daniel Toe",
-      "github": "",
-      "githubUrl": ""
-    },
-    {
-      "name": "Victoriano Giralt",
-      "github": "",
-      "githubUrl": ""
-    }
-  ],
-  "mailingLists": [
-    {
-      "type": "Mailing list",
-      "url": "mailto:mailman-developers@python.org",
-      "label": "Mailman Developers"
-    },
-    {
-      "type": "Mailing list",
-      "url": "mailto:mailman-users@mailman3.org",
-      "label": "Mailman 3 Users"
-    }
-  ],
-  "tip": "Primary mentor communication happens through the Mailman Developers mailing list or #mailman IRC.",
-  "status": "ok",
-  "lastFetched": "2026-05-09T16:09:12.548Z"
-},
+  "GNU Mailman": {
+    "org": "GNU Mailman",
+    "ideasUrl": "https://wiki.list.org/DEV/Google-Summer-of-Code-2026",
+    "channels": [
+      {
+        "type": "IRC",
+        "url": "https://libera.chat/",
+        "label": "#mailman on Libera.Chat"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Abhilash Raj",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Stephen J. Turnbull",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Mark Sapiro",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Daniel Toe",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Victoriano Giralt",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Mailing list",
+        "url": "mailto:mailman-developers@python.org",
+        "label": "Mailman Developers"
+      },
+      {
+        "type": "Mailing list",
+        "url": "mailto:mailman-users@mailman3.org",
+        "label": "Mailman 3 Users"
+      }
+    ],
+    "tip": "Primary mentor communication happens through the Mailman Developers mailing list or #mailman IRC.",
+    "status": "ok",
+    "lastFetched": "2026-05-09T16:09:12.548Z"
+  },
   "GNU Octave": {
     "org": "GNU Octave",
     "ideasUrl": "https://wiki.octave.org/Summer_of_Code_-_Getting_Started",
@@ -1654,7 +1723,7 @@
     "status": "no-contact-found",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
-"GRAME": {
+  "GRAME": {
     "org": "GRAME",
     "ideasUrl": "https://github.com/grame-cncm/faust/wiki/GSoC-2026",
     "channels": [
@@ -1728,10 +1797,26 @@
       }
     ],
     "mentors": [
-      { "name": "Prof. Sergei Gleyzer", "github": "", "githubUrl": "" },
-      { "name": "Prof. Xabier Granja", "github": "", "githubUrl": "" },
-      { "name": "Prof. Emanuele Usai", "github": "", "githubUrl": "" },
-      { "name": "Prof. Despina Stavrinos", "github": "", "githubUrl": "" }
+      {
+        "name": "Prof. Sergei Gleyzer",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Prof. Xabier Granja",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Prof. Emanuele Usai",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Prof. Despina Stavrinos",
+        "github": "",
+        "githubUrl": ""
+      }
     ],
     "mailingLists": [
       {
@@ -1768,17 +1853,37 @@
     "org": "Internet Archive",
     "ideasUrl": "https://docs.google.com/document/d/1EjzrHVapOZuzdI_Qqd_ravaTgiDWnxlMRbjjbzfd_-I/edit?tab=t.0",
     "channels": [
-        {
-            "type": "Slack",
-            "url": "https://internetarchive.slack.com"
-        }
+      {
+        "type": "Slack",
+        "url": "https://internetarchive.slack.com"
+      }
     ],
     "mentors": [
-        { "name": "Mark Graham", "github": "", "githubUrl": "" },
-        { "name": "Sawood Alam", "github": "ibnesayeed", "githubUrl": "https://github.com/ibnesayeed" },
-        { "name": "Will Howes", "github": "", "githubUrl": "" },
-        { "name": "Mek Karpeles", "github": "mekarpeles", "githubUrl": "https://github.com/mekarpeles" },
-        { "name": "Drini Cami", "github": "", "githubUrl": "" }
+      {
+        "name": "Mark Graham",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Sawood Alam",
+        "github": "ibnesayeed",
+        "githubUrl": "https://github.com/ibnesayeed"
+      },
+      {
+        "name": "Will Howes",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Mek Karpeles",
+        "github": "mekarpeles",
+        "githubUrl": "https://github.com/mekarpeles"
+      },
+      {
+        "name": "Drini Cami",
+        "github": "",
+        "githubUrl": ""
+      }
     ],
     "mailingLists": [],
     "tip": "Mentors collaborate via Slack. Use the interest form on the ideas page to connect with them before submitting your proposal.",
@@ -1796,7 +1901,7 @@
       }
     ],
     "mentors": [
-       {
+      {
         "name": "Paulo Henrique Junqueira Amorim",
         "github": "paulojamorim",
         "githubUrl": "https://github.com/paulojamorim"
@@ -1988,19 +2093,19 @@
     ],
     "mentors": [
       {
-        "name":"Benoît BERAUD",
-        "github":"benoit74",
-        "githubUrl":"https://github.com/benoit74"
+        "name": "Benoît BERAUD",
+        "github": "benoit74",
+        "githubUrl": "https://github.com/benoit74"
       },
       {
-        "name":"Travis Briggs",
-        "github":"audiodude",
-        "githubUrl":"https://github.com/audiodude"
+        "name": "Travis Briggs",
+        "github": "audiodude",
+        "githubUrl": "https://github.com/audiodude"
       },
       {
-        "name":"Mohit Mali",
-        "github":"MohitMaliDeveloper",
-        "githubUrl":"https://github.com/MohitMaliDeveloper/"
+        "name": "Mohit Mali",
+        "github": "MohitMaliDeveloper",
+        "githubUrl": "https://github.com/MohitMaliDeveloper/"
       }
     ],
     "mailingLists": [],
@@ -2110,34 +2215,54 @@
     "status": "no-contact-found",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
-"LibreCube Initiative": {
-  "org": "LibreCube Initiative",
-  "ideasUrl": "https://librecube.org/google-summer-of-code/",
-  "channels": [
-    {
-      "type": "Matrix",
-      "url": "https://matrix.to/#/#librecube.org:matrix.org",
-      "label": "LibreCube Matrix Room"
-    }
-  ],
-  "mentors": [
-    { "name": "Artur Scholz", "github": "", "githubUrl": "" },
-    { "name": "Peter Mader", "github": "", "githubUrl": "" },
-    { "name": "Sai", "github": "", "githubUrl": "" },
-    { "name": "Tamara Hinderman", "github": "", "githubUrl": "" },
-    { "name": "Shayan Majumder", "github": "", "githubUrl": "" }
-  ],
-  "mailingLists": [
-    {
-      "type": "Mailing list",
-      "url": "mailto:gsoc@librecube.org",
-      "label": "gsoc@librecube.org"
-    }
-  ],
-  "tip": "Please email directly to the mentors (with gsoc@librecube.org in copy), with a short text about yourself (your skills and interests) and what of the project(s) you find interesting to work on.",
-  "status": "ok",
-  "lastFetched": "2026-05-09T16:09:12.548Z"
-},
+  "LibreCube Initiative": {
+    "org": "LibreCube Initiative",
+    "ideasUrl": "https://librecube.org/google-summer-of-code/",
+    "channels": [
+      {
+        "type": "Matrix",
+        "url": "https://matrix.to/#/#librecube.org:matrix.org",
+        "label": "LibreCube Matrix Room"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Artur Scholz",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Peter Mader",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Sai",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Tamara Hinderman",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Shayan Majumder",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Mailing list",
+        "url": "mailto:gsoc@librecube.org",
+        "label": "gsoc@librecube.org"
+      }
+    ],
+    "tip": "Please email directly to the mentors (with gsoc@librecube.org in copy), with a short text about yourself (your skills and interests) and what of the project(s) you find interesting to work on.",
+    "status": "ok",
+    "lastFetched": "2026-05-09T16:09:12.548Z"
+  },
   "LibreHealth": {
     "org": "LibreHealth",
     "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/librehealth",
@@ -2192,48 +2317,48 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "libssh": {
-  "org": "libssh",
-  "ideasUrl": "https://www.libssh.org/development/google-summer-of-code/",
-  "channels": [
-    {
-      "type": "Matrix",
-      "url": "https://matrix.to/#/#libssh:matrix.org",
-      "label": "libssh Matrix"
-    }
-  ],
-  "mentors": [
-    {
-      "name": "Jakub Jelen",
-      "github": "jakuje",
-      "githubUrl": "https://github.com/jakuje"
-    },
-    {
-      "name": "Sahana Prasad",
-      "github": "saprasad",
-      "githubUrl": "https://github.com/saprasad"
-    },
-    {
-      "name": "Eshan Kelkar",
-      "github": "galorithm",
-      "githubUrl": "https://github.com/galorithm"
-    },
-    {
-      "name": "Andreas Schneider",
-      "github": "asn",
-      "githubUrl": "https://github.com/asn"
-    }
-  ],
-  "mailingLists": [
-    {
-      "type": "Mailing list",
-      "url": "https://www.libssh.org/communication/",
-      "label": "libssh Communication"
-    }
-  ],
-  "tip": "Join the libssh mailing list and interact before applying. A non-trivial merge request on GitLab is required before proposals are considered.",
-  "status": "ok",
-  "lastFetched": "2026-05-09T16:09:12.548Z"
-},
+    "org": "libssh",
+    "ideasUrl": "https://www.libssh.org/development/google-summer-of-code/",
+    "channels": [
+      {
+        "type": "Matrix",
+        "url": "https://matrix.to/#/#libssh:matrix.org",
+        "label": "libssh Matrix"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Jakub Jelen",
+        "github": "jakuje",
+        "githubUrl": "https://github.com/jakuje"
+      },
+      {
+        "name": "Sahana Prasad",
+        "github": "saprasad",
+        "githubUrl": "https://github.com/saprasad"
+      },
+      {
+        "name": "Eshan Kelkar",
+        "github": "galorithm",
+        "githubUrl": "https://github.com/galorithm"
+      },
+      {
+        "name": "Andreas Schneider",
+        "github": "asn",
+        "githubUrl": "https://github.com/asn"
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Mailing list",
+        "url": "https://www.libssh.org/communication/",
+        "label": "libssh Communication"
+      }
+    ],
+    "tip": "Join the libssh mailing list and interact before applying. A non-trivial merge request on GitLab is required before proposals are considered.",
+    "status": "ok",
+    "lastFetched": "2026-05-09T16:09:12.548Z"
+  },
   "Liquid Galaxy project": {
     "org": "Liquid Galaxy project",
     "ideasUrl": "https://github.com/LiquidGalaxyLAB/liquid-galaxy/wiki/Google-Summer-of-Code-2026",
@@ -2282,7 +2407,7 @@
       }
     ],
     "mailingLists": [],
-    "tip" : "To contribute to the Project take a look at its Contribution Guide",
+    "tip": "To contribute to the Project take a look at its Contribution Guide",
     "status": "ok",
     "lastFetched": "2026-05-29T13:10:00.000Z"
   },
@@ -2691,11 +2816,11 @@
         "url": "https://slack.openfoodfacts.org/",
         "label": "#off-explorer"
       }
-  ],
+    ],
     "mentors": [
       {
-        "name" : "VaiTon",
-        "github" : "VaiTon",
+        "name": "VaiTon",
+        "github": "VaiTon",
         "githubUrl": "https://github.com/VaiTon"
       }
     ],
@@ -3090,7 +3215,7 @@
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
-"OSGeo (Open Source Geospatial Foundation)": {
+  "OSGeo (Open Source Geospatial Foundation)": {
     "org": "OSGeo (Open Source Geospatial Foundation)",
     "ideasUrl": "https://wiki.osgeo.org/wiki/Google_Summer_of_Code_2026_Ideas",
     "channels": [
@@ -3247,43 +3372,43 @@
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
-"Processing Foundation": {
-  "org": "Processing Foundation",
-  "ideasUrl": "https://github.com/processing/Processing-Foundation-GSoC/wiki/Project-Ideas-List-(GSoC-2026)#project-ideas-list",
-"channels": [
-    {
+  "Processing Foundation": {
+    "org": "Processing Foundation",
+    "ideasUrl": "https://github.com/processing/Processing-Foundation-GSoC/wiki/Project-Ideas-List-(GSoC-2026)#project-ideas-list",
+    "channels": [
+      {
         "type": "Discourse Forum",
         "url": "https://discourse.processing.org/",
         "label": "Discourse Forum"
-    }
-],
-  "mentors": [
-    {
-      "name": "Divyansh013",
-      "github": "Divyansh013",
-      "githubUrl": "https://github.com/Divyansh013"
-    },
-    {
-      "name": "Claire Peng",
-      "github": "clairep94",
-      "githubUrl": "https://github.com/clairep94"
-    },
-    {
-      "name": "Diya Solanki",
-      "github": "diyaayay",
-      "githubUrl": "https://github.com/diyaayay"
-    }
-  ],
- "mailingLists": [
-    {
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Divyansh013",
+        "github": "Divyansh013",
+        "githubUrl": "https://github.com/Divyansh013"
+      },
+      {
+        "name": "Claire Peng",
+        "github": "clairep94",
+        "githubUrl": "https://github.com/clairep94"
+      },
+      {
+        "name": "Diya Solanki",
+        "github": "diyaayay",
+        "githubUrl": "https://github.com/diyaayay"
+      }
+    ],
+    "mailingLists": [
+      {
         "type": "Mailing list",
         "url": "mailto:foundation@processingfoundation.org",
         "label": "Foundation mailing list"
-    }
-],
-  "tip": "",
-  "status": "ok",
-  "lastFetched": "2026-05-22T04:12:12.000Z"
+      }
+    ],
+    "tip": "",
+    "status": "ok",
+    "lastFetched": "2026-05-22T04:12:12.000Z"
   },
   "Project Mesa": {
     "org": "Project Mesa",
@@ -3416,18 +3541,18 @@
   "Ruby": {
     "org": "Ruby",
     "ideasUrl": "https://github.com/rubygsoc/rubygsoc/wiki/Ideas-List-(2026)",
-      "channels": [
-    {
-      "type": "Slack",
-      "label": "#rubygsoc",
-      "url": "https://bundler.slack.com"
-    },
-    {
-      "type": "Discord",
-      "label": "Ruby GSoC Discord",
-      "url": "https://discord.gg/7ESQJSjr"
-    }
-  ],
+    "channels": [
+      {
+        "type": "Slack",
+        "label": "#rubygsoc",
+        "url": "https://bundler.slack.com"
+      },
+      {
+        "type": "Discord",
+        "label": "Ruby GSoC Discord",
+        "url": "https://discord.gg/7ESQJSjr"
+      }
+    ],
     "mentors": [
       {
         "name": "Colby Swandale",
@@ -3471,59 +3596,59 @@
       }
     ],
     "mailingLists": [
-    {
-      "type": "Mailing list",
-      "url": "https://groups.google.com/g/rubygsoc",
-      "label": "rubygsoc"
-    }
-  ],
+      {
+        "type": "Mailing list",
+        "url": "https://groups.google.com/g/rubygsoc",
+        "label": "rubygsoc"
+      }
+    ],
     "tip": "Blog: https://rubygsoc.github.io/ | For direct contact, email Saroj at saroj@zoras.me",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
-"SageMath": {
-  "org": "SageMath",
-  "ideasUrl": "https://wiki.sagemath.org/GSoC/2026",
-  "channels": [
-    {
-      "type": "Zulip",
-      "label": "SageMath Zulip",
-      "url": "https://sagemath.zulipchat.com/"
-    }
-  ],
-  "mentors": [
-    {
-      "name": "Travis Scrimshaw",
-      "github": "tscrim",
-      "githubUrl": "https://github.com/tscrim"
-    },
-    {
-      "name": "Martin Rubey",
-      "github": "mantepse",
-      "githubUrl": "https://github.com/mantepse"
-    },
-    {
-      "name": "David Coudert",
-      "github": "dcoudert",
-      "githubUrl": "https://github.com/dcoudert"
-    },
-    {
-      "name": "Rocky Bernstein",
-      "github": "rocky",
-      "githubUrl": "https://github.com/rocky"
-    }
-  ],
-  "mailingLists": [
-    {
-      "type": "Mailing list",
-      "url": "https://groups.google.com/g/sage-gsoc",
-      "label": "sage-gsoc"
-    }
-  ],
-  "tip": "Send a short introduction with your background and the project idea you're interested in.",
-  "status": "ok",
-  "lastFetched": "2026-05-09T16:09:12.548Z"
-},
+  "SageMath": {
+    "org": "SageMath",
+    "ideasUrl": "https://wiki.sagemath.org/GSoC/2026",
+    "channels": [
+      {
+        "type": "Zulip",
+        "label": "SageMath Zulip",
+        "url": "https://sagemath.zulipchat.com/"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Travis Scrimshaw",
+        "github": "tscrim",
+        "githubUrl": "https://github.com/tscrim"
+      },
+      {
+        "name": "Martin Rubey",
+        "github": "mantepse",
+        "githubUrl": "https://github.com/mantepse"
+      },
+      {
+        "name": "David Coudert",
+        "github": "dcoudert",
+        "githubUrl": "https://github.com/dcoudert"
+      },
+      {
+        "name": "Rocky Bernstein",
+        "github": "rocky",
+        "githubUrl": "https://github.com/rocky"
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Mailing list",
+        "url": "https://groups.google.com/g/sage-gsoc",
+        "label": "sage-gsoc"
+      }
+    ],
+    "tip": "Send a short introduction with your background and the project idea you're interested in.",
+    "status": "ok",
+    "lastFetched": "2026-05-09T16:09:12.548Z"
+  },
   "ScummVM": {
     "org": "ScummVM",
     "ideasUrl": "https://github.com/scummvm/scummvm/wiki/GSoC-Ideas-2026",
@@ -3561,37 +3686,73 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Ste||ar group": {
-  "org": "Ste||ar group",
-  "ideasUrl": "https://github.com/STEllAR-GROUP/hpx/wiki/GSoC-Submission-Template",
-  "channels": [
-    {
-      "type": "Discord",
-      "url": "https://discord.com/invite/Tn9QuzVjvy",
-      "label": "#ste||ar Discord"
-    },
-    {
-      "type": "Slack",
-      "url": "",
-      "label": "#hpx Slack"
-    }
-  ],
-  "mentors": [
-    { "name": "Hartmut Kaiser", "github": "hkaiser", "githubUrl": "https://github.com/hkaiser" },
-    { "name": "strackar", "github": "strackar", "githubUrl": "https://github.com/strackar" },
-    { "name": "Isidoros", "github": "isidoros", "githubUrl": "https://github.com/isidoros" },
-    { "name": "Shreyas", "github": "shreyas-kowshik", "githubUrl": "https://github.com/shreyas-kowshik" },
-    { "name": "Panos Syskakis", "github": "pansysk75", "githubUrl": "https://github.com/pansysk75" },
-    { "name": "Karame Mohammadiporshokooh", "github": "", "githubUrl": "" }
-  ],
-  "mailingLists": [
-    { "type": "Mailing list", "url": "mailto:fellows@stellar-group.org", "label": "fellows@stellar-group.org" },
-    { "type": "Mailing list", "url": "mailto:hpx-users@stellar-group.org", "label": "hpx-users@stellar-group.org" },
-    { "type": "Mailing list", "url": "mailto:hpx-devel@stellar-group.org", "label": "hpx-devel@stellar-group.org" }
-  ],
-  "tip": "Join the Discord server and introduce yourself before asking project-specific questions.",
-  "status": "ok",
-  "lastFetched": "2026-05-09T16:09:12.548Z"
-},
+    "org": "Ste||ar group",
+    "ideasUrl": "https://github.com/STEllAR-GROUP/hpx/wiki/GSoC-Submission-Template",
+    "channels": [
+      {
+        "type": "Discord",
+        "url": "https://discord.com/invite/Tn9QuzVjvy",
+        "label": "#ste||ar Discord"
+      },
+      {
+        "type": "Slack",
+        "url": "",
+        "label": "#hpx Slack"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Hartmut Kaiser",
+        "github": "hkaiser",
+        "githubUrl": "https://github.com/hkaiser"
+      },
+      {
+        "name": "strackar",
+        "github": "strackar",
+        "githubUrl": "https://github.com/strackar"
+      },
+      {
+        "name": "Isidoros",
+        "github": "isidoros",
+        "githubUrl": "https://github.com/isidoros"
+      },
+      {
+        "name": "Shreyas",
+        "github": "shreyas-kowshik",
+        "githubUrl": "https://github.com/shreyas-kowshik"
+      },
+      {
+        "name": "Panos Syskakis",
+        "github": "pansysk75",
+        "githubUrl": "https://github.com/pansysk75"
+      },
+      {
+        "name": "Karame Mohammadiporshokooh",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Mailing list",
+        "url": "mailto:fellows@stellar-group.org",
+        "label": "fellows@stellar-group.org"
+      },
+      {
+        "type": "Mailing list",
+        "url": "mailto:hpx-users@stellar-group.org",
+        "label": "hpx-users@stellar-group.org"
+      },
+      {
+        "type": "Mailing list",
+        "url": "mailto:hpx-devel@stellar-group.org",
+        "label": "hpx-devel@stellar-group.org"
+      }
+    ],
+    "tip": "Join the Discord server and introduce yourself before asking project-specific questions.",
+    "status": "ok",
+    "lastFetched": "2026-05-09T16:09:12.548Z"
+  },
   "Stichting SU2": {
     "org": "Stichting SU2",
     "ideasUrl": "https://su2code.github.io/gsoc.html",
@@ -3602,58 +3763,58 @@
     "status": "fetch-failed",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
-"Submitty": {
-  "org": "Submitty",
-  "ideasUrl": "https://github.com/Submitty/Submitty/wiki/Google-Summer-of-Code",
-  "channels": [
-  {
-    "type": "Zulip",
-    "url": "https://submitty.zulipchat.com/",
-    "label": "Submitty Zulip"
-  }
-],
-  "mentors": [
-  {
-    "name": "JManion32",
-    "github": "JManion32",
-    "githubUrl": "https://github.com/JManion32"
+  "Submitty": {
+    "org": "Submitty",
+    "ideasUrl": "https://github.com/Submitty/Submitty/wiki/Google-Summer-of-Code",
+    "channels": [
+      {
+        "type": "Zulip",
+        "url": "https://submitty.zulipchat.com/",
+        "label": "Submitty Zulip"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "JManion32",
+        "github": "JManion32",
+        "githubUrl": "https://github.com/JManion32"
+      },
+      {
+        "name": "williamjallen",
+        "github": "williamjallen",
+        "githubUrl": "https://github.com/williamjallen"
+      },
+      {
+        "name": "cjreed121",
+        "github": "cjreed121",
+        "githubUrl": "https://github.com/cjreed121"
+      },
+      {
+        "name": "bmcutler",
+        "github": "bmcutler",
+        "githubUrl": "https://github.com/bmcutler"
+      },
+      {
+        "name": "IDzyre",
+        "github": "IDzyre",
+        "githubUrl": "https://github.com/IDzyre"
+      },
+      {
+        "name": "shailpatels",
+        "github": "shailpatels",
+        "githubUrl": "https://github.com/shailpatels"
+      },
+      {
+        "name": "MasterOdin",
+        "github": "MasterOdin",
+        "githubUrl": "https://github.com/MasterOdin"
+      }
+    ],
+    "mailingLists": [],
+    "tip": "Join the Submitty Zulip server to communicate with mentors and contributors.",
+    "status": "ok",
+    "lastFetched": "2026-05-21T11:30:00.000Z"
   },
-  {
-    "name": "williamjallen",
-    "github": "williamjallen",
-    "githubUrl": "https://github.com/williamjallen"
-  },
-  {
-    "name": "cjreed121",
-    "github": "cjreed121",
-    "githubUrl": "https://github.com/cjreed121"
-  },
-  {
-    "name": "bmcutler",
-    "github": "bmcutler",
-    "githubUrl": "https://github.com/bmcutler"
-  },
-  {
-    "name": "IDzyre",
-    "github": "IDzyre",
-    "githubUrl": "https://github.com/IDzyre"
-  },
-  {
-    "name": "shailpatels",
-    "github": "shailpatels",
-    "githubUrl": "https://github.com/shailpatels"
-  },
-  {
-    "name": "MasterOdin",
-    "github": "MasterOdin",
-    "githubUrl": "https://github.com/MasterOdin"
-  }
-],
-  "mailingLists": [],
-  "tip": "Join the Submitty Zulip server to communicate with mentors and contributors.",
-  "status": "ok",
- "lastFetched": "2026-05-21T11:30:00.000Z"
-},
   "Sugar Labs": {
     "org": "Sugar Labs",
     "ideasUrl": "https://github.com/sugarlabs/GSoC/blob/master/Ideas-2026.md",
@@ -3768,28 +3929,28 @@
       }
     ],
     "mentors": [
-        {
-          "name": "Gaurav Mishra",
-          "github": "GMishx",
-          "githubUrl": "https://github.com/GMishx"
-        },
-        {
-          "name": "Amrit Kumar Verma",
-          "github": "amritkv",
-          "githubUrl": "https://github.com/amritkv"
-        },
-        {
-          "name": "Farooq Fateh Aftab",
-          "github": "Farooq-Fateh-Aftab",
-          "githubUrl": "https://github.com/Farooq-Fateh-Aftab"
-        }
+      {
+        "name": "Gaurav Mishra",
+        "github": "GMishx",
+        "githubUrl": "https://github.com/GMishx"
+      },
+      {
+        "name": "Amrit Kumar Verma",
+        "github": "amritkv",
+        "githubUrl": "https://github.com/amritkv"
+      },
+      {
+        "name": "Farooq Fateh Aftab",
+        "github": "Farooq-Fateh-Aftab",
+        "githubUrl": "https://github.com/Farooq-Fateh-Aftab"
+      }
     ],
     "mailingLists": [
-        {
-          "type": "mailing-list",
-          "url": "mailto:sw360-dev@eclipse.org",
-          "label": "SW360 Developer Mailing List"
-        }
+      {
+        "type": "mailing-list",
+        "url": "mailto:sw360-dev@eclipse.org",
+        "label": "SW360 Developer Mailing List"
+      }
     ],
     "tip": "Join and say hi in the GSoC channel before DMing mentors.",
     "status": "ok",
@@ -3927,21 +4088,21 @@
       }
     ],
     "mentors": [
-          {
-            "name": "Mahmoud Khawaja",
-            "github": "Mahmoud-Khawaja",
-            "githubUrl": "https://github.com/Mahmoud-Khawaja"
-          },
-          {
-            "name": "Franck van Breugel",
-            "github": "franck-van-breugel",
-            "githubUrl": "https://github.com/franck-van-breugel"
-          },
-          {
-            "name": "Cyrille Artho",
-            "github": "cyrille-artho",
-            "githubUrl": "https://github.com/cyrille-artho"
-          }
+      {
+        "name": "Mahmoud Khawaja",
+        "github": "Mahmoud-Khawaja",
+        "githubUrl": "https://github.com/Mahmoud-Khawaja"
+      },
+      {
+        "name": "Franck van Breugel",
+        "github": "franck-van-breugel",
+        "githubUrl": "https://github.com/franck-van-breugel"
+      },
+      {
+        "name": "Cyrille Artho",
+        "github": "cyrille-artho",
+        "githubUrl": "https://github.com/cyrille-artho"
+      }
     ],
     "mailingLists": [
       {
@@ -3956,12 +4117,105 @@
   },
   "The Julia Language": {
     "org": "The Julia Language",
-    "ideasUrl": "https://julialang.org/jsoc/gsoc/projects/",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "fetch-failed",
+    "ideasUrl": "https://julialang.org/jsoc/allprojects/",
+    "channels": [
+      {
+        "type": "Slack",
+        "url": "https://julialang.org/slack/",
+        "label": "JuliaLang Slack (#jsoc channel)"
+      },
+      {
+        "type": "Zulip",
+        "url": "https://julialang.zulipchat.com",
+        "label": "Julia Zulip"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Gabriele Bozzola",
+        "github": "sbozzolo",
+        "githubUrl": "https://github.com/sbozzolo"
+      },
+      {
+        "name": "Morten Piibeleht",
+        "github": "mortenpi",
+        "githubUrl": "https://github.com/mortenpi"
+      },
+      {
+        "name": "Fredrik Ekre",
+        "github": "fredrikekre",
+        "githubUrl": "https://github.com/fredrikekre"
+      },
+      {
+        "name": "Dennis Ogiermann",
+        "github": "termi-official",
+        "githubUrl": "https://github.com/termi-official"
+      },
+      {
+        "name": "Carlo Lucibello",
+        "github": "CarloLucibello",
+        "githubUrl": "https://github.com/CarloLucibello"
+      },
+      {
+        "name": "Tim Besard",
+        "github": "maleadt",
+        "githubUrl": "https://github.com/maleadt"
+      },
+      {
+        "name": "Valentin Churavy",
+        "github": "vchuravy",
+        "githubUrl": "https://github.com/vchuravy"
+      },
+      {
+        "name": "Julian Samaroo",
+        "github": "jpsamaroo",
+        "githubUrl": "https://github.com/jpsamaroo"
+      },
+      {
+        "name": "George Datseris",
+        "github": "Datseris",
+        "githubUrl": "https://github.com/Datseris"
+      },
+      {
+        "name": "Stefan Krastanov",
+        "github": "Krastanov",
+        "githubUrl": "https://github.com/Krastanov"
+      },
+      {
+        "name": "Joe Greener",
+        "github": "jgreener64",
+        "githubUrl": "https://github.com/jgreener64"
+      },
+      {
+        "name": "Dhairya Gandhi",
+        "github": "DhairyaLGandhi",
+        "githubUrl": "https://github.com/DhairyaLGandhi"
+      },
+      {
+        "name": "Marcelo Forets",
+        "github": "mforets",
+        "githubUrl": "https://github.com/mforets"
+      },
+      {
+        "name": "Christian Schilling",
+        "github": "schillic",
+        "githubUrl": "https://github.com/schillic"
+      },
+      {
+        "name": "Shuhei Kadowaki",
+        "github": "aviatesk",
+        "githubUrl": "https://github.com/aviatesk"
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Email",
+        "url": "mailto:jsoc@julialang.org",
+        "label": "JSoC Admin Email (jsoc@julialang.org)"
+      }
+    ],
+    "tip": "Join the JuliaLang Slack and introduce yourself in the #jsoc channel. You can also post on Julia Zulip.",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "The Libreswan Project": {
@@ -3969,16 +4223,28 @@
     "ideasUrl": "https://github.com/libreswan/libreswan/wiki/GSoC-2026-Code-Project-Ideas",
     "channels": [
       {
-       "type": "IRC",
-       "url": "https://web.libera.chat/#libreswan",
-        "label": "#libreswan on Libera.Chat" 
+        "type": "IRC",
+        "url": "https://web.libera.chat/#libreswan",
+        "label": "#libreswan on Libera.Chat"
       }
     ],
     "mentors": [
-      { "name": "Andrew Cagney", "github": "cagney", "githubUrl": "https://github.com/cagney" },
-      { "name": "Paul Wouters", "github": "letoams", "githubUrl": "https://github.com/letoams" },
-      { "name": "Tuomo Soini", "github": "", "githubUrl": "" }
-],
+      {
+        "name": "Andrew Cagney",
+        "github": "cagney",
+        "githubUrl": "https://github.com/cagney"
+      },
+      {
+        "name": "Paul Wouters",
+        "github": "letoams",
+        "githubUrl": "https://github.com/letoams"
+      },
+      {
+        "name": "Tuomo Soini",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
     "mailingLists": [
       {
         "type": "Mailing list",
@@ -4157,11 +4423,12 @@
     "org": "The NetBSD Foundation",
     "ideasUrl": "https://wiki.netbsd.org/projects/gsoc/",
     "channels": [
-      {"type": "IRC",
+      {
+        "type": "IRC",
         "url": "https://web.libera.chat/#NetBSD-code",
         "label": "NetBSD Foundation IRC Channel on Libera Chat"
       }
-      ],
+    ],
     "mentors": [
       {
         "name": "zoulasc",
@@ -4470,38 +4737,38 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "UC OSPO": {
-  "org": "UC OSPO",
-  "ideasUrl": "https://ucsc-ospo.github.io/osre26/",
-  "channels": [
-    {
-      "type": "Slack",
-      "url": "https://join.slack.com/t/uc-ospo-network/shared_invite/zt-3c6yw4l11-WU2PB4jUwAtXTDK09h8orQ",
-      "label": "UC OSPO Network Slack"
-    }
-  ],
-  "mentors": [
-    {
-      "name": "Carlos Maltzahn",
-      "github": "carlosmaltzahn",
-      "githubUrl": "https://github.com/carlosmaltzahn"
-    },
-    {
-      "name": "Stephanie Lieggi",
-      "github": "slieggi",
-      "githubUrl": "https://github.com/slieggi"
-    }
-  ],
-  "mailingLists": [
-    {
-      "type": "Email",
-      "url": "mailto:ospo-info-group@ucsc.edu",
-      "label": "ospo-info-group@ucsc.edu"
-    }
-  ],
-  "tip": "Join the UC OSPO Network Slack and email ospo-info-group@ucsc.edu for any eligibility questions.",
-  "status": "ok",
-  "lastFetched": "2026-05-28T00:00:00.000Z"
-},
+    "org": "UC OSPO",
+    "ideasUrl": "https://ucsc-ospo.github.io/osre26/",
+    "channels": [
+      {
+        "type": "Slack",
+        "url": "https://join.slack.com/t/uc-ospo-network/shared_invite/zt-3c6yw4l11-WU2PB4jUwAtXTDK09h8orQ",
+        "label": "UC OSPO Network Slack"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Carlos Maltzahn",
+        "github": "carlosmaltzahn",
+        "githubUrl": "https://github.com/carlosmaltzahn"
+      },
+      {
+        "name": "Stephanie Lieggi",
+        "github": "slieggi",
+        "githubUrl": "https://github.com/slieggi"
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Email",
+        "url": "mailto:ospo-info-group@ucsc.edu",
+        "label": "ospo-info-group@ucsc.edu"
+      }
+    ],
+    "tip": "Join the UC OSPO Network Slack and email ospo-info-group@ucsc.edu for any eligibility questions.",
+    "status": "ok",
+    "lastFetched": "2026-05-28T00:00:00.000Z"
+  },
   "Unikraft": {
     "org": "Unikraft",
     "ideasUrl": "https://github.com/unikraft/gsoc/blob/staging/gsoc-2026/ideas.md",
@@ -4563,17 +4830,17 @@
     "org": "United Nations Office of Information Communication Technology",
     "ideasUrl": "https://github.com/un-oict",
     "channels": [
-   {
-    "type": "Email",
-    "url": "mailto:mithusa.kajendran@un.org",
-    "label": "UN OICT GSoC Admin"
-  },
-  {
-    "type": "Email",
-    "url": "mailto:mdowney@humanitech.group",
-    "label": "Michael Downey - OICT Admin"
-  }
-],
+      {
+        "type": "Email",
+        "url": "mailto:mithusa.kajendran@un.org",
+        "label": "UN OICT GSoC Admin"
+      },
+      {
+        "type": "Email",
+        "url": "mailto:mdowney@humanitech.group",
+        "label": "Michael Downey - OICT Admin"
+      }
+    ],
     "mentors": [
       {
         "name": "Vincent Harkins",
@@ -4596,7 +4863,6 @@
         "githubUrl": ""
       }
     ],
-    
     "tip": "Contact mentors directly via email or reach org admins at mithusa.kajendran@un.org for general GSoC questions.",
     "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
@@ -4891,30 +5157,30 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Zulip": {
-  "org": "Zulip",
-  "ideasUrl": "https://zulip.readthedocs.io/en/latest/outreach/gsoc.html",
-  "channels": [
-    {
-      "type": "Zulip",
-      "url": "https://chat.zulip.org/",
-      "label": "Zulip contributor chat"
-    }
-  ],
-  "mentors": [
-    {
-      "name": "Tim Abbott",
-      "github": "timabbott",
-      "githubUrl": "https://github.com/timabbott"
-    },
-    {
-      "name": "Anders Kaseorg",
-      "github": "andersk",
-      "githubUrl": "https://github.com/andersk"
-    }
-  ],
-  "mailingLists": [],
-  "tip": "Join the Zulip contributor chat and introduce yourself before discussing project ideas.",
-  "status": "ok",
-  "lastFetched": "2026-05-27T20:20:00.000Z"
-}
+    "org": "Zulip",
+    "ideasUrl": "https://zulip.readthedocs.io/en/latest/outreach/gsoc.html",
+    "channels": [
+      {
+        "type": "Zulip",
+        "url": "https://chat.zulip.org/",
+        "label": "Zulip contributor chat"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Tim Abbott",
+        "github": "timabbott",
+        "githubUrl": "https://github.com/timabbott"
+      },
+      {
+        "name": "Anders Kaseorg",
+        "github": "andersk",
+        "githubUrl": "https://github.com/andersk"
+      }
+    ],
+    "mailingLists": [],
+    "tip": "Join the Zulip contributor chat and introduce yourself before discussing project ideas.",
+    "status": "ok",
+    "lastFetched": "2026-05-27T20:20:00.000Z"
+  }
 }


### PR DESCRIPTION
Fixes #416

## Changes Made
- Updated `ideasUrl` from broken URL (`/jsoc/gsoc/projects/`) to correct working URL (`/jsoc/allprojects/`)
- Added Slack (#jsoc channel) and Zulip communication channels
- Added 15 verified mentor GitHub handles from the official ideas page
- Added JSoC admin email (jsoc@julialang.org)
- Set status to `ok`

## Research Notes
- The ideas page URL mentioned in the issue (`https://julialang.org/jsoc/gsoc/projects/`) returns a **404 error**
- The correct and working ideas page is `https://julialang.org/jsoc/allprojects/` ✅
- All mentor handles were verified directly from the live ideas page
- Communication channels confirmed from https://julialang.org/jsoc/