### PR TITLE
fix: handle bookmark storage failures gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -2237,6 +2237,17 @@ kbd:hover{
     }
   }
 
+  function persistBookmarksToStorage() {
+    try {
+      localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
+      return true;
+    } catch (error) {
+      console.error('[Bookmarks] Failed to persist bookmarks:', error);
+      alert('Bookmarks could not be saved because your browser blocked storage. Your current session still works, but bookmarks may not persist after refresh.');
+      return false;
+    }
+  }
+
   function trimGitHubPathSlashes(path) {
     let start = 0;
     let end = path.length;
@@ -3514,7 +3525,7 @@ btn.__orgListenerAttached = true;
     if (!orgName) return;
     if (shouldAdd) bookmarkedSet.add(orgName);
     else           bookmarkedSet.delete(orgName);
-    localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
+    persistBookmarksToStorage();
     refreshOrgGridAfterBookmarkChange();
     renderWatchlist();
     updateAIInsights();
@@ -3548,7 +3559,7 @@ btn.__orgListenerAttached = true;
     if (!bookmarkedSet.size) return;
     if (!confirm(`Remove all ${bookmarkedSet.size} bookmarked organization(s)? This cannot be undone.`)) return;
     bookmarkedSet.clear();
-    localStorage.setItem('bookmarks', JSON.stringify([]));
+    persistBookmarksToStorage();
     applyFilters();
     renderWatchlist();
     updateAIInsights();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -776,11 +776,22 @@ function parseStoredBookmarks() {
   }
 }
 
+function persistBookmarksToStorage() {
+  try {
+    localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
+    return true;
+  } catch (error) {
+    console.error('[Bookmarks] Failed to persist bookmarks:', error);
+    alert('Bookmarks could not be saved because your browser blocked storage. Your current session still works, but bookmarks may not persist after refresh.');
+    return false;
+  }
+}
+
 function syncBookmark(name, shouldAdd) {
   if (!name) return;
   if (shouldAdd) bookmarkedSet.add(name);
   else bookmarkedSet.delete(name);
-  localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
+  persistBookmarksToStorage();
 
   refreshOrgGridAfterBookmarkChange();
   renderWatchlist();
@@ -827,7 +838,7 @@ function clearAllBookmarks() {
   if (!bookmarkedSet.size) return;
   if (!confirm(`Remove all ${bookmarkedSet.size} bookmarked organization(s)? This cannot be undone.`)) return;
   bookmarkedSet.clear();
-  localStorage.setItem('bookmarks', JSON.stringify([]));
+  persistBookmarksToStorage();
   applyFilters();
   renderWatchlist();
   updateAIInsights();


### PR DESCRIPTION
## Summary
- wrap bookmark persistence in a safe storage helper
- keep the bookmark UI responsive even when browser storage is blocked
- alert the user when bookmarks cannot be persisted so the failure is visible instead of silent
- apply the same resilience to both bookmark toggle flows in the page scripts

## Validation
- `node --check src/js/app.js`
- `npm test`
- `git diff --check`

Fixes #1697
