### PR TITLE
fix: improve tech stack visibility in dark mode and correct Python icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,8 +298,8 @@ kbd:hover{
     .gh-stat-item { font-family: 'Fira Code', monospace; font-size: 0.75rem; color: #4ade80; display: flex; align-items: center; gap: 0.5rem; }
 
     .tech-tags, .fit-tags { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-    .tech-tag { background: #f3f4f6; color: #4b5563; font-size: 0.7rem; font-weight: 600; padding: 0.4rem 0.8rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; }
-    .fit-tag { background: #eff6ff; color: #2563eb; font-size: 0.7rem; font-weight: 600; padding: 0.4rem 0.8rem; border-radius: 0.5rem; border: 1px solid #dbeafe; }
+    .tech-tag { background: #f3f4f6; color: #111827; font-size: 0.7rem; font-weight: 600; padding: 0.4rem 0.8rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; }
+    .fit-tag { background: #eff6ff; color: #1d4ed8; font-size: 0.7rem; font-weight: 600; padding: 0.4rem 0.8rem; border-radius: 0.5rem; border: 1px solid #dbeafe; }
     .mentor-link-chip { display:inline-flex; align-items:center; gap:.45rem; background:#fff7ed; color:#9d4300; border:1px solid #fed7aa; border-radius:999px; padding:.45rem .75rem; font-size:.75rem; font-weight:700; }
     .mentor-handle-chip { display:inline-flex; align-items:center; gap:.35rem; background:#f3f4f6; color:#374151; border:1px solid #e5e7eb; border-radius:999px; padding:.4rem .7rem; font-size:.75rem; font-weight:600; }
     .mentor-card { background:#ffffff; border:1px solid #e5e7eb; border-radius:1rem; padding:1.25rem; box-shadow:0 1px 2px rgba(15,23,42,.04); }
@@ -557,8 +557,8 @@ kbd:hover{
     .dark .group-hover\:text-primary:hover, .dark .group:hover .group-hover\:text-primary { color: #f97316 !important; }
     
     /* Dark mode - Tech tags */
-    .dark .tech-tag { background: #27272a; color: #d4d4d8; border-color: #3f3f46; }
-    .dark .fit-tag { background: #1e293b; color: #93c5fd; border-color: #334155; }
+    .dark .tech-tag { background: #27272a; color: #f4f4f5; border-color: #3f3f46; }
+    .dark .fit-tag { background: #172554; color: #bfdbfe; border-color: #334155; }
     .dark .mentor-link-chip { background: rgba(124,45,18,0.72); color: #fff7ed; border-color: rgba(251,146,60,0.45); }
     .dark .mentor-handle-chip { background: #27272a; color: #d4d4d8; border-color: #3f3f46; }
     .dark .mentor-card, .dark .mentor-empty { background:#18181b; border-color:#3f3f46; }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -95,6 +95,33 @@ const CHANNEL_ICONS = {
   Slack: '💬', Zulip: '💬', Discord: '🎮', Matrix: '🔗', IRC: '🖥️', 'Mailing list': '📧'
 };
 
+const TECH_ICON_MAP = {
+  python: 'terminal',
+  javascript: 'code',
+  typescript: 'data_object',
+  react: 'auto_awesome',
+  nodejs: 'dns',
+  django: 'grid_view',
+  docker: 'deployed_code',
+  kubernetes: 'cloud',
+  c: 'memory',
+  'c++': 'memory',
+  css: 'palette',
+  html: 'language',
+  java: 'code',
+  rust: 'build',
+  go: 'sync_alt',
+  ruby: 'diamond',
+  swift: 'bolt',
+  kotlin: 'bolt'
+};
+
+function renderTechTag(tag) {
+  const value = String(tag || '');
+  const icon = TECH_ICON_MAP[value.toLowerCase()] || 'code';
+  return safeHTML`<span class="tech-tag inline-flex items-center gap-1.5"><span class="material-symbols-outlined text-[11px] leading-none">${icon}</span><span>${value}</span></span>`;
+}
+
 const CONTACT_TIPS = {
   Slack: 'Join and say hi in the GSoC channel before DMing mentors.',
   Discord: 'Introduce yourself in the public channel before asking project-specific questions.',
@@ -1154,8 +1181,8 @@ function renderOrgs(reset = true) {
       ? safeHTML`<img src="${logoUrl}" data-org-name="${org.name}" alt="${org.name} logo" class="w-full h-full object-contain rounded-lg" />`
       : safeHTML`<div class="logo-placeholder flex w-full h-full items-center justify-center text-primary font-bold text-xl bg-primary/5">${(org.name || '?')[0].toUpperCase()}</div>`;
 
-    const tagsHtml = org.tags.slice(0, 3).map(t => safeHTML`<span class="px-2 py-0.5 bg-surface-container-low dark:bg-zinc-800 text-[10px] font-mono rounded text-zinc-600 dark:text-zinc-400">${t}</span>`);
-    const moreTagsHtml = org.tags.length > 3 ? safeHTML`<span class="px-2 py-0.5 bg-surface-container-low dark:bg-zinc-800 text-[10px] font-mono rounded text-zinc-600 dark:text-zinc-400 cursor-help" title="${org.tags.slice(3).join(', ')}">+${String(org.tags.length - 3)}</span>` : '';
+    const tagsHtml = org.tags.slice(0, 3).map(t => safeHTML`<span class="px-2 py-0.5 bg-surface-container-low dark:bg-zinc-800 text-[10px] font-mono rounded text-zinc-700 dark:text-zinc-100">${t}</span>`);
+    const moreTagsHtml = org.tags.length > 3 ? safeHTML`<span class="px-2 py-0.5 bg-surface-container-low dark:bg-zinc-800 text-[10px] font-mono rounded text-zinc-700 dark:text-zinc-100 cursor-help" title="${org.tags.slice(3).join(', ')}">+${String(org.tags.length - 3)}</span>` : '';
 
     const catLabel = getCategoryMeta(org.cat).label.toUpperCase();
     const isBookmarkedStr = isBookmarked ? 'true' : 'false';
@@ -1442,7 +1469,7 @@ globalThis.openModal = function (name, triggerElement = null) {
   if (mFetchBtn) mFetchBtn.textContent = gh ? '↻ Refresh' : 'Fetch Live Stats';
 
   const mTech = document.getElementById('mTech');
-  if (mTech) mTech.innerHTML = org.tags.map(t => safeHTML`<span class="tech-tag">${t}</span>`).join('');
+  if (mTech) mTech.innerHTML = org.tags.map(t => renderTechTag(t)).join('');
 
   const mFit = document.getElementById('mFit');
   if (mFit) mFit.innerHTML = org.fit.map(f => safeHTML`<span class="fit-tag">${f}</span>`).join('');


### PR DESCRIPTION
Related Issue

Closes #911 

Program

GSSoC 


## Summary

* Fixed low contrast text issue in dark mode for tech stack cards.
* Corrected the Python icon displayed in the tech stack section.

## Changes Made

* Added proper dark mode text color classes for better readability.
* Updated Python icon mapping to use the correct icon.
* Verified UI consistency across light and dark themes.

## Testing

* Tested tech stack cards in light mode.
* Tested tech stack cards in dark mode.
* Confirmed correct Python icon rendering.
* Checked that all cards remain readable and visually consistent.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

