### PR TITLE
Docs: Fix poor image alt text for the Flowchart in README (#1424)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Built with a responsive and lightweight architecture, the platform delivers a se
 
 ## 📈 Flowchart
 
-<img width="8192" height="1328" alt="User Action Flow for Org-2026-05-05-154517" src="https://github.com/user-attachments/assets/a56902d0-e172-42e9-b0d5-8a8ee2c7d156" />
+<img width="8192" height="1328" alt="Flowchart showing the user action flow for discovering and filtering GSoC organizations" src="https://github.com/user-attachments/assets/a56902d0-e172-42e9-b0d5-8a8ee2c7d156" />
 
 ---
 


### PR DESCRIPTION
## Program
program: gssoc

## Description
The flowchart image in the README used a raw auto-generated filename as its alt text, which is an accessibility issue for users relying on screen readers.

## Changes
- Changed the alt text on the flowchart image in README.md from `User Action Flow for Org-2026-05-05-154517` to `Flowchart showing the user action flow for discovering and filtering GSoC organizations`

## Related Issue
Closes #1424

## Type of Change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have signed my commits using git commit -s
- [x] I have linked a valid issue
