### PR TITLE
fix: validate file type in resume uploader to reject non-.txt files

### DIFF
--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -127,6 +127,12 @@ document.addEventListener('DOMContentLoaded', () => {
     fileUpload.addEventListener('change', (e) => {
       const file = e.target.files[0];
       if (!file) return;
+      const ext = file.name.split('.').pop().toLowerCase();
+      if (ext !== 'txt' || !file.type.startsWith('text/')) {
+        showError('Only .txt files are accepted. Please upload a plain text file.');
+        fileUpload.value = '';
+        return;
+      }
       file.text().then(text => {
         resumeText.value = text;
       }).catch(err => {


### PR DESCRIPTION
The resume uploader accepted binary files (.pptx, .png, etc.) and processed corrupted content for skill extraction. Added extension and MIME type validation before reading the file.

Closes #1736

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

