### PR TITLE
fix: single-row pagination with first/last nav & mobile filter chip hover cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1126,6 +1126,12 @@ kbd:hover{
         border-radius: 999px;
       }
     }
+@media (pointer: coarse) {
+  .filter-chip.bg-orange-600:hover {
+    background-color: #ea580c !important;
+    color: #ffffff !important;
+  }
+}
 
 </style>
   <link rel="manifest" href="manifest.json" />
@@ -1452,7 +1458,7 @@ kbd:hover{
       <p class="text-zinc-400 font-headline italic">Loading organization directory...</p>
     </div>
   </div>
-  <div id="orgPagination" class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Organizations pagination"></div>
+  <div id="orgPagination" class="mt-12 flex flex-nowrap items-center justify-center gap-1 overflow-x-auto no-scrollbar" aria-label="Organizations pagination"></div>
   <!-- Empty State -->
   <div id="emptyState" class="hidden py-20 text-center animate-fade-up">
     <div class="text-6xl mb-4">🔍</div>
@@ -1746,7 +1752,7 @@ kbd:hover{
       </button>
     </div>
   </div>
-  <div id="mentorPagination" class="mt-10 flex flex-wrap items-center justify-center gap-2" aria-label="Mentor pagination"></div>
+  <div id="mentorPagination" class="mt-10 flex flex-nowrap items-center justify-center gap-1 overflow-x-auto no-scrollbar" aria-label="Mentor pagination"></div>
 </section>
  
 <!-- ═══════════════════ CONTRIBUTOR GUIDE ═══════════════════ -->
@@ -3052,71 +3058,46 @@ function renderPaginationControls(containerId, totalItems, currentPage, onPageCh
   if (!container) return;
 
   const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
-
-  if (totalPages <= 1) {
-    container.innerHTML = '';
-    container.style.display = 'none';
-    return;
-  }
+  if (totalPages <= 1) { container.innerHTML = ''; container.style.display = 'none'; return; }
 
   container.style.display = 'flex';
 
-  const baseClass = 'px-4 py-2 rounded-full border text-xs font-bold transition-all';
-  const normalClass = 'bg-white text-zinc-600 border-zinc-200 hover:border-primary hover:text-primary';
-  const activeClass = 'bg-primary text-white border-primary';
-  const disabledClass = 'opacity-50 cursor-not-allowed';
+  const base = 'inline-flex items-center justify-center min-w-[32px] h-8 px-2 rounded-full border text-xs font-bold transition-all select-none';
+  const normal = 'bg-white text-zinc-600 border-zinc-200 hover:border-primary hover:text-primary cursor-pointer';
+  const active = 'bg-primary text-white border-primary cursor-default';
+  const dis = 'bg-white text-zinc-300 border-zinc-100 cursor-not-allowed pointer-events-none';
+  const ellipsisCls = 'inline-flex items-center justify-center min-w-[24px] h-8 text-xs text-zinc-400 border-none bg-transparent cursor-default select-none';
 
-  const pageButtons = Array.from({ length: totalPages }, (_, index) => {
-    const page = index + 1;
-    return `
-      <button
-        type="button"
-        class="${baseClass} ${page === currentPage ? activeClass : normalClass}"
-        data-page="${page}"
-        aria-label="Go to page ${page}"
-        ${page === currentPage ? 'aria-current="page"' : ''}
-      >
-        ${page}
-      </button>
-    `;
-  }).join('');
+  const navBtn = (label, page, isDisabled, ariaLabel) =>
+    `<button type="button" class="${base} ${isDisabled ? dis : normal} whitespace-nowrap px-3" data-page="${page}" ${isDisabled ? 'disabled' : ''} aria-label="${ariaLabel}">${label}</button>`;
+  const pageBtn = (page) =>
+    `<button type="button" class="${base} ${page === currentPage ? active : normal}" data-page="${page}" aria-label="Go to page ${page}" ${page === currentPage ? 'aria-current="page"' : ''}>${page}</button>`;
+  const dot = `<span class="${ellipsisCls}">…</span>`;
 
-  container.innerHTML = `
-    <button
-      type="button"
-      class="${baseClass} ${normalClass} ${currentPage === 1 ? disabledClass : ''}"
-      data-page="${currentPage - 1}"
-      ${currentPage === 1 ? 'disabled' : ''}
-    >
-      Previous
-    </button>
+  const WING = 2;
+  const pages = [];
+  const addPage = (p) => { if (!pages.includes(p) && p >= 1 && p <= totalPages) pages.push(p); };
+  addPage(1); addPage(totalPages);
+  for (let i = currentPage - WING; i <= currentPage + WING; i++) addPage(i);
+  pages.sort((a, b) => a - b);
 
-    ${pageButtons}
+  let pageHTML = '';
+  for (let i = 0; i < pages.length; i++) {
+    if (i > 0 && pages[i] - pages[i - 1] > 1) pageHTML += dot;
+    pageHTML += pageBtn(pages[i]);
+  }
 
-    <button
-      type="button"
-      class="${baseClass} ${normalClass} ${currentPage === totalPages ? disabledClass : ''}"
-      data-page="${currentPage + 1}"
-      ${currentPage === totalPages ? 'disabled' : ''}
-    >
-      Next
-    </button>
-  `;
+  container.innerHTML =
+    navBtn('«', 1, currentPage === 1, 'First page') +
+    navBtn('‹', currentPage - 1, currentPage === 1, 'Previous page') +
+    pageHTML +
+    navBtn('›', currentPage + 1, currentPage === totalPages, 'Next page') +
+    navBtn('»', totalPages, currentPage === totalPages, 'Last page');
 
   container.querySelectorAll('[data-page]').forEach(button => {
     button.addEventListener('click', () => {
       const page = Number(button.dataset.page);
-
-      if (
-        button.disabled ||
-        Number.isNaN(page) ||
-        page < 1 ||
-        page > totalPages ||
-        page === currentPage
-      ) {
-        return;
-      }
-
+      if (button.disabled || Number.isNaN(page) || page < 1 || page > totalPages || page === currentPage) return;
       onPageChange(page);
     });
   });
@@ -5098,11 +5079,9 @@ if(e.key.toLowerCase()==='r'){
     if (!hoverCapable) {
       element.addEventListener('click', (event) => {
         event.stopPropagation();
-        if (tooltip.classList.contains('show') && tooltip.textContent === element.dataset.tooltip) {
-          hideTooltip();
-        } else {
-          showTooltip(element);
-        }
+        clearTimeout(element._tooltipTimer);
+        showTooltip(element);
+        element._tooltipTimer = setTimeout(() => hideTooltip(), 3000);
       });
     }
   });

--- a/index.html
+++ b/index.html
@@ -1129,7 +1129,11 @@ kbd:hover{
 @media (pointer: coarse) {
   .filter-chip.bg-orange-600:hover {
     background-color: #ea580c !important;
-    color: #ffffff !important;
+    color: #1a0a00 !important;
+  }
+  .filter-chip.bg-surface-container-highest:hover {
+    background-color: revert !important;
+    color: revert !important;
   }
 }
 
@@ -5079,9 +5083,9 @@ if(e.key.toLowerCase()==='r'){
     if (!hoverCapable) {
       element.addEventListener('click', (event) => {
         event.stopPropagation();
-        clearTimeout(element._tooltipTimer);
+        clearTimeout(window._globalTooltipTimer);
         showTooltip(element);
-        element._tooltipTimer = setTimeout(() => hideTooltip(), 3000);
+        window._globalTooltipTimer = setTimeout(() => hideTooltip(), 3000);
       });
     }
   });

--- a/index.html
+++ b/index.html
@@ -5083,9 +5083,9 @@ if(e.key.toLowerCase()==='r'){
     if (!hoverCapable) {
       element.addEventListener('click', (event) => {
         event.stopPropagation();
-        clearTimeout(window._globalTooltipTimer);
+        clearTimeout(globalThis._globalTooltipTimer);
         showTooltip(element);
-        window._globalTooltipTimer = setTimeout(() => hideTooltip(), 3000);
+        globalThis._globalTooltipTimer = setTimeout(() => hideTooltip(), 3000);
       });
     }
   });


### PR DESCRIPTION
## Program
program: gssoc

## Description

1. Pagination — single row layout:
The pagination in both the "Organisations" and "Mentor Finder" sections was wrapping into multiple rows on smaller screens, making it hard to navigate.

2. Mobile filter chip hover — removed unwanted colour on tap
On touch/mobile devices, tapping a filter chip (e.g. Veterans Only, Newcomers) was triggering the desktop hover colour (bg-primary dark brownish-red) in addition to the selected state, making it visually confusing.

3. PR review fixes:
   Fixed a race condition where tapping chips rapidly caused the first chip's 
   tooltip timer to prematurely hide the second chip's tooltip. Also fixed 
   WCAG AA contrast failure on selected chip text.

## Changes

- Replaced the "render every page as a button" approach with a windowed paginator that shows current page ±2 neighbours, always anchored by first and last page, with … ellipsis for gaps
- Added « (first) and » (last) jump buttons on both ends, alongside ‹ prev and › next
- Container set to flex-nowrap with overflow-x-auto as a safety net
- Added @media (pointer: coarse) CSS rule that forces the selected chip to stay bright orange (#ea580c) on touch, preventing the dark hover colour from bleeding in
- Replaced per-element tooltip timer (element._tooltipTimer) with a single 
  global timer (window._globalTooltipTimer) to prevent race condition on rapid taps
- Updated selected chip text color from #ffffff to #1a0a00 to meet WCAG AA 
  contrast ratio requirements (was 3.56:1, now exceeds 4.5:1)

## Result
- Pagination now stays on a single row at all screen sizes with standard navigation controls.
- On mobile, selected filter chips now consistently show the correct bright orange selected colour with no dark hover bleed.
- Tapping multiple chips rapidly now correctly shows each tooltip for its full 3 seconds
- Selected filter chip text now meets WCAG AA accessibility contrast standards on mobile

## Screenshots

### Before fix (pagination):
<img width="1918" height="982" alt="image" src="https://github.com/user-attachments/assets/7ab6d51b-4a80-4745-abb2-18f4a408a87f" />
<img width="500" height="856" alt="image" src="https://github.com/user-attachments/assets/7465a621-76bb-4afe-b57b-d12c83f53db9" />

### After fix (pagination):
<img width="1918" height="978" alt="image" src="https://github.com/user-attachments/assets/d07b9751-b427-40ed-8c7c-84ee26af4f36" />
<img width="510" height="858" alt="image" src="https://github.com/user-attachments/assets/31d8e37f-de51-417c-8130-2f9dea41942a" />

## Screen Recordings

### Before fix ( filter chip hover):
https://github.com/user-attachments/assets/a6538d11-05ad-4bea-b182-a81c0807712b

### After fix (filter chip hover):

https://github.com/user-attachments/assets/aee94b2d-e1a1-48e3-914a-b6a04c021375


### After Fix (pagination):

https://github.com/user-attachments/assets/ec987673-0949-492a-8ec3-3d30799c537a


https://github.com/user-attachments/assets/0765311a-f0b8-4765-be26-a98da2fde78c



## Type of Change
- [x] Bug fix 

## Related Issue
Closes #1824 

## Checklist
- My code follows the style guidelines of this project
-  I have performed a self-review of my own code
- My changes generate no new warnings
- I have tested on mobile view and laptop view both

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

