### PR TITLE
fix: convert hours to days in Last Updated timestamp for readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -4180,7 +4180,8 @@ if(org.ideas){
       if (lastUpdatedEl) {
         if (data.updated_at) {
           const mins = Math.max(1, Math.floor((Date.now() - new Date(data.updated_at).getTime()) / 60000));
-          const relative = mins < 60 ? `${mins} min ago` : `${Math.floor(mins / 60)} hours ago`;
+          const hours = Math.floor(mins / 60);
+          const relative = mins < 60 ? `${mins} min ago` : hours < 24 ? `${hours} hours ago` : `${Math.floor(hours / 24)} days ago`;
           lastUpdatedEl.textContent = `Last updated: ${relative}`;
         } else {
           lastUpdatedEl.textContent = 'Last updated: unavailable';

--- a/index.html
+++ b/index.html
@@ -4181,7 +4181,15 @@ if(org.ideas){
         if (data.updated_at) {
           const mins = Math.max(1, Math.floor((Date.now() - new Date(data.updated_at).getTime()) / 60000));
           const hours = Math.floor(mins / 60);
-          const relative = mins < 60 ? `${mins} min ago` : hours < 24 ? `${hours} hours ago` : `${Math.floor(hours / 24)} days ago`;
+          const days = Math.floor(hours / 24);
+          let relative;
+          if (mins < 60) {
+            relative = `${mins} min ago`;
+          } else if (hours < 24) {
+            relative = `${hours} hours ago`;
+          } else {
+            relative = `${days} days ago`;
+          }
           lastUpdatedEl.textContent = `Last updated: ${relative}`;
         } else {
           lastUpdatedEl.textContent = 'Last updated: unavailable';

--- a/index.html
+++ b/index.html
@@ -4186,9 +4186,9 @@ if(org.ideas){
           if (mins < 60) {
             relative = `${mins} min ago`;
           } else if (hours < 24) {
-            relative = `${hours} hours ago`;
+            relative = `${hours} ${hours === 1 ? 'hour' : 'hours'} ago`;
           } else {
-            relative = `${days} days ago`;
+            relative = `${days} ${days === 1 ? 'day' : 'days'} ago`;
           }
           lastUpdatedEl.textContent = `Last updated: ${relative}`;
         } else {


### PR DESCRIPTION
program: gssoc

### 📝 Description of Changes

* Fixed Bug: Resolved the issue where the "Last updated" timestamp in the Good First Issues section displayed time only in hours (e.g. "286 hours ago"), making it hard to read at a glance.
* Added a third time unit case: when the duration exceeds 24 hours, the timestamp now displays in days instead (e.g. "11 days ago").
* Logic: under 60 minutes → "X min ago", under 24 hours → "X hours ago", 24+ hours → "X days ago".
* Fully adhered to the repository's zero-build, vanilla architecture with zero added dependencies.

### 🔗 Related Issue Link
Closes #1092

### 🛠️ Type of Change

- Bug fix (non-breaking change which fixes an issue)

### 🧪 Testing Steps

1. Opened index.html locally in a browser environment.
2. Verified that timestamps under 60 minutes display as "X min ago".
3. Verified that timestamps between 1-24 hours display as "X hours ago".
4. Verified that timestamps over 24 hours display as "X days ago".

### 📸 Screenshots
Before:
<img width="1607" height="845" alt="image" src="https://github.com/user-attachments/assets/df03dd32-6617-4649-bd81-a3f00c6628c4" />


After:
<img width="629" height="83" alt="image" src="https://github.com/user-attachments/assets/e66c6f12-1874-488c-baaa-8a19e239abfb" />

Console test showing the fix works correctly: timestamps under 24h show hours, timestamps over 24h convert to days (e.g. 50 hours → 2 days ago)


### ☑️ Checklist Confirmation

- [x] My code follows the existing clean code style and formatting guidelines of this project.
- [x] I have tested my changes locally before creating this pull request.
- [x] This PR is minimal, highly focused, and does not contain unrelated modifications.
- [x] Every commit included in this pull request has been explicitly signed off using `git commit -s`.
- [x] I have not opened multiple minor PRs to farm points maliciously.