### PR TITLE
fix: pre-fetched issues ready status card on mobile screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -1567,9 +1567,9 @@ kbd:hover{
         <p class="text-xs text-green-600" id="issuesBannerSubtitle">Updated every 6 hours via GitHub Actions — no API rate limits for visitors.</p>
       </div>
     </div>
-    <div class="ml-auto text-right">
+    <div class="sm:ml-auto flex flex-col items-start sm:items-end gap-1">
       <span id="issuesLastUpdated" class="text-xs font-mono text-green-600">Last updated: pending refresh</span>
-      <span id="issuesStaleNote" class="hidden ml-2 text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2 py-0.5">⏸ GSoC selection complete. Data won't update frequently.</span>
+      <span id="issuesStaleNote" class="hidden text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2 py-0.5">⏸ GSoC selection complete. Data won't update frequently.</span>
     </div>
   </div>
   <!-- Issue Cards -->


### PR DESCRIPTION
## Program
program: gssoc

## Description
The "Pre-fetched Issues Ready" status card has responsiveness issues that affect the layout on smaller screen sizes as shown in the screenshot.

## Changes
- Updated layout to use a flex-column structure on small screens and right alignment on larger screens.
- Removed unnecessary left margin (ml-2) that caused spacing inconsistencies.

## Result
- Better mobile responsiveness.
- Consistent alignment across screen sizes.
- Cleaner spacing between elements.

## Screenshots

### Before fixing:
<img width="517" height="880" alt="image" src="https://github.com/user-attachments/assets/207e43f4-6756-4b9a-92d5-f79e00b94aa1" />

### After Fixing:
<img width="526" height="861" alt="image" src="https://github.com/user-attachments/assets/84685259-2a45-4290-beb0-fabdfc83845b" />


## Type of Change
- [x] Bug fix 

## Related Issue
Closes #1681 

## Checklist
- My code follows the style guidelines of this project
-  I have performed a self-review of my own code
- My changes generate no new warnings
- I have tested on mobile view and laptop view both