### PR TITLE
fix: support owner-only GitHub entries in stats and GFI fetching

### DIFF
--- a/api/github.js
+++ b/api/github.js
@@ -29,12 +29,16 @@ export default async function handler(req) {
   const user = searchParams.get('user');
   const gfiMode = searchParams.get('gfi') === '1';
   const issuesMode = searchParams.get('issues') === '1';
+  const isOwnerOnly = !!repo && !repo.includes('/');
 
   if (!repo && !user) {
     return new Response(JSON.stringify({ error: 'Missing repo or user parameter' }), { status: 400, headers });
   }
 
-  const isOwnerOnly = repo && !repo.includes('/');
+  if (repo && isOwnerOnly && !/^[\w.-]+$/.test(repo)) {
+    return new Response(JSON.stringify({ error: 'Invalid repo' }), { status: 400, headers });
+  }
+
   if (repo && !isOwnerOnly && !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
     return new Response(JSON.stringify({ error: 'Invalid repo' }), { status: 400, headers });
   }
@@ -44,7 +48,12 @@ export default async function handler(req) {
   }
 
   // Helper: build GitHub search qualifier for repo or org
-  const repoQualifier = repo ? (isOwnerOnly ? `org:${repo}` : `repo:${repo}`) : '';
+  let repoQualifier = '';
+  let repoPath = '';
+  if (repo) {
+    repoQualifier = isOwnerOnly ? `org:${repo}` : `repo:${repo}`;
+    repoPath = isOwnerOnly ? encodeURIComponent(repo) : repo.split('/').map(encodeURIComponent).join('/');
+  }
 
   const token = process.env.GITHUB_TOKEN;
 
@@ -221,13 +230,20 @@ export default async function handler(req) {
 
     if (isOwnerOnly) {
       // Owner-only GitHub value: fetch org-level info instead of repo stats
-      const orgRes = await fetchWithFallback(`https://api.github.com/orgs/${repo}`, { headers: ghHeaders });
+      const orgRes = await fetchWithFallback(`https://api.github.com/orgs/${repoPath}`, { headers: ghHeaders });
       if (!orgRes.ok) {
         return new Response(JSON.stringify({
           name: repo,
           description: 'Organization-level GitHub entry — no specific repository. Good First Issues are searched across all repos in this org.',
-          stars: null, forks: null, open_issues: null,
-          lastCommit: '—', activity: 'unknown',
+          stars: null,
+          forks: null,
+          issues: null,
+          watchers: null,
+          lastCommit: '—',
+          activity: 'unknown',
+          language: null,
+          gfi: null,
+          ts: Date.now(),
           isOwnerOnly: true,
         }), { status: 200, headers });
       }
@@ -276,15 +292,16 @@ export default async function handler(req) {
     const activity = activityDays < 14 ? 'active' : activityDays < 60 ? 'moderate' : 'low';
 
     const result = {
-      stars: repoData.stargazers_count,
-      forks: repoData.forks_count,
-      issues: repoData.open_issues_count,
-      watchers: repoData.watchers_count,
+      stars: repoData.stargazers_count ?? null,
+      forks: repoData.forks_count ?? null,
+      issues: repoData.open_issues_count ?? null,
+      watchers: repoData.watchers_count ?? null,
       lastCommit,
       activity,
-      language: repoData.language,
+      language: repoData.language ?? null,
       gfi: null,  // fetched separately via ?gfi=1 to avoid rate limiting
       ts: Date.now(),
+      isOwnerOnly: !!repoData.isOwnerOnly,
     };
 
     safeCacheSet(repo, result);

--- a/api/github.js
+++ b/api/github.js
@@ -34,13 +34,17 @@ export default async function handler(req) {
     return new Response(JSON.stringify({ error: 'Missing repo or user parameter' }), { status: 400, headers });
   }
 
-  if (repo && !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+  const isOwnerOnly = repo && !repo.includes('/');
+  if (repo && !isOwnerOnly && !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
     return new Response(JSON.stringify({ error: 'Invalid repo' }), { status: 400, headers });
   }
 
   if (user && !/^[\w.-]+$/.test(user)) {
     return new Response(JSON.stringify({ error: 'Invalid user' }), { status: 400, headers });
   }
+
+  // Helper: build GitHub search qualifier for repo or org
+  const repoQualifier = repo ? (isOwnerOnly ? `org:${repo}` : `repo:${repo}`) : '';
 
   const token = process.env.GITHUB_TOKEN;
 
@@ -156,7 +160,7 @@ export default async function handler(req) {
       return new Response(JSON.stringify({ total: cached.total, items: cached.items, cached: true }), { status: 200, headers });
     }
     try {
-      const q = encodeURIComponent(`repo:${repo} label:"good first issue" state:open`);
+      const q = encodeURIComponent(`${repoQualifier} label:"good first issue" state:open`);
       const res = await fetchWithFallback(
         `https://api.github.com/search/issues?q=${q}&per_page=30&sort=created&order=desc`,
         { headers: ghHeaders }
@@ -189,7 +193,7 @@ export default async function handler(req) {
       return new Response(JSON.stringify({ gfi: cached.gfi }), { status: 200, headers });
     }
     try {
-      const q = encodeURIComponent(`repo:${repo} label:"good first issue" state:open`);
+      const q = encodeURIComponent(`${repoQualifier} label:"good first issue" state:open`);
       const res = await fetchWithFallback(
         `https://api.github.com/search/issues?q=${q}&per_page=1`,
         { headers: ghHeaders }
@@ -213,35 +217,59 @@ export default async function handler(req) {
   }
 
   try {
-    const [repoRes, commitsRes] = await Promise.all([
-      fetchWithFallback(`https://api.github.com/repos/${repo}`, { headers: ghHeaders }),
-      fetchWithFallback(`https://api.github.com/repos/${repo}/commits?per_page=1`, { headers: ghHeaders }),
-    ]);
+    let repoData, lastCommit = '—', activityDays = 9999;
 
-    if (!repoRes.ok) {
-      const err = await repoRes.json().catch(() => ({}));
-      return new Response(JSON.stringify({ error: err.message || 'Repo not found' }), { status: repoRes.status, headers });
-    }
+    if (isOwnerOnly) {
+      // Owner-only GitHub value: fetch org-level info instead of repo stats
+      const orgRes = await fetchWithFallback(`https://api.github.com/orgs/${repo}`, { headers: ghHeaders });
+      if (!orgRes.ok) {
+        return new Response(JSON.stringify({
+          name: repo,
+          description: 'Organization-level GitHub entry — no specific repository. Good First Issues are searched across all repos in this org.',
+          stars: null, forks: null, open_issues: null,
+          lastCommit: '—', activity: 'unknown',
+          isOwnerOnly: true,
+        }), { status: 200, headers });
+      }
+      const orgData = await orgRes.json();
+      repoData = {
+        name: orgData.name || repo,
+        full_name: repo,
+        description: orgData.description || 'Organization-level GitHub entry',
+        stargazers_count: null,
+        forks_count: null,
+        open_issues_count: null,
+        html_url: orgData.html_url || `https://github.com/${repo}`,
+        isOwnerOnly: true,
+      };
+    } else {
+      const [repoRes, commitsRes] = await Promise.all([
+        fetchWithFallback(`https://api.github.com/repos/${repo}`, { headers: ghHeaders }),
+        fetchWithFallback(`https://api.github.com/repos/${repo}/commits?per_page=1`, { headers: ghHeaders }),
+      ]);
 
-    const repoData = await repoRes.json();
+      if (!repoRes.ok) {
+        const err = await repoRes.json().catch(() => ({}));
+        return new Response(JSON.stringify({ error: err.message || 'Repo not found' }), { status: repoRes.status, headers });
+      }
 
-    let lastCommit = '—';
-    let activityDays = 9999;
-    if (commitsRes.ok) {
-      try {
-        const commits = await commitsRes.json();
-        if (commits[0]?.commit?.author?.date) {
-          const d = new Date(commits[0].commit.author.date);
-          activityDays = Math.floor((Date.now() - d) / 86400000);
-          if (activityDays === 0) lastCommit = 'Today';
-          else if (activityDays === 1) lastCommit = '1d ago';
-          else if (activityDays < 30) lastCommit = `${activityDays}d ago`;
-          else if (activityDays < 365) lastCommit = `${Math.floor(activityDays / 30)}mo ago`;
-          else lastCommit = `${Math.floor(activityDays / 365)}y ago`;
+      repoData = await repoRes.json();
+
+      if (commitsRes.ok) {
+        try {
+          const commits = await commitsRes.json();
+          if (commits[0]?.commit?.author?.date) {
+            const d = new Date(commits[0].commit.author.date);
+            activityDays = Math.floor((Date.now() - d) / 86400000);
+            if (activityDays === 0) lastCommit = 'Today';
+            else if (activityDays === 1) lastCommit = '1d ago';
+            else if (activityDays < 30) lastCommit = `${activityDays}d ago`;
+            else if (activityDays < 365) lastCommit = `${Math.floor(activityDays / 30)}mo ago`;
+            else lastCommit = `${Math.floor(activityDays / 365)}y ago`;
+          }
+        } catch {
+          // Non-JSON body — fall through with safe defaults
         }
-      } catch {
-        // Non-JSON body (CDN error page, Cloudflare interstitial, empty response).
-        // Fall through with safe defaults: lastCommit = '—', activityDays = 9999.
       }
     }
 


### PR DESCRIPTION
## Description

Fixes #1678

Three GSoC organizations (C2SI `c2siorg`, ML4SCI `ML4SCI`, UNICEF Innovation `UNICEFInnovation`) use **owner-only** GitHub values (just the org name) instead of `owner/repo` format. The API previously rejected these, causing GitHub stats and Good First Issue counts to silently fail for these orgs.

## Changes

### `api/github.js`

1. **Relaxed validation** — Accept `owner`-only format alongside `owner/repo` format
2. **GFI search** — Use `org:` GitHub search qualifier instead of `repo:` when the value is owner-only (searches all repos under the org)
3. **Stats fallback** — For owner-only values, fetch org-level info from `/orgs/{owner}`; return `null` stats with `isOwnerOnly: true` flag
4. **Affected orgs**: `c2siorg`, `ML4SCI`, `UNICEFInnovation`

The frontend already handles `null` stats gracefully via the `fmt()` function (displays `—`).

## Testing

- Owner-only orgs now show `—` for stars/forks with a fallback message
- GFI counts are searched across all repos under the org
- Normal `owner/repo` format entries are unaffected

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

