### PR TITLE
Update FreeCAD mentor contact information and communication channels

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -700,9 +700,71 @@
         "type": "Discord",
         "url": "https://discord.com/invite/w2cTKGzccC",
         "label": "Discord"
+      },
+      {
+        "type":"Forum",
+        "url":"https://forum.freecad.org/",
+        "label":"Forum"
+      },
+      {
+        "type":"Reddit",
+        "url":"https://www.reddit.com/r/FreeCAD",
+        "label":"reddit"
+      }
+
+    ],
+    "mentors": [
+      {
+        "name":"MarioAlexis",
+        "github":"marioalexis84",
+        "githubUrl":"https://github.com/marioalexis84"
+      },
+      {
+        "name":"Turan Furkan Topak",
+        "github":"Reqrefusion",
+        "githubUrl":"https://github.com/Reqrefusion"
+      },
+      {
+        "name":"Aik-Siong koh",
+        "github":"ailsiongkoh",
+        "githubUrl":"https://github.com/aiksiongkoh"
+      },
+      {
+        "name":"Jackson Oursland",
+        "github":"oursland",
+        "githubUrl":"https://github.com/oursland"
+      },
+      {
+        "name":"Kacper Donat",
+        "github":"kadet1090",
+        "githubUrl":"https://github.com/kadet1090"
+      },
+      {
+        "name":"Obelisk",
+        "github":"obelisk79",
+        "githubUrl":"https://github.com/obelisk79"
+      },
+      {
+        "name":"Pieter Hijma",
+        "github":"pieterhijma",
+        "githubUrl":"https://github.com/pieterhijma"
+      },
+      {
+        "name":"Carlo D.",
+        "github":"onekk",
+        "githubUrl":"https://github.com/onekk"
+      },
+      {
+        "name":"David Planella",
+        "github":"dplanella",
+        "githubUrl":"https://github.com/dplanella"
+      },
+      {
+        "name":"Benjamin Nauck",
+        "github":"hyarion",
+        "githubUrl":"https://github.com/hyarion"
       }
     ],
-    "mentors": [],
     "mailingLists": [],
     "tip": "Introduce yourself in the public channel before asking project-specific questions.",
     "status": "ok",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -726,7 +726,7 @@
       },
       {
         "name":"Aik-Siong koh",
-        "github":"ailsiongkoh",
+        "github":"aiksiongkoh",
         "githubUrl":"https://github.com/aiksiongkoh"
       },
       {


### PR DESCRIPTION
# Summary  
This PR update the FreeCAD entry in data/mentors.json by manually researching and verifying mentor contact information  

# changes Made  
- Verified the FreeCAD ideas page URL
- updated mentor communication channels  
- Added available mentor github handles  
- updated mailing list/contact information where applicable  
- changed status to ok after verification  
# verification Sources  
- FreeCAD ideas page  
- FreeCAD GSoC 2026 Organization profile  
- official FreeCAD community resources  
# GSSoC  
This contribution is made as part of GirlScript Summer of code(GSSoC) 2026  
# Related Issue
closes #295