### PR TITLE
fix: scroll up button

### DIFF
--- a/src/js/footer.js
+++ b/src/js/footer.js
@@ -28,21 +28,18 @@ function initFooter() {
   const footerElement = document.querySelector('.premium-footer');
 
   if (backToTopBtn) {
-    let ticking = false; // Variable to track the requestAnimationFrame state
+    let ticking = false;
 
-    window.addEventListener('scroll', () => {
-      // Issue 1 Fix: Throttle the scroll event using requestAnimationFrame
+    globalThis.addEventListener('scroll', () => {
       if (!ticking) {
-        window.requestAnimationFrame(() => {
+        globalThis.requestAnimationFrame(() => {
           let shouldShow = false;
 
           if (footerElement) {
-            // Get the distance from the top of the viewport to the top of the footer
             const footerTop = footerElement.getBoundingClientRect().top;
-            shouldShow = footerTop <= window.innerHeight + 50; 
+            shouldShow = footerTop <= globalThis.innerHeight + 50; 
           } else {
-            // Issue 2 Fix: Apply bot's exact suggestion for the fallback
-            shouldShow = window.scrollY > 300;
+            shouldShow = globalThis.scrollY > 300;
           }
 
           if (shouldShow) {
@@ -51,17 +48,16 @@ function initFooter() {
             backToTopBtn.classList.remove('show');
           }
 
-          ticking = false; // Reset the tick so the next frame can fire
+          ticking = false;
         });
         ticking = true;
       }
     }, { passive: true });
 
     backToTopBtn.addEventListener('click', () => {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
+      globalThis.scrollTo({ top: 0, behavior: 'smooth' });
     });
   }
-
   updateFooterStats();
 }
 

--- a/src/js/footer.js
+++ b/src/js/footer.js
@@ -28,25 +28,32 @@ function initFooter() {
   const footerElement = document.querySelector('.premium-footer');
 
   if (backToTopBtn) {
+    let ticking = false; // Variable to track the requestAnimationFrame state
+
     window.addEventListener('scroll', () => {
-      let shouldShow = false;
+      // Issue 1 Fix: Throttle the scroll event using requestAnimationFrame
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          let shouldShow = false;
 
-      if (footerElement) {
-        // Get the distance from the top of the viewport to the top of the footer
-        const footerTop = footerElement.getBoundingClientRect().top;
-        
-        // Show the button as soon as the top of the footer enters the screen
-        // (adding a small 50px buffer so it doesn't pop in too abruptly)
-        shouldShow = footerTop <= window.innerHeight + 50; 
-      } else {
-        // Fallback just in case the footer class changes
-        shouldShow = window.scrollY + window.innerHeight >= document.body.scrollHeight - 300;
-      }
+          if (footerElement) {
+            // Get the distance from the top of the viewport to the top of the footer
+            const footerTop = footerElement.getBoundingClientRect().top;
+            shouldShow = footerTop <= window.innerHeight + 50; 
+          } else {
+            // Issue 2 Fix: Apply bot's exact suggestion for the fallback
+            shouldShow = window.scrollY > 300;
+          }
 
-      if (shouldShow) {
-        backToTopBtn.classList.add('show');
-      } else {
-        backToTopBtn.classList.remove('show');
+          if (shouldShow) {
+            backToTopBtn.classList.add('show');
+          } else {
+            backToTopBtn.classList.remove('show');
+          }
+
+          ticking = false; // Reset the tick so the next frame can fire
+        });
+        ticking = true;
       }
     }, { passive: true });
 

--- a/src/js/footer.js
+++ b/src/js/footer.js
@@ -23,14 +23,23 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
+// Store the listener outside the function so it can be cleaned up
+let footerScrollHandler = null;
+
 function initFooter() {
   const backToTopBtn = document.getElementById('back-to-top-btn');
   const footerElement = document.querySelector('.premium-footer');
 
   if (backToTopBtn) {
-    let ticking = false;
+    // FIX: Remove existing listener if initFooter is called multiple times
+    if (footerScrollHandler) {
+      globalThis.removeEventListener('scroll', footerScrollHandler);
+    }
 
-    globalThis.addEventListener('scroll', () => {
+    let ticking = false;
+    
+    // Assign the logic to our tracked variable
+    footerScrollHandler = () => {
       if (!ticking) {
         globalThis.requestAnimationFrame(() => {
           let shouldShow = false;
@@ -52,12 +61,20 @@ function initFooter() {
         });
         ticking = true;
       }
-    }, { passive: true });
+    };
 
-    backToTopBtn.addEventListener('click', () => {
-      globalThis.scrollTo({ top: 0, behavior: 'smooth' });
-    });
+    // Attach the tracked listener
+    globalThis.addEventListener('scroll', footerScrollHandler, { passive: true });
+
+    // FIX: Ensure click listener is only attached once
+    if (!backToTopBtn.dataset.clickBound) {
+      backToTopBtn.addEventListener('click', () => {
+        globalThis.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+      backToTopBtn.dataset.clickBound = 'true';
+    }
   }
+  
   updateFooterStats();
 }
 

--- a/src/js/footer.js
+++ b/src/js/footer.js
@@ -25,9 +25,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
 function initFooter() {
   const backToTopBtn = document.getElementById('back-to-top-btn');
+  const footerElement = document.querySelector('.premium-footer');
+
   if (backToTopBtn) {
     window.addEventListener('scroll', () => {
-      if (window.scrollY > 300) {
+      let shouldShow = false;
+
+      if (footerElement) {
+        // Get the distance from the top of the viewport to the top of the footer
+        const footerTop = footerElement.getBoundingClientRect().top;
+        
+        // Show the button as soon as the top of the footer enters the screen
+        // (adding a small 50px buffer so it doesn't pop in too abruptly)
+        shouldShow = footerTop <= window.innerHeight + 50; 
+      } else {
+        // Fallback just in case the footer class changes
+        shouldShow = window.scrollY + window.innerHeight >= document.body.scrollHeight - 300;
+      }
+
+      if (shouldShow) {
         backToTopBtn.classList.add('show');
       } else {
         backToTopBtn.classList.remove('show');

--- a/src/styles.css
+++ b/src/styles.css
@@ -528,8 +528,8 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 
 #back-to-top-btn {
   position: fixed;
-  bottom: 24px;
-  right: 24px;
+  bottom: calc(var(--section-fab-bottom) + (var(--section-fab-size) + var(--section-fab-gap)) * 2 + 50px);
+  right: calc(var(--section-fab-right) + env(safe-area-inset-right));
   width: 44px;
   height: 44px;
   border-radius: 50%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -528,8 +528,8 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 
 #back-to-top-btn {
   position: fixed;
-  bottom: calc(var(--section-fab-bottom) + (var(--section-fab-size) + var(--section-fab-gap)) * 2 + 50px);
-  right: calc(var(--section-fab-right) + env(safe-area-inset-right));
+  bottom: calc(var(--section-fab-bottom, 24px) + (var(--section-fab-size, 48px) + var(--section-fab-gap, 10px)) * 2 + 50px);
+  right: calc(var(--section-fab-right, 24px) + env(safe-area-inset-right));
   width: 44px;
   height: 44px;
   border-radius: 50%;


### PR DESCRIPTION
## Program
program: gssoc

## Description

This PR addresses UI and behavior issues with the scroll-to-top button (#back-to-top-btn). The scroll-up (back-to-top) arrow remains visible while scrolling and overlaps with the existing floating navigation controls located at the bottom-right corner of the page. This causes UI clutter and makes the controls appear crowded on both desktop and mobile views.

## Changes

CSS (styles.css):
- Dynamic Positioning & Fallbacks: Updated the #back-to-top-btn position to use dynamic calc() functions. Added explicit fallback values (e.g., 24px, 48px, 10px) to the CSS variables to prevent the browser from dropping the rule if variables are undefined.
- Overlap Fix: Added a 50px buffer to the bottom calculation to ensure the scroll-up button completely clears the floating "Section" indicator.

JavaScript (footer.js):
- Memory Leak Prevention: Extracted the scroll event logic into a tracked variable (footerScrollHandler). Added a cleanup step (removeEventListener) to ensure previous listeners are removed before re-attaching, preventing duplicate listeners when initFooter() is called dynamically.
- Listener Deduplication: Added a dataset.clickBound check to guarantee the click event listener is only attached to the button once.
- Performance Optimization: Wrapped the scroll event logic inside requestAnimationFrame with a ticking state tracker. This throttles the getBoundingClientRect() layout calculations to prevent scroll jank on mobile devices.
- Environment Safety: Replaced all instances of window with globalThis to resolve SonarCloud static analysis warnings and ensure the code is safe across different execution environments.
- Visibility Logic: Changed the button to appear dynamically when .premium-footer enters the viewport. Restored globalThis.scrollY > 300 as a safe fallback behavior in case the footer element is ever removed or renamed.

## Result
- The scroll-to-top arrow now sits cleanly above the section indicator without any visual overlap.
- The button appears reliably and seamlessly as soon as the "Get in Touch" / Footer section scrolls into view, providing a consistent user experience across both desktop and mobile layouts.

## Screen Recording

### Before Fix Desktop View:

https://github.com/user-attachments/assets/81598a29-4709-4441-95a4-7864f1cc25d9

### Before Fix Mobile View:

https://github.com/user-attachments/assets/49d2c9fa-ac01-47fa-9300-40f9bba821ea

### After Fix Desktop View:

https://github.com/user-attachments/assets/912d4a3f-aa64-429a-92a0-064cdea303f8

### After Fix Mobile View:

https://github.com/user-attachments/assets/913a64a2-2b19-4a78-a705-4edb5cdbc95b

## Type of Change
- [x] Bug fix 

## Related Issue
Closes #1828  

## Checklist
- My code follows the style guidelines of this project
-  I have performed a self-review of my own code
- My changes generate no new warnings
- I have tested on mobile view and laptop view both

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

