### PR TITLE
Fix: navbar in desktop view and prevent scroll event overriding active nav state after navbar click

### DIFF
--- a/index.html
+++ b/index.html
@@ -5051,15 +5051,24 @@ if(e.key.toLowerCase()==='r'){
     });
   }
 
+  let isNavClicking = false;
+  let navClickTimer = null;
+
   document.querySelectorAll(".desktop-nav-link").forEach(link => {
     link.addEventListener("click", () => {
+      isNavClicking = true;
+      clearTimeout(navClickTimer);
       setCurrentSectionById(link.dataset.section);
+      navClickTimer = setTimeout(() => { isNavClicking = false; }, 1000);
     });
   });
 
   document.querySelectorAll(".mobile-menu-link").forEach(link => {
     link.addEventListener("click", () => {
+      isNavClicking = true;
+      clearTimeout(navClickTimer);
       setCurrentSectionById(link.dataset.section);
+      navClickTimer = setTimeout(() => { isNavClicking = false; }, 1000);
 
       if (typeof globalThis.toggleMenu === "function") {
         globalThis.toggleMenu();
@@ -5068,12 +5077,11 @@ if(e.key.toLowerCase()==='r'){
   });
 
   function updateCurrentSection() {
+    if (isNavClicking) return; // ignore scroll during nav click
     const scrollPos = window.scrollY + getSectionDetectionOffset();
-
     sections.forEach((section, index) => {
       if (scrollPos >= section.offsetTop) currentSection = index;
     });
-
     updateNavState();
   }
 

--- a/index.html
+++ b/index.html
@@ -5047,7 +5047,6 @@ if(e.key.toLowerCase()==='r'){
 
   let isNavClicking = false;
   let navClickTimer = null;
-  let scrollStopTimer = null;
 
   document.querySelectorAll(".desktop-nav-link").forEach(link => {
     link.addEventListener("click", (e) => {
@@ -5058,7 +5057,6 @@ if(e.key.toLowerCase()==='r'){
       scrollToSectionIndex(currentSection);
       navClickTimer = setTimeout(() => {
         isNavClicking = false;
-        
       }, 1500);
     });
   });
@@ -5072,7 +5070,6 @@ if(e.key.toLowerCase()==='r'){
       scrollToSectionIndex(currentSection);
       navClickTimer = setTimeout(() => {
         isNavClicking = false;
-        
       }, 1500);
 
       if (typeof globalThis.toggleMenu === "function") {
@@ -5101,16 +5098,15 @@ if(e.key.toLowerCase()==='r'){
     }
 
     const observer = new IntersectionObserver((entries) => {
-      if (isNavClicking) return;
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          const index = sections.indexOf(entry.target);
-          if (index !== -1) {
-            currentSection = index;
-            updateNavState();
-          }
-        }
-      });
+        if (isNavClicking) return;
+        const intersecting = entries
+          .filter(entry => entry.isIntersecting)
+          .map(entry => sections.indexOf(entry.target))
+          .filter(index => index !== -1);
+        if (intersecting.length === 0) return;
+        // Pick the topmost (lowest index) visible section
+        currentSection = Math.min(...intersecting);
+        updateNavState();
     }, {
       rootMargin: `-${(mainHeader?.clientHeight || 0) + 10}px 0px -60% 0px`,
       threshold: 0

--- a/index.html
+++ b/index.html
@@ -5097,15 +5097,21 @@ if(e.key.toLowerCase()==='r'){
       updateNavState();
     }
 
+    const visibleSections = new Set();
+
     const observer = new IntersectionObserver((entries) => {
-        if (isNavClicking) return;
-        const intersecting = entries
-          .filter(entry => entry.isIntersecting)
-          .map(entry => sections.indexOf(entry.target))
-          .filter(index => index !== -1);
-        if (intersecting.length === 0) return;
-        // Pick the topmost (lowest index) visible section
-        currentSection = Math.min(...intersecting);
+       if (isNavClicking) return;
+        entries.forEach(entry => {
+          const index = sections.indexOf(entry.target);
+          if (index === -1) return;
+          if (entry.isIntersecting) {
+            visibleSections.add(index);
+          } else {
+            visibleSections.delete(index);
+          }
+        });
+        if (visibleSections.size === 0) return;
+        currentSection = Math.min(...visibleSections);
         updateNavState();
     }, {
       rootMargin: `-${(mainHeader?.clientHeight || 0) + 10}px 0px -60% 0px`,

--- a/index.html
+++ b/index.html
@@ -5110,7 +5110,9 @@ if(e.key.toLowerCase()==='r'){
             visibleSections.delete(index);
           }
         });
-        if (visibleSections.size === 0) return;
+        if (visibleSections.size === 0) {
+          return;
+        }
         currentSection = Math.min(...visibleSections);
         updateNavState();
     }, {

--- a/index.html
+++ b/index.html
@@ -1093,12 +1093,13 @@ kbd:hover{
       </span>
       </a>
       <nav class="hidden md:flex items-center gap-6 text-sm font-medium">
-        <a class="desktop-nav-link text-orange-600 is-active transition-colors" href="#orgs" data-section="orgs">Organizations</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#timeline" data-section="timeline">Timeline</a>
+        <a class="desktop-nav-link text-orange-600 is-active transition-colors" href="#orgs" data-section="orgs">Organizations</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#ai-recommender" data-section="ai-recommender">AI Recommender</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#watchlist" data-section="watchlist">Watchlist</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#issues" data-section="issues">Issues</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#mentors" data-section="mentors">Mentors</a>
+        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#guide" data-section="guide">Guide</a>
       </nav>
     </div>
     

--- a/index.html
+++ b/index.html
@@ -5059,7 +5059,7 @@ if(e.key.toLowerCase()==='r'){
       isNavClicking = true;
       clearTimeout(navClickTimer);
       setCurrentSectionById(link.dataset.section);
-      navClickTimer = setTimeout(() => { isNavClicking = false; }, 1000);
+      navClickTimer = setTimeout(() => { isNavClicking = false; updateCurrentSection(); }, 1000);
     });
   });
 

--- a/index.html
+++ b/index.html
@@ -4983,15 +4983,9 @@ if(e.key.toLowerCase()==='r'){
 
   function scrollToSectionIndex(index) {
     const targetSection = sections[index];
-
     if (!targetSection) return;
-
-    const targetTop = Math.max(0, targetSection.offsetTop - getSectionDetectionOffset());
-
-    window.scrollTo({
-      top: targetTop,
-      behavior: "smooth"
-    });
+    // Use scrollIntoView to respect scroll-margin-top defined in CSS
+    targetSection.scrollIntoView({ behavior: "smooth", block: "start" });
   }
 
   function updateSectionIndicator() {
@@ -5053,22 +5047,33 @@ if(e.key.toLowerCase()==='r'){
 
   let isNavClicking = false;
   let navClickTimer = null;
+  let scrollStopTimer = null;
 
   document.querySelectorAll(".desktop-nav-link").forEach(link => {
-    link.addEventListener("click", () => {
+    link.addEventListener("click", (e) => {
+      e.preventDefault(); // stop browser anchor scroll
       isNavClicking = true;
       clearTimeout(navClickTimer);
       setCurrentSectionById(link.dataset.section);
-      navClickTimer = setTimeout(() => { isNavClicking = false; updateCurrentSection(); }, 1000);
+      scrollToSectionIndex(currentSection);
+      navClickTimer = setTimeout(() => {
+        isNavClicking = false;
+        
+      }, 1500);
     });
   });
 
   document.querySelectorAll(".mobile-menu-link").forEach(link => {
-    link.addEventListener("click", () => {
+    link.addEventListener("click", (e) => {
+      e.preventDefault(); // stop browser anchor scroll
       isNavClicking = true;
       clearTimeout(navClickTimer);
       setCurrentSectionById(link.dataset.section);
-      navClickTimer = setTimeout(() => { isNavClicking = false; }, 1000);
+      scrollToSectionIndex(currentSection);
+      navClickTimer = setTimeout(() => {
+        isNavClicking = false;
+        
+      }, 1500);
 
       if (typeof globalThis.toggleMenu === "function") {
         globalThis.toggleMenu();
@@ -5077,17 +5082,43 @@ if(e.key.toLowerCase()==='r'){
   });
 
   function updateCurrentSection() {
-    if (isNavClicking) return; // ignore scroll during nav click
-    const scrollPos = window.scrollY + getSectionDetectionOffset();
-    sections.forEach((section, index) => {
-      if (scrollPos >= section.offsetTop) currentSection = index;
-    });
-    updateNavState();
-  }
+      if (isNavClicking) return;
+      const offset = getSectionDetectionOffset() + 10;
+      let found = 0;
+      let closestDistance = Infinity;
+      sections.forEach((section, index) => {
+        const rect = section.getBoundingClientRect();
+        if (rect.top <= offset) {
+          const distance = offset - rect.top;
+          if (distance < closestDistance) {
+            closestDistance = distance;
+            found = index;
+          }
+        }
+      });
+      currentSection = found;
+      updateNavState();
+    }
 
-  window.addEventListener("scroll", updateCurrentSection, { passive: true });
-  window.addEventListener("resize", updateCurrentSection);
-  updateCurrentSection();
+    const observer = new IntersectionObserver((entries) => {
+      if (isNavClicking) return;
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          const index = sections.indexOf(entry.target);
+          if (index !== -1) {
+            currentSection = index;
+            updateNavState();
+          }
+        }
+      });
+    }, {
+      rootMargin: `-${(mainHeader?.clientHeight || 0) + 10}px 0px -60% 0px`,
+      threshold: 0
+    });
+
+    sections.forEach(section => observer.observe(section));
+    window.addEventListener("resize", updateCurrentSection);
+    updateCurrentSection();
 
   document.getElementById("nextSectionBtn")?.addEventListener("click", () => {
     if (currentSection < sections.length - 1) {

--- a/index.html
+++ b/index.html
@@ -1094,7 +1094,7 @@ kbd:hover{
       </a>
       <nav class="hidden md:flex items-center gap-6 text-sm font-medium">
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#timeline" data-section="timeline">Timeline</a>
-        <a class="desktop-nav-link text-orange-600 is-active transition-colors" href="#orgs" data-section="orgs">Organizations</a>
+        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#orgs" data-section="orgs">Organizations</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#ai-recommender" data-section="ai-recommender">AI Recommender</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#watchlist" data-section="watchlist">Watchlist</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#issues" data-section="issues">Issues</a>


### PR DESCRIPTION
## Program
program: gssoc

## Description
The desktop header navigation was out of sync with the mobile navigation menu. The nav items were in a different order and the Guide link was entirely missing from the desktop view, causing an inconsistent experience across screen sizes.

'Organizations' in the navbar in desktop view had 'is-active' hardcoded on it. This caused it to always appear underlined and highlighted in orange on desktop, regardless of the current scroll position.

When a user clicked a nav link, the active highlight would incorrectly show the previous section instead of the one clicked. This happened because the smooth scroll triggered the 'scroll' event listener which recalculated the active section based on the current 'scrollY' — which was still at the old position mid-scroll — overwriting the correct active state set by the click handler.

## Changes
- Moved 'Timeline' before 'Organizations' in the desktop nav to match the mobile menu order
- Added the missing 'Guide' link at the end of the desktop nav
- Removed hardcoded 'is-active' and 'text-orange-600' classes from the 'Organizations' link so the active state is now fully controlled by JavaScript on scroll

- Replaced window.scrollTo() with targetSection.scrollIntoView() to respect scroll-margin-top defined in CSS
- Added isNavClicking flag and navClickTimer that suppresses scroll observer updates for 1500ms after a nav link is clicked
- Replaced the old scroll-position-based updateCurrentSection() with an IntersectionObserver that tracks which sections are visible and highlights the topmost one
- Added e.preventDefault() to both desktop and mobile nav click handlers to stop browser default anchor scroll behavior
- Removed the window.addEventListener("scroll", updateCurrentSection) listener since section tracking is now handled entirely by the IntersectionObserver

## Result

The desktop navigation now mirrors the mobile menu order, includes the Guide link, and correctly highlights only the currently visible section as the user scrolls.

Clicking any nav link now immediately and correctly highlights the selected section. Once the smooth scroll settles, scroll-based active state detection resumes as normal.

## Screenshots

### Before:
<img width="1918" height="977" alt="image" src="https://github.com/user-attachments/assets/d16648d2-8029-45cc-abb3-6aadebb776ad" />

### After:
<img width="1918" height="982" alt="image" src="https://github.com/user-attachments/assets/81068740-134a-4a3e-a636-669d2b2007a0" />

## Screen Recordings

### Desktop View Video after fixing
https://github.com/user-attachments/assets/2eb2026b-0f9d-4fe3-9a1b-e974d9102a00

### Mobile View Video after fixing
https://github.com/user-attachments/assets/15d69812-1366-447d-9721-5d857b71b4d7

## Type of Change
- [x] Bug fix 

## Related Issue
Closes #1795 
Closes #1796 

## Checklist
- My code follows the style guidelines of this project
-  I have performed a self-review of my own code
- My changes generate no new warnings
- I have tested on mobile view and laptop view both