### PR TITLE
fix: handle QuotaExceededError in bookmark localStorage writes

### DIFF
--- a/index.html
+++ b/index.html
@@ -433,8 +433,6 @@ kbd:hover{
     .proposal-preview blockquote { border-left: 4px solid #ddd; padding-left: 1rem; color: #666; margin-bottom: 1rem; }
     .proposal-preview a { color: #f97316; text-decoration: underline; }
     .proposal-preview-error { color: #ba1a1a; font-size: 0.875rem; }
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
-
     /* Custom Scrollbar for Modal */
     .modal::-webkit-scrollbar { width: 6px; }
     .modal::-webkit-scrollbar-track { background: transparent; }

--- a/index.html
+++ b/index.html
@@ -3651,7 +3651,12 @@ btn.__orgListenerAttached = true;
     if (!orgName) return;
     if (shouldAdd) bookmarkedSet.add(orgName);
     else           bookmarkedSet.delete(orgName);
-    localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
+    try {
+      localStorage.setItem('bookmarks', JSON.stringify([...bookmarkedSet]));
+    } catch (e) {
+      alert('Could not save bookmark due to storage limits. Please free up some space in your browser settings.');
+      return;
+    }
     refreshOrgGridAfterBookmarkChange();
     renderWatchlist();
     updateAIInsights();
@@ -3685,7 +3690,12 @@ btn.__orgListenerAttached = true;
     if (!bookmarkedSet.size) return;
     if (!confirm(`Remove all ${bookmarkedSet.size} bookmarked organization(s)? This cannot be undone.`)) return;
     bookmarkedSet.clear();
-    localStorage.setItem('bookmarks', JSON.stringify([]));
+    try {
+      localStorage.setItem('bookmarks', JSON.stringify([]));
+    } catch (e) {
+      alert('Could not clear bookmarks due to storage limits.');
+      return;
+    }
     applyFilters();
     renderWatchlist();
     updateAIInsights();


### PR DESCRIPTION
## Description
Wraps `localStorage.setItem` in `syncBookmark` and `clearAllBookmarks` with try/catch to prevent uncaught `QuotaExceededError` / `SecurityError` when storage is unavailable or full.

**Changes**
- `syncBookmark` — catch storage write failure, alert user, return early
- `clearAllBookmarks` — catch storage write failure, alert user, return early

**Fixes** #1697

## GSSoC
- Closes #1697

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

