### PR TITLE
fix: reject non-text file uploads in resume/skills uploader

### DIFF
--- a/api/github.js
+++ b/api/github.js
@@ -3,6 +3,13 @@ export const config = { runtime: 'edge' };
 const CACHE = new Map();
 const CACHE_TTL = 60 * 60 * 1000; // 1 hour
 const CACHE_MAX_SIZE = 1000;
+const OWNER_NAME_RE = /^[\w.-]+$/;
+const FULL_REPO_RE = /^[\w.-]+\/[\w.-]+$/;
+
+function buildRepoQualifier(repo, isOwnerOnly) {
+  if (!repo) return '';
+  return isOwnerOnly ? `org:${repo}` : `repo:${repo}`;
+}
 
 function safeCacheSet(key, value) {
   if (!CACHE.has(key) && CACHE.size >= CACHE_MAX_SIZE) {
@@ -29,12 +36,13 @@ export default async function handler(req) {
   const user = searchParams.get('user');
   const gfiMode = searchParams.get('gfi') === '1';
   const issuesMode = searchParams.get('issues') === '1';
+  const isOwnerOnly = !!repo && !repo.includes('/');
 
   if (!repo && !user) {
     return new Response(JSON.stringify({ error: 'Missing repo or user parameter' }), { status: 400, headers });
   }
 
-  if (repo && !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+  if (repo && !(isOwnerOnly ? OWNER_NAME_RE.test(repo) : FULL_REPO_RE.test(repo))) {
     return new Response(JSON.stringify({ error: 'Invalid repo' }), { status: 400, headers });
   }
 
@@ -156,7 +164,7 @@ export default async function handler(req) {
       return new Response(JSON.stringify({ total: cached.total, items: cached.items, cached: true }), { status: 200, headers });
     }
     try {
-      const q = encodeURIComponent(`repo:${repo} label:"good first issue" state:open`);
+      const q = encodeURIComponent(`${buildRepoQualifier(repo, isOwnerOnly)} label:"good first issue" state:open`);
       const res = await fetchWithFallback(
         `https://api.github.com/search/issues?q=${q}&per_page=30&sort=created&order=desc`,
         { headers: ghHeaders }
@@ -189,7 +197,7 @@ export default async function handler(req) {
       return new Response(JSON.stringify({ gfi: cached.gfi }), { status: 200, headers });
     }
     try {
-      const q = encodeURIComponent(`repo:${repo} label:"good first issue" state:open`);
+      const q = encodeURIComponent(`${buildRepoQualifier(repo, isOwnerOnly)} label:"good first issue" state:open`);
       const res = await fetchWithFallback(
         `https://api.github.com/search/issues?q=${q}&per_page=1`,
         { headers: ghHeaders }
@@ -213,6 +221,46 @@ export default async function handler(req) {
   }
 
   try {
+    if (isOwnerOnly) {
+      const orgRes = await fetchWithFallback(`https://api.github.com/orgs/${repo}`, { headers: ghHeaders });
+      if (!orgRes.ok) {
+        return new Response(JSON.stringify({
+          name: repo,
+          description: 'Organization-level GitHub entry — no specific repository. Good First Issues are searched across all repos in this org.',
+          stars: null,
+          forks: null,
+          issues: null,
+          watchers: null,
+          lastCommit: '—',
+          activity: 'unknown',
+          language: null,
+          gfi: null,
+          ts: Date.now(),
+          isOwnerOnly: true,
+        }), { status: 200, headers });
+      }
+
+      const repoData = await orgRes.json();
+
+      const result = {
+        name: repoData.name || repo,
+        description: repoData.description || 'Organization-level GitHub entry',
+        stars: null,
+        forks: null,
+        issues: null,
+        watchers: null,
+        lastCommit: '—',
+        activity: 'unknown',
+        language: null,
+        gfi: null,
+        ts: Date.now(),
+        isOwnerOnly: true,
+      };
+
+      safeCacheSet(repo, result);
+      return new Response(JSON.stringify(result), { status: 200, headers });
+    }
+
     const [repoRes, commitsRes] = await Promise.all([
       fetchWithFallback(`https://api.github.com/repos/${repo}`, { headers: ghHeaders }),
       fetchWithFallback(`https://api.github.com/repos/${repo}/commits?per_page=1`, { headers: ghHeaders }),
@@ -228,7 +276,12 @@ export default async function handler(req) {
     let lastCommit = '—';
     let activityDays = 9999;
     if (commitsRes.ok) {
-      const commits = await commitsRes.json();
+      let commits = [];
+      try {
+        commits = await commitsRes.json();
+      } catch {
+        commits = [];
+      }
       if (commits[0]?.commit?.author?.date) {
         const d = new Date(commits[0].commit.author.date);
         activityDays = Math.floor((Date.now() - d) / 86400000);
@@ -246,12 +299,13 @@ export default async function handler(req) {
       stars: repoData.stargazers_count,
       forks: repoData.forks_count,
       issues: repoData.open_issues_count,
-      watchers: repoData.watchers_count,
+      watchers: repoData.watchers_count ?? null,
       lastCommit,
       activity,
-      language: repoData.language,
+      language: repoData.language ?? null,
       gfi: null,  // fetched separately via ?gfi=1 to avoid rate limiting
       ts: Date.now(),
+      isOwnerOnly: false,
     };
 
     safeCacheSet(repo, result);

--- a/api/github.js
+++ b/api/github.js
@@ -34,17 +34,13 @@ export default async function handler(req) {
     return new Response(JSON.stringify({ error: 'Missing repo or user parameter' }), { status: 400, headers });
   }
 
-  const isOwnerOnly = repo && !repo.includes('/');
-  if (repo && !isOwnerOnly && !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+  if (repo && !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
     return new Response(JSON.stringify({ error: 'Invalid repo' }), { status: 400, headers });
   }
 
   if (user && !/^[\w.-]+$/.test(user)) {
     return new Response(JSON.stringify({ error: 'Invalid user' }), { status: 400, headers });
   }
-
-  // Helper: build GitHub search qualifier for repo or org
-  const repoQualifier = repo ? (isOwnerOnly ? `org:${repo}` : `repo:${repo}`) : '';
 
   const token = process.env.GITHUB_TOKEN;
 
@@ -160,7 +156,7 @@ export default async function handler(req) {
       return new Response(JSON.stringify({ total: cached.total, items: cached.items, cached: true }), { status: 200, headers });
     }
     try {
-      const q = encodeURIComponent(`${repoQualifier} label:"good first issue" state:open`);
+      const q = encodeURIComponent(`repo:${repo} label:"good first issue" state:open`);
       const res = await fetchWithFallback(
         `https://api.github.com/search/issues?q=${q}&per_page=30&sort=created&order=desc`,
         { headers: ghHeaders }
@@ -193,7 +189,7 @@ export default async function handler(req) {
       return new Response(JSON.stringify({ gfi: cached.gfi }), { status: 200, headers });
     }
     try {
-      const q = encodeURIComponent(`${repoQualifier} label:"good first issue" state:open`);
+      const q = encodeURIComponent(`repo:${repo} label:"good first issue" state:open`);
       const res = await fetchWithFallback(
         `https://api.github.com/search/issues?q=${q}&per_page=1`,
         { headers: ghHeaders }
@@ -217,59 +213,30 @@ export default async function handler(req) {
   }
 
   try {
-    let repoData, lastCommit = '—', activityDays = 9999;
+    const [repoRes, commitsRes] = await Promise.all([
+      fetchWithFallback(`https://api.github.com/repos/${repo}`, { headers: ghHeaders }),
+      fetchWithFallback(`https://api.github.com/repos/${repo}/commits?per_page=1`, { headers: ghHeaders }),
+    ]);
 
-    if (isOwnerOnly) {
-      // Owner-only GitHub value: fetch org-level info instead of repo stats
-      const orgRes = await fetchWithFallback(`https://api.github.com/orgs/${repo}`, { headers: ghHeaders });
-      if (!orgRes.ok) {
-        return new Response(JSON.stringify({
-          name: repo,
-          description: 'Organization-level GitHub entry — no specific repository. Good First Issues are searched across all repos in this org.',
-          stars: null, forks: null, open_issues: null,
-          lastCommit: '—', activity: 'unknown',
-          isOwnerOnly: true,
-        }), { status: 200, headers });
-      }
-      const orgData = await orgRes.json();
-      repoData = {
-        name: orgData.name || repo,
-        full_name: repo,
-        description: orgData.description || 'Organization-level GitHub entry',
-        stargazers_count: null,
-        forks_count: null,
-        open_issues_count: null,
-        html_url: orgData.html_url || `https://github.com/${repo}`,
-        isOwnerOnly: true,
-      };
-    } else {
-      const [repoRes, commitsRes] = await Promise.all([
-        fetchWithFallback(`https://api.github.com/repos/${repo}`, { headers: ghHeaders }),
-        fetchWithFallback(`https://api.github.com/repos/${repo}/commits?per_page=1`, { headers: ghHeaders }),
-      ]);
+    if (!repoRes.ok) {
+      const err = await repoRes.json().catch(() => ({}));
+      return new Response(JSON.stringify({ error: err.message || 'Repo not found' }), { status: repoRes.status, headers });
+    }
 
-      if (!repoRes.ok) {
-        const err = await repoRes.json().catch(() => ({}));
-        return new Response(JSON.stringify({ error: err.message || 'Repo not found' }), { status: repoRes.status, headers });
-      }
+    const repoData = await repoRes.json();
 
-      repoData = await repoRes.json();
-
-      if (commitsRes.ok) {
-        try {
-          const commits = await commitsRes.json();
-          if (commits[0]?.commit?.author?.date) {
-            const d = new Date(commits[0].commit.author.date);
-            activityDays = Math.floor((Date.now() - d) / 86400000);
-            if (activityDays === 0) lastCommit = 'Today';
-            else if (activityDays === 1) lastCommit = '1d ago';
-            else if (activityDays < 30) lastCommit = `${activityDays}d ago`;
-            else if (activityDays < 365) lastCommit = `${Math.floor(activityDays / 30)}mo ago`;
-            else lastCommit = `${Math.floor(activityDays / 365)}y ago`;
-          }
-        } catch {
-          // Non-JSON body — fall through with safe defaults
-        }
+    let lastCommit = '—';
+    let activityDays = 9999;
+    if (commitsRes.ok) {
+      const commits = await commitsRes.json();
+      if (commits[0]?.commit?.author?.date) {
+        const d = new Date(commits[0].commit.author.date);
+        activityDays = Math.floor((Date.now() - d) / 86400000);
+        if (activityDays === 0) lastCommit = 'Today';
+        else if (activityDays === 1) lastCommit = '1d ago';
+        else if (activityDays < 30) lastCommit = `${activityDays}d ago`;
+        else if (activityDays < 365) lastCommit = `${Math.floor(activityDays / 30)}mo ago`;
+        else lastCommit = `${Math.floor(activityDays / 365)}y ago`;
       }
     }
 

--- a/api/github.js
+++ b/api/github.js
@@ -34,13 +34,17 @@ export default async function handler(req) {
     return new Response(JSON.stringify({ error: 'Missing repo or user parameter' }), { status: 400, headers });
   }
 
-  if (repo && !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+  const isOwnerOnly = repo && !repo.includes('/');
+  if (repo && !isOwnerOnly && !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
     return new Response(JSON.stringify({ error: 'Invalid repo' }), { status: 400, headers });
   }
 
   if (user && !/^[\w.-]+$/.test(user)) {
     return new Response(JSON.stringify({ error: 'Invalid user' }), { status: 400, headers });
   }
+
+  // Helper: build GitHub search qualifier for repo or org
+  const repoQualifier = repo ? (isOwnerOnly ? `org:${repo}` : `repo:${repo}`) : '';
 
   const token = process.env.GITHUB_TOKEN;
 
@@ -156,7 +160,7 @@ export default async function handler(req) {
       return new Response(JSON.stringify({ total: cached.total, items: cached.items, cached: true }), { status: 200, headers });
     }
     try {
-      const q = encodeURIComponent(`repo:${repo} label:"good first issue" state:open`);
+      const q = encodeURIComponent(`${repoQualifier} label:"good first issue" state:open`);
       const res = await fetchWithFallback(
         `https://api.github.com/search/issues?q=${q}&per_page=30&sort=created&order=desc`,
         { headers: ghHeaders }
@@ -189,7 +193,7 @@ export default async function handler(req) {
       return new Response(JSON.stringify({ gfi: cached.gfi }), { status: 200, headers });
     }
     try {
-      const q = encodeURIComponent(`repo:${repo} label:"good first issue" state:open`);
+      const q = encodeURIComponent(`${repoQualifier} label:"good first issue" state:open`);
       const res = await fetchWithFallback(
         `https://api.github.com/search/issues?q=${q}&per_page=1`,
         { headers: ghHeaders }
@@ -213,35 +217,59 @@ export default async function handler(req) {
   }
 
   try {
-    const [repoRes, commitsRes] = await Promise.all([
-      fetchWithFallback(`https://api.github.com/repos/${repo}`, { headers: ghHeaders }),
-      fetchWithFallback(`https://api.github.com/repos/${repo}/commits?per_page=1`, { headers: ghHeaders }),
-    ]);
+    let repoData, lastCommit = '—', activityDays = 9999;
 
-    if (!repoRes.ok) {
-      const err = await repoRes.json().catch(() => ({}));
-      return new Response(JSON.stringify({ error: err.message || 'Repo not found' }), { status: repoRes.status, headers });
-    }
+    if (isOwnerOnly) {
+      // Owner-only GitHub value: fetch org-level info instead of repo stats
+      const orgRes = await fetchWithFallback(`https://api.github.com/orgs/${repo}`, { headers: ghHeaders });
+      if (!orgRes.ok) {
+        return new Response(JSON.stringify({
+          name: repo,
+          description: 'Organization-level GitHub entry — no specific repository. Good First Issues are searched across all repos in this org.',
+          stars: null, forks: null, open_issues: null,
+          lastCommit: '—', activity: 'unknown',
+          isOwnerOnly: true,
+        }), { status: 200, headers });
+      }
+      const orgData = await orgRes.json();
+      repoData = {
+        name: orgData.name || repo,
+        full_name: repo,
+        description: orgData.description || 'Organization-level GitHub entry',
+        stargazers_count: null,
+        forks_count: null,
+        open_issues_count: null,
+        html_url: orgData.html_url || `https://github.com/${repo}`,
+        isOwnerOnly: true,
+      };
+    } else {
+      const [repoRes, commitsRes] = await Promise.all([
+        fetchWithFallback(`https://api.github.com/repos/${repo}`, { headers: ghHeaders }),
+        fetchWithFallback(`https://api.github.com/repos/${repo}/commits?per_page=1`, { headers: ghHeaders }),
+      ]);
 
-    const repoData = await repoRes.json();
+      if (!repoRes.ok) {
+        const err = await repoRes.json().catch(() => ({}));
+        return new Response(JSON.stringify({ error: err.message || 'Repo not found' }), { status: repoRes.status, headers });
+      }
 
-    let lastCommit = '—';
-    let activityDays = 9999;
-    if (commitsRes.ok) {
-      try {
-        const commits = await commitsRes.json();
-        if (commits[0]?.commit?.author?.date) {
-          const d = new Date(commits[0].commit.author.date);
-          activityDays = Math.floor((Date.now() - d) / 86400000);
-          if (activityDays === 0) lastCommit = 'Today';
-          else if (activityDays === 1) lastCommit = '1d ago';
-          else if (activityDays < 30) lastCommit = `${activityDays}d ago`;
-          else if (activityDays < 365) lastCommit = `${Math.floor(activityDays / 30)}mo ago`;
-          else lastCommit = `${Math.floor(activityDays / 365)}y ago`;
+      repoData = await repoRes.json();
+
+      if (commitsRes.ok) {
+        try {
+          const commits = await commitsRes.json();
+          if (commits[0]?.commit?.author?.date) {
+            const d = new Date(commits[0].commit.author.date);
+            activityDays = Math.floor((Date.now() - d) / 86400000);
+            if (activityDays === 0) lastCommit = 'Today';
+            else if (activityDays === 1) lastCommit = '1d ago';
+            else if (activityDays < 30) lastCommit = `${activityDays}d ago`;
+            else if (activityDays < 365) lastCommit = `${Math.floor(activityDays / 30)}mo ago`;
+            else lastCommit = `${Math.floor(activityDays / 365)}y ago`;
+          }
+        } catch {
+          // Non-JSON body — fall through with safe defaults
         }
-      } catch {
-        // Non-JSON body (CDN error page, Cloudflare interstitial, empty response).
-        // Fall through with safe defaults: lastCommit = '—', activityDays = 9999.
       }
     }
 

--- a/api/github.js
+++ b/api/github.js
@@ -3,13 +3,6 @@ export const config = { runtime: 'edge' };
 const CACHE = new Map();
 const CACHE_TTL = 60 * 60 * 1000; // 1 hour
 const CACHE_MAX_SIZE = 1000;
-const OWNER_NAME_RE = /^[\w.-]+$/;
-const FULL_REPO_RE = /^[\w.-]+\/[\w.-]+$/;
-
-function buildRepoQualifier(repo, isOwnerOnly) {
-  if (!repo) return '';
-  return isOwnerOnly ? `org:${repo}` : `repo:${repo}`;
-}
 
 function safeCacheSet(key, value) {
   if (!CACHE.has(key) && CACHE.size >= CACHE_MAX_SIZE) {
@@ -36,13 +29,12 @@ export default async function handler(req) {
   const user = searchParams.get('user');
   const gfiMode = searchParams.get('gfi') === '1';
   const issuesMode = searchParams.get('issues') === '1';
-  const isOwnerOnly = !!repo && !repo.includes('/');
 
   if (!repo && !user) {
     return new Response(JSON.stringify({ error: 'Missing repo or user parameter' }), { status: 400, headers });
   }
 
-  if (repo && !(isOwnerOnly ? OWNER_NAME_RE.test(repo) : FULL_REPO_RE.test(repo))) {
+  if (repo && !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
     return new Response(JSON.stringify({ error: 'Invalid repo' }), { status: 400, headers });
   }
 
@@ -164,7 +156,7 @@ export default async function handler(req) {
       return new Response(JSON.stringify({ total: cached.total, items: cached.items, cached: true }), { status: 200, headers });
     }
     try {
-      const q = encodeURIComponent(`${buildRepoQualifier(repo, isOwnerOnly)} label:"good first issue" state:open`);
+      const q = encodeURIComponent(`repo:${repo} label:"good first issue" state:open`);
       const res = await fetchWithFallback(
         `https://api.github.com/search/issues?q=${q}&per_page=30&sort=created&order=desc`,
         { headers: ghHeaders }
@@ -197,7 +189,7 @@ export default async function handler(req) {
       return new Response(JSON.stringify({ gfi: cached.gfi }), { status: 200, headers });
     }
     try {
-      const q = encodeURIComponent(`${buildRepoQualifier(repo, isOwnerOnly)} label:"good first issue" state:open`);
+      const q = encodeURIComponent(`repo:${repo} label:"good first issue" state:open`);
       const res = await fetchWithFallback(
         `https://api.github.com/search/issues?q=${q}&per_page=1`,
         { headers: ghHeaders }
@@ -221,46 +213,6 @@ export default async function handler(req) {
   }
 
   try {
-    if (isOwnerOnly) {
-      const orgRes = await fetchWithFallback(`https://api.github.com/orgs/${repo}`, { headers: ghHeaders });
-      if (!orgRes.ok) {
-        return new Response(JSON.stringify({
-          name: repo,
-          description: 'Organization-level GitHub entry — no specific repository. Good First Issues are searched across all repos in this org.',
-          stars: null,
-          forks: null,
-          issues: null,
-          watchers: null,
-          lastCommit: '—',
-          activity: 'unknown',
-          language: null,
-          gfi: null,
-          ts: Date.now(),
-          isOwnerOnly: true,
-        }), { status: 200, headers });
-      }
-
-      const repoData = await orgRes.json();
-
-      const result = {
-        name: repoData.name || repo,
-        description: repoData.description || 'Organization-level GitHub entry',
-        stars: null,
-        forks: null,
-        issues: null,
-        watchers: null,
-        lastCommit: '—',
-        activity: 'unknown',
-        language: null,
-        gfi: null,
-        ts: Date.now(),
-        isOwnerOnly: true,
-      };
-
-      safeCacheSet(repo, result);
-      return new Response(JSON.stringify(result), { status: 200, headers });
-    }
-
     const [repoRes, commitsRes] = await Promise.all([
       fetchWithFallback(`https://api.github.com/repos/${repo}`, { headers: ghHeaders }),
       fetchWithFallback(`https://api.github.com/repos/${repo}/commits?per_page=1`, { headers: ghHeaders }),
@@ -276,12 +228,7 @@ export default async function handler(req) {
     let lastCommit = '—';
     let activityDays = 9999;
     if (commitsRes.ok) {
-      let commits = [];
-      try {
-        commits = await commitsRes.json();
-      } catch {
-        commits = [];
-      }
+      const commits = await commitsRes.json();
       if (commits[0]?.commit?.author?.date) {
         const d = new Date(commits[0].commit.author.date);
         activityDays = Math.floor((Date.now() - d) / 86400000);
@@ -299,13 +246,12 @@ export default async function handler(req) {
       stars: repoData.stargazers_count,
       forks: repoData.forks_count,
       issues: repoData.open_issues_count,
-      watchers: repoData.watchers_count ?? null,
+      watchers: repoData.watchers_count,
       lastCommit,
       activity,
-      language: repoData.language ?? null,
+      language: repoData.language,
       gfi: null,  // fetched separately via ?gfi=1 to avoid rate limiting
       ts: Date.now(),
-      isOwnerOnly: false,
     };
 
     safeCacheSet(repo, result);

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -137,7 +137,9 @@ document.addEventListener('DOMContentLoaded', () => {
       const ext = file.name.split('.').pop().toLowerCase();
       const validExts = ['txt', 'text', 'md', 'csv', 'json', 'xml', 'html', 'htm', 'log', 'ini', 'cfg', 'yaml', 'yml', 'toml', 'conf', 'sh', 'bat', 'ps1'];
       const validMimes = ['text/', 'application/json', 'application/xml', 'application/x-yaml'];
-      const isTextFile = validExts.includes(ext) && validMimes.some(m => file.type.startsWith(m));
+      const hasValidExt = validExts.includes(ext);
+      const hasValidMime = !file.type || validMimes.some((m) => file.type.startsWith(m));
+      const isTextFile = hasValidExt && hasValidMime;
       if (!isTextFile) {
         showError(`Unsupported file type ".${ext}". Please upload a plain text file (.txt).`);
         fileUpload.value = '';

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -137,18 +137,18 @@ document.addEventListener('DOMContentLoaded', () => {
       const ext = file.name.split('.').pop().toLowerCase();
       const validExts = ['txt', 'text', 'md', 'csv', 'json', 'xml', 'html', 'htm', 'log', 'ini', 'cfg', 'yaml', 'yml', 'toml', 'conf', 'sh', 'bat', 'ps1'];
       const validMimes = ['text/', 'application/json', 'application/xml', 'application/x-yaml'];
-      const isTextFile = validExts.includes(ext) || validMimes.some(m => file.type.startsWith(m));
+      const isTextFile = validExts.includes(ext) && validMimes.some(m => file.type.startsWith(m));
       if (!isTextFile) {
         showError(`Unsupported file type ".${ext}". Please upload a plain text file (.txt).`);
         fileUpload.value = '';
         return;
       }
+      if (file.size > 51200) {
+        showError('File is too large. Please upload a file under 50 KB.');
+        fileUpload.value = '';
+        return;
+      }
       file.text().then(text => {
-        if (text.length > 50000) {
-          showError('File is too large. Please upload a file under 50 KB.');
-          fileUpload.value = '';
-          return;
-        }
         resumeText.value = text;
       }).catch(err => {
         console.error("File Read Error:", err);

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -134,7 +134,21 @@ document.addEventListener('DOMContentLoaded', () => {
     fileUpload.addEventListener('change', (e) => {
       const file = e.target.files[0];
       if (!file) return;
+      const ext = file.name.split('.').pop().toLowerCase();
+      const validExts = ['txt', 'text', 'md', 'csv', 'json', 'xml', 'html', 'htm', 'log', 'ini', 'cfg', 'yaml', 'yml', 'toml', 'conf', 'sh', 'bat', 'ps1'];
+      const validMimes = ['text/', 'application/json', 'application/xml', 'application/x-yaml'];
+      const isTextFile = validExts.includes(ext) || validMimes.some(m => file.type.startsWith(m));
+      if (!isTextFile) {
+        showError(`Unsupported file type ".${ext}". Please upload a plain text file (.txt).`);
+        fileUpload.value = '';
+        return;
+      }
       file.text().then(text => {
+        if (text.length > 50000) {
+          showError('File is too large. Please upload a file under 50 KB.');
+          fileUpload.value = '';
+          return;
+        }
         resumeText.value = text;
       }).catch(err => {
         console.error("File Read Error:", err);


### PR DESCRIPTION
## Description

Fixes #1736

The resume/skills uploader now rejects unsupported files before reading them as text. This prevents binary or XML content from being treated as resume input and keeps skill extraction and recommendations reliable.

## Changes

### `src/js/recommendation-ui.js`

Added validation before processing uploaded files:
1. **Extension check** — Only allows supported text-based formats.
2. **MIME type check** — Requires a text-like MIME type alongside the extension.
3. **Size limit** — Rejects files over 50 KB before reading them.
4. **Error messaging** — Shows a clear error when an unsupported file is selected.
5. **Input reset** — Clears the file input on rejection so users can retry.

## Testing

- `git diff --check`
- `node --check src/js/recommendation-ui.js`