### PR TITLE
feat: add tech stack tags to Good First Issues closes #632

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1772,6 +1772,13 @@ async function renderGoodFirstIssues() {
         <p class="text-xs text-zinc-500 mb-3 font-mono">${issue.repo || ''}</p>
         <div class="flex flex-wrap gap-1.5">
           ${labelsHtml}
+          ${issue.tech_stack && issue.tech_stack.length ? 
+  `<div class="flex flex-wrap gap-1 mt-1">
+    ${issue.tech_stack.slice(0,3).map(t => 
+      `<span class="text-[10px] px-2 py-0.5 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded-full font-mono">${t}</span>`
+    ).join('')}
+  </div>` 
+: ''}
           <span class="text-[10px] px-2 py-0.5 bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 rounded">${String(issue.comments || 0)} comments</span>
         </div>`;
       container.appendChild(card);


### PR DESCRIPTION
## What changes did I make?
Added tech stack tags to Good First Issues section so contributors can see required programming languages before picking an issue.

## How does it work?
Each issue card now shows language/framework tags below the existing labels.

Fixes #632

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

