### PR TITLE
feat: add personal application tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -3673,7 +3673,9 @@ btn.__orgListenerAttached = true;
       column.addEventListener('drop', (e) => {
         e.preventDefault();
         column.classList.remove('drag-over');
-        if (trackerDragName) setTrackerStatus(trackerDragName, stage.key);
+        const draggedName = e.dataTransfer?.getData('text/plain') || trackerDragName;
+        if (draggedName) setTrackerStatus(draggedName, stage.key);
+        trackerDragName = null;
       });
 
       board.appendChild(column);
@@ -3682,7 +3684,14 @@ btn.__orgListenerAttached = true;
     // ── Wire per-card controls ────────────────────────────────────────────────
     board.querySelectorAll('.tracker-card').forEach(card => {
       const name = card.dataset.trackerOrg;
-      card.addEventListener('dragstart', () => { trackerDragName = name; card.classList.add('dragging'); });
+      card.addEventListener('dragstart', (e) => {
+        trackerDragName = name;
+        card.classList.add('dragging');
+        if (e.dataTransfer) {
+          e.dataTransfer.effectAllowed = 'move';
+          e.dataTransfer.setData('text/plain', name);
+        }
+      });
       card.addEventListener('dragend',   () => { trackerDragName = null; card.classList.remove('dragging'); });
     });
     board.querySelectorAll('[data-tracker-status]').forEach(sel => {

--- a/index.html
+++ b/index.html
@@ -388,9 +388,18 @@
     html { width: 100%; scroll-behavior: smooth; }
     
     /* Scroll offset for fixed header */
-    #timeline, #orgs, #guide, #watchlist, #issues, #mentors, #ai-recommender, #contact {
+    #timeline, #orgs, #guide, #watchlist, #tracker, #issues, #mentors, #ai-recommender, #contact {
       scroll-margin-top: 80px;
     }
+
+    /* Application Tracker (Kanban board) */
+    .tracker-column.drag-over {
+      border-color: #f97316;
+      background: rgba(249, 115, 22, 0.06);
+    }
+    .tracker-card.dragging { opacity: 0.4; }
+    .tracker-card[draggable="true"] { cursor: grab; }
+    .tracker-card[draggable="true"]:active { cursor: grabbing; }
 
     .desktop-nav-link {
       position: relative;
@@ -885,6 +894,7 @@
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#timeline" data-section="timeline">Timeline</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#ai-recommender" data-section="ai-recommender">AI Recommender</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#watchlist" data-section="watchlist">Watchlist</a>
+        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#tracker" data-section="tracker">My Tracker</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#issues" data-section="issues">Issues</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#mentors" data-section="mentors">Mentors</a>
       </nav>
@@ -972,6 +982,10 @@
       <a href="#watchlist" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="watchlist">
         <span class="material-symbols-outlined text-lg">bookmark</span>
         Watchlist
+      </a>
+      <a href="#tracker" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="tracker">
+        <span class="material-symbols-outlined text-lg">view_kanban</span>
+        My Tracker
       </a>
       <a href="#issues" onclick="setActiveMenu(this)" class="mobile-menu-link flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-700 hover:bg-zinc-100 font-medium text-sm transition-colors" data-section="issues">
         <span class="material-symbols-outlined text-lg">bug_report</span>
@@ -1297,6 +1311,42 @@
         </div>
       </div>
     </div>
+  </div>
+</section>
+
+<!-- ═══════════════════ MY TRACKER (PERSONAL APPLICATION TRACKER) ═══════════════════ -->
+<section id="tracker" class="py-20 px-6">
+  <div class="max-w-7xl mx-auto">
+    <div class="mb-12 flex items-start justify-between gap-4 flex-wrap">
+      <div>
+        <span class="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary">Application Progress</span>
+        <h2 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mt-2">My Tracker.</h2>
+        <p class="text-zinc-600 mt-4 max-w-2xl">Save organizations and track your GSoC application from first interest to a submitted proposal. Drag a card between stages on desktop, or use the dropdown on any device. Everything stays in your browser.</p>
+      </div>
+      <button id="clearTrackerBtn"
+        class="hidden mt-8 flex-shrink-0 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-red-500 border border-red-200 rounded-full px-4 py-2 hover:bg-red-50 transition-colors"
+        title="Remove all tracked organizations">
+        <span class="material-symbols-outlined text-sm">delete_sweep</span>
+        Clear All
+      </button>
+    </div>
+
+    <!-- Empty state -->
+    <div id="trackerEmpty" class="hidden py-16 text-center border-2 border-dashed border-zinc-200 rounded-2xl">
+      <span class="material-symbols-outlined text-4xl text-zinc-300 mb-4 block">view_kanban</span>
+      <p class="font-bold text-zinc-500 mb-1">Your Tracker is Empty</p>
+      <p class="text-sm text-zinc-400 mb-6">Click "Track" on any organization card to start managing your application here.</p>
+      <button
+        onclick="document.getElementById('orgs').scrollIntoView({ behavior: 'smooth' })"
+        class="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-full text-sm font-bold hover:bg-orange-600 hover:scale-105 transition-all duration-200 shadow-md shadow-primary/20 focus:outline-none focus:ring-2 focus:ring-primary/40 focus:ring-offset-2"
+        aria-label="Browse Organizations - scroll to the organization directory">
+        <span class="material-symbols-outlined text-sm">travel_explore</span>
+        Browse Organizations
+      </button>
+    </div>
+
+    <!-- Kanban board (columns rendered by renderTracker) -->
+    <div id="trackerBoard" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6"></div>
   </div>
 </section>
 
@@ -2865,6 +2915,9 @@ function setDesktopNavState(activeSection) {
              <button data-compare-org="${escapeHtml(org.name)}" class="text-[10px] font-bold uppercase tracking-widest ${isComparing ? 'text-primary' : 'text-zinc-400'} hover:text-primary flex items-center gap-1">
                 <span class="material-symbols-outlined text-sm">${isComparing ? 'check_circle' : 'compare_arrows'}</span> ${isComparing ? 'Comparing' : 'Compare'}
              </button>
+             <button data-track-org="${escapeHtml(org.name)}" class="text-[10px] font-bold uppercase tracking-widest ${isTracked(org.name) ? 'text-primary' : 'text-zinc-400'} hover:text-primary flex items-center gap-1" title="${isTracked(org.name) ? 'In your tracker' : 'Add to your tracker'}">
+                <span class="material-symbols-outlined text-sm">${isTracked(org.name) ? 'playlist_add_check' : 'playlist_add'}</span> <span class="track-label">${isTracked(org.name) ? 'Tracking' : 'Track'}</span>
+             </button>
           </div>
            <button data-open-org="${org.name}" class="text-primary font-bold text-xs uppercase tracking-widest flex items-center gap-1 group-hover:gap-2 transition-all">View <span class="material-symbols-outlined text-sm">arrow_forward</span></button>
         </div>
@@ -2902,6 +2955,13 @@ function setDesktopNavState(activeSection) {
     (root.querySelectorAll ? root.querySelectorAll('[data-compare-org]') : []).forEach(btn => {
       if (btn.__orgListenerAttached) return;
       btn.addEventListener('click', (e) => toggleCompare(e, btn.dataset.compareOrg));
+      btn.__orgListenerAttached = true;
+    });
+
+    // tracker (Add to Tracker) buttons
+    (root.querySelectorAll ? root.querySelectorAll('[data-track-org]') : []).forEach(btn => {
+      if (btn.__orgListenerAttached) return;
+      btn.addEventListener('click', (e) => toggleTracker(e, btn.dataset.trackOrg));
       btn.__orgListenerAttached = true;
     });
 
@@ -3433,6 +3493,210 @@ btn.__orgListenerAttached = true;
           Based on ${bookmarks.length} saved org${bookmarks.length !== 1 ? 's' : ''} · Automated insight
         </p>
       </div>`;
+  }
+
+  // ── Personal Application Tracker ─────────────────────────────────────────────
+  // A lightweight Kanban board kept entirely separate from the Watchlist
+  // bookmarks. State persists to localStorage under 'appTracker' as a map of
+  // { orgName: stageKey } so it respects the project's no-database / no-sign-up rule.
+  const TRACKER_KEY = 'appTracker';
+  const TRACKER_STAGES = [
+    { key: 'interested',  label: 'Interested',                       icon: 'visibility' },
+    { key: 'researching', label: 'Researching / Talking to Mentors', icon: 'forum' },
+    { key: 'drafting',    label: 'Drafting Proposal',                icon: 'edit_document' },
+    { key: 'submitted',   label: 'Proposal Submitted',              icon: 'task_alt' },
+  ];
+  const TRACKER_STAGE_KEYS = new Set(TRACKER_STAGES.map(s => s.key));
+  const DEFAULT_TRACKER_STAGE = 'interested';
+  let trackerDragName = null;
+
+  function loadTracker() {
+    const map = new Map();
+    try {
+      const parsed = JSON.parse(localStorage.getItem(TRACKER_KEY) || '{}');
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const orgNames = new Set(ORGS.map(o => o.name));
+        Object.entries(parsed).forEach(([name, stage]) => {
+          if (orgNames.has(name) && TRACKER_STAGE_KEYS.has(stage)) map.set(name, stage);
+        });
+      }
+    } catch {
+      // localStorage unavailable or corrupt — start empty.
+    }
+    return map;
+  }
+
+  const trackerMap = loadTracker();
+
+  function saveTracker() {
+    try {
+      localStorage.setItem(TRACKER_KEY, JSON.stringify(Object.fromEntries(trackerMap)));
+    } catch (error) {
+      console.warn('Tracker persistence failed:', error);
+    }
+  }
+
+  function isTracked(name) {
+    return trackerMap.has(name);
+  }
+
+  // Keep the "Track" buttons on the visible org cards in sync with tracker state.
+  function refreshVisibleTrackButtons() {
+    document.querySelectorAll('#orgGrid [data-track-org]').forEach(btn => {
+      const tracked = isTracked(btn.dataset.trackOrg);
+      btn.classList.toggle('text-primary', tracked);
+      btn.classList.toggle('text-zinc-400', !tracked);
+      btn.title = tracked ? 'In your tracker' : 'Add to your tracker';
+      const icon = btn.querySelector('.material-symbols-outlined');
+      if (icon) icon.textContent = tracked ? 'playlist_add_check' : 'playlist_add';
+      const label = btn.querySelector('.track-label');
+      if (label) label.textContent = tracked ? 'Tracking' : 'Track';
+    });
+  }
+
+  function addToTracker(name) {
+    if (!name || isTracked(name) || !ORGS.some(o => o.name === name)) return;
+    trackerMap.set(name, DEFAULT_TRACKER_STAGE);
+    saveTracker();
+    refreshVisibleTrackButtons();
+    renderTracker();
+  }
+
+  function removeFromTracker(name) {
+    if (!trackerMap.has(name)) return;
+    trackerMap.delete(name);
+    saveTracker();
+    refreshVisibleTrackButtons();
+    renderTracker();
+  }
+
+  function setTrackerStatus(name, stage) {
+    if (!trackerMap.has(name) || !TRACKER_STAGE_KEYS.has(stage) || trackerMap.get(name) === stage) return;
+    trackerMap.set(name, stage);
+    saveTracker();
+    renderTracker();
+  }
+
+  function toggleTracker(e, name) {
+    if (e) e.stopPropagation();
+    if (isTracked(name)) removeFromTracker(name);
+    else addToTracker(name);
+  }
+
+  function clearTracker() {
+    if (!trackerMap.size) return;
+    if (!confirm(`Remove all ${trackerMap.size} tracked organization(s)? This cannot be undone.`)) return;
+    trackerMap.clear();
+    saveTracker();
+    refreshVisibleTrackButtons();
+    renderTracker();
+  }
+
+  function trackerCardHtml(org, stageKey) {
+    const githubOwner = githubOwnerFromValue(org.github);
+    const logoUrl     = githubOwner ? `https://github.com/${githubOwner}.png?size=80` : '';
+    const category    = getCategoryMeta(org.cat);
+    const options = TRACKER_STAGES.map(s =>
+      `<option value="${s.key}" ${s.key === stageKey ? 'selected' : ''}>${escapeHtml(s.label)}</option>`
+    ).join('');
+
+    return `
+      <div class="tracker-card bg-white rounded-xl p-3 border border-zinc-100 hover:shadow-md hover:border-primary/20 transition-all" draggable="true" data-tracker-org="${escapeHtml(org.name)}">
+        <div class="flex items-start gap-2.5 mb-2.5">
+          <div class="w-9 h-9 rounded-lg bg-surface-container-low flex items-center justify-center flex-shrink-0 overflow-hidden border border-zinc-100">
+            ${logoUrl
+              ? `<img src="${escapeHtml(logoUrl)}" data-org-name="${escapeHtml(org.name)}" alt="${escapeHtml(org.name + ' logo')}" class="w-full h-full object-contain">`
+              : `<span class="material-symbols-outlined text-primary text-base">corporate_fare</span>`}
+          </div>
+          <div class="flex-1 min-w-0">
+            <button data-tracker-open="${escapeHtml(org.name)}" class="block text-left font-bold text-sm text-zinc-900 leading-tight truncate hover:text-primary transition-colors w-full" title="${escapeHtml(org.name)}">${escapeHtml(org.name)}</button>
+            <span class="text-[10px] font-label font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full ${category.className}">${escapeHtml(category.label)}</span>
+          </div>
+          <button data-tracker-remove="${escapeHtml(org.name)}" class="flex-shrink-0 text-zinc-300 hover:text-red-500 transition-colors" title="Remove from tracker" aria-label="Remove ${escapeHtml(org.name)} from tracker">
+            <span class="material-symbols-outlined text-base">close</span>
+          </button>
+        </div>
+        <select data-tracker-status="${escapeHtml(org.name)}" aria-label="Application stage for ${escapeHtml(org.name)}" class="w-full text-xs font-medium rounded-lg border border-zinc-200 bg-surface-container-low px-2 py-1.5 text-zinc-700 focus:outline-none focus:ring-2 focus:ring-primary/40 cursor-pointer">
+          ${options}
+        </select>
+      </div>`;
+  }
+
+  // ── renderTracker ────────────────────────────────────────────────────────────
+  function renderTracker() {
+    const board    = document.getElementById('trackerBoard');
+    const empty    = document.getElementById('trackerEmpty');
+    const clearBtn = document.getElementById('clearTrackerBtn');
+    if (!board) return;
+
+    const total = trackerMap.size;
+    if (clearBtn) clearBtn.classList.toggle('hidden', total === 0);
+
+    // ── Empty state ───────────────────────────────────────────────────────────
+    if (total === 0) {
+      board.innerHTML = '';
+      board.classList.add('hidden');
+      if (empty) empty.classList.remove('hidden');
+      return;
+    }
+    board.classList.remove('hidden');
+    if (empty) empty.classList.add('hidden');
+
+    // ── One column per stage ──────────────────────────────────────────────────
+    board.innerHTML = '';
+    TRACKER_STAGES.forEach(stage => {
+      const orgsInStage = [...trackerMap.entries()]
+        .filter(([, s]) => s === stage.key)
+        .map(([name]) => ORGS.find(o => o.name === name))
+        .filter(Boolean);
+
+      const column = document.createElement('div');
+      column.className = 'tracker-column bg-surface-container-low rounded-2xl p-4 border border-zinc-100 transition-colors';
+      column.dataset.stage = stage.key;
+
+      const cardsHtml = orgsInStage.map(org => trackerCardHtml(org, stage.key)).join('')
+        || `<p class="text-xs text-zinc-400 text-center py-8 border-2 border-dashed border-zinc-200 rounded-xl">Drop or add organizations here</p>`;
+
+      column.innerHTML = `
+        <div class="flex items-center justify-between gap-2 mb-4 px-1">
+          <div class="flex items-center gap-2 min-w-0">
+            <span class="material-symbols-outlined text-primary text-lg">${stage.icon}</span>
+            <h3 class="font-bold text-sm text-zinc-900 truncate">${escapeHtml(stage.label)}</h3>
+          </div>
+          <span class="flex-shrink-0 rounded-full bg-white px-2 py-0.5 text-[11px] font-bold text-zinc-500 border border-zinc-200">${orgsInStage.length}</span>
+        </div>
+        <div class="space-y-3">${cardsHtml}</div>`;
+
+      // Drag-and-drop target (desktop). The dropdown is the touch/mobile fallback.
+      column.addEventListener('dragover', (e) => { e.preventDefault(); column.classList.add('drag-over'); });
+      column.addEventListener('dragleave', () => column.classList.remove('drag-over'));
+      column.addEventListener('drop', (e) => {
+        e.preventDefault();
+        column.classList.remove('drag-over');
+        if (trackerDragName) setTrackerStatus(trackerDragName, stage.key);
+      });
+
+      board.appendChild(column);
+    });
+
+    // ── Wire per-card controls ────────────────────────────────────────────────
+    board.querySelectorAll('.tracker-card').forEach(card => {
+      const name = card.dataset.trackerOrg;
+      card.addEventListener('dragstart', () => { trackerDragName = name; card.classList.add('dragging'); });
+      card.addEventListener('dragend',   () => { trackerDragName = null; card.classList.remove('dragging'); });
+    });
+    board.querySelectorAll('[data-tracker-status]').forEach(sel => {
+      sel.addEventListener('change', (e) => setTrackerStatus(sel.dataset.trackerStatus, e.target.value));
+    });
+    board.querySelectorAll('[data-tracker-remove]').forEach(btn => {
+      btn.addEventListener('click', () => removeFromTracker(btn.dataset.trackerRemove));
+    });
+    board.querySelectorAll('[data-tracker-open]').forEach(btn => {
+      btn.addEventListener('click', () => openModal(btn.dataset.trackerOpen));
+    });
+
+    // Logo fallback handling, consistent with the org cards / watchlist.
+    attachOrgCardListeners(board);
   }
 
   function addRecentlyViewed(name) {
@@ -4349,6 +4613,8 @@ if(org.ideas){
   })();
   renderOrgs();
   renderWatchlist();
+  renderTracker();
+  document.getElementById('clearTrackerBtn')?.addEventListener('click', clearTracker);
   renderRecentlyViewed();
   updateAIInsights();   // populate AI insight panel on page load
   loadMentorData();


### PR DESCRIPTION
## 🚀 Program
GSSoC

## 📝 Description
Adds a **Personal Application Tracker** — a simple Kanban board that lets users shortlist organizations and track their GSoC application progress directly on the site, instead of leaving for Notion/Excel/paper.

This is intentionally separate from the existing **Watchlist** (a favorites list). As noted in the issue's "Alternatives Considered," a status tracker is more useful for real applicants, so this feature is kept fully independent and does not change Watchlist/bookmark behavior.

Highlights:
- A **"Track"** button on every organization card (toggles to "Tracking").
- A new **"My Tracker"** tab in the desktop nav and the mobile menu.
- A board with the four standard GSoC stages: **Interested**, **Researching / Talking to Mentors**, **Drafting Proposal**, **Proposal Submitted**.
- Move orgs between stages via **drag-and-drop** (desktop) **or** a **status dropdown** (works on touch/mobile).
- Remove a single org or **Clear All**, with an empty state that links back to the directory.
- State persists to `localStorage` under a dedicated `appTracker` key — no database, no sign-up.
- Responsive: 4 columns on desktop → stacked single column on mobile.

**Scope:** only `index.html` is modified. No new files, no new dependencies, no changes to existing features.

## 🔗 Related Issue
Closes #1733

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Open `index.html` in a browser.
2. In the **Organizations** grid, click **Track** on a couple of org cards (the button changes to "Tracking").
3. Open the **My Tracker** tab — the saved orgs appear under **Interested**.
4. Change an org's stage using its **dropdown**, and/or **drag** a card into another column.
5. **Reload the page** — your tracker and each org's stage are preserved.
6. Use the **×** on a card to remove one org, or **Clear All** to empty the board.
7. Resize to mobile width to confirm the board stacks into a single column.
8. Confirm the existing **Watchlist** (star button) still works and is unaffected.



## ✅ Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)