### PR TITLE
fix: align privacy.html navbar and footer with homepage styling

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2352,7 +2352,23 @@
         "label": "Konflux Slack"
       }
     ],
-    "mentors": [],
+    "mentors": [
+      {
+        "name": "Erik Skultety",
+        "github": "eskultety",
+        "githubUrl": "https://github.com/eskultety"
+      },
+      {
+        "name": "Adam Kaplan",
+        "github": "adambkaplan",
+        "githubUrl": "https://github.com/adambkaplan"
+      },
+      {
+        "name": "Ralph Bean",
+        "github": "ralphbean",
+        "githubUrl": "https://github.com/ralphbean"
+      }
+],
     "mailingLists": [],
     "tip": "Join and say hi in the GSoC channel before DMing mentors.",
     "status": "ok",

--- a/privacy.html
+++ b/privacy.html
@@ -7,12 +7,11 @@
   <meta name="description" content="Privacy Policy for FindMyGSoC." />
   <link rel="canonical" href="https://findmygsoc.vercel.app/privacy.html" />
   <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" integrity="sha384-NPToXI2n6gWUtTP7kSreAjbTuFo/Ud8X117P3IzZKfYqse84nsxKYkLO4Q4Jwmiz" crossorigin="anonymous" />
-   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/styles.css" />
 
   <script>
-    // Theme restoration
     (function(){
       try {
         if (localStorage.getItem('theme') === 'dark') {
@@ -22,18 +21,21 @@
     })();
   </script>
   <script>
-    // Tailwind Configuration
     tailwind.config = {
       darkMode: 'class',
       theme: {
         extend: {
           colors: {
-            primary: { DEFAULT: '#f97316', container: '#ffedd5' },
-            surface: { DEFAULT: '#ffffff', 'container-low': '#f4f4f5' }
+            "primary": "#9d4300",
+            "primary-container": "#f97316",
+            "surface": "#ffffff",
+            "surface-container-low": "#f4f4f5",
+            "on-surface": "#1a1c1c",
+            "secondary": "#006c47",
           },
           fontFamily: {
             sans: ['"Plus Jakarta Sans"', 'sans-serif'],
-            headline: ['"Space Grotesk"', 'sans-serif'],
+            headline: ['"Plus Jakarta Sans"', 'sans-serif'],
             mono: ['"Fira Code"', 'monospace']
           }
         }
@@ -41,26 +43,27 @@
     }
   </script>
 </head>
-<body class="privacy-page bg-surface text-zinc-900 antialiased selection:bg-orange-200 selection:text-orange-900 transition-colors duration-300">
+<body class="privacy-page bg-white text-zinc-900 antialiased selection:bg-orange-200 selection:text-orange-900 transition-colors duration-300">
 
-<header class="fixed top-0 w-full z-50 transition-all duration-300 border-b border-zinc-200 bg-white/80 backdrop-blur-md">
-  <div class="max-w-7xl mx-auto px-6 h-20 flex items-center justify-between">
-    <div class="flex items-center gap-3">
-      <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-primary to-primary-container flex items-center justify-center shadow-lg shadow-orange-500/20">
-        <span class="text-white font-extrabold text-xl">G</span>
+<header class="fixed top-0 w-full z-50 bg-white/80 backdrop-blur-md shadow-sm border-b border-zinc-200">
+  <div class="flex items-center justify-between px-4 sm:px-6 py-3 max-w-7xl mx-auto w-full">
+    <a href="index.html" class="flex items-center gap-2">
+      <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center flex-shrink-0">
+        <span class="text-white font-bold text-sm">G</span>
       </div>
-      <a href="index.html" class="font-extrabold text-xl tracking-tight font-headline">FindMy<span class="text-primary">GSoC</span></a>
-    </div>
-    <nav class="hidden md:flex items-center gap-8" aria-label="Main navigation">
-      <a href="index.html#orgs" class="text-sm font-bold text-zinc-600 hover:text-zinc-900 transition-colors">Organizations</a>
-      <a href="index.html#guide" class="text-sm font-bold text-zinc-600 hover:text-zinc-900 transition-colors">Guide</a>
-      <a href="index.html#issues" class="text-sm font-bold text-zinc-600 hover:text-zinc-900 transition-colors">Issues</a>
+      <span class="text-base sm:text-lg font-extrabold tracking-tight text-zinc-900 font-headline whitespace-nowrap">
+        <span class="hidden sm:inline">GSoC 2026 </span>
+        <span class="text-primary italic">Org Finder</span>
+      </span>
+    </a>
+    <nav class="hidden md:flex items-center gap-6 text-sm font-medium" aria-label="Main navigation">
+      <a href="index.html#orgs" class="text-zinc-600 hover:text-zinc-900 transition-colors">Organizations</a>
+      <a href="index.html#guide" class="text-zinc-600 hover:text-zinc-900 transition-colors">Guide</a>
+      <a href="index.html#issues" class="text-zinc-600 hover:text-zinc-900 transition-colors">Issues</a>
     </nav>
-    <div class="flex items-center gap-4">
-      <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer" class="hidden sm:flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-900 text-white text-xs font-bold hover:bg-zinc-700 transition-colors">
-        <span class="material-symbols-outlined text-sm">star</span> Star & Contribute
-      </a>
-    </div>
+    <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer" class="hidden sm:flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-900 text-white text-xs font-bold hover:bg-zinc-700 transition-colors">
+      <span class="material-symbols-outlined text-sm">star</span> Star & Contribute
+    </a>
   </div>
 </header>
 
@@ -88,6 +91,7 @@
 
 <!-- Footer Placeholder -->
 <div id="footer-placeholder"></div>
+<script src="agent/scripts/orgs.js"></script>
 <script src="src/js/footer.js"></script>
 
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Privacy Policy for FindMyGSoC." />
   <link rel="canonical" href="https://findmygsoc.vercel.app/privacy.html" />
   <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" crossorigin="anonymous" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/styles.css" />
 
@@ -28,8 +28,8 @@
           colors: {
             "primary": "#9d4300",
             "primary-container": "#f97316",
-            "surface": "#ffffff",
-            "surface-container-low": "#f4f4f5",
+            "surface": "#f9f9f9",
+            "surface-container-low": "#f3f3f3",
             "on-surface": "#1a1c1c",
             "secondary": "#006c47",
           },


### PR DESCRIPTION
Fixes #1656

PROGRAME  : GSSOC

Changes:
- Match logo size (w-8 h-8), gradient, and font with index.html
- Update Tailwind color tokens to match homepage
- Remove integrity hash blocking Google Fonts from loading
- Load orgs.js to populate footer platform stats

Tested locally - navbar and footer now match homepage exactly.
## SCREENSHOT BEFORE 
<img width="1908" height="1073" alt="image" src="https://github.com/user-attachments/assets/d3d3d205-e3e9-44bb-98da-ca7f43c656ad" />
## AFTER 
<img width="1918" height="1087" alt="image" src="https://github.com/user-attachments/assets/d7c17cca-5ee2-4acd-bb95-7f15bc3de4b1" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

