### PR TITLE
fix: auto-scroll focused organization card during keyboard navigation

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -647,9 +647,15 @@ const GRID_COLS = () => {
 
 function scrollToFocused() {
   setTimeout(() => {
-    const g = document.getElementById('orgGrid');
-    const card = g?.querySelector(`[data-filtered-idx="${focusedIdx}"]`);
-    if (card) card.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    const cards = document.querySelectorAll('#orgGrid article');
+    const card = cards[focusedIdx];
+    if (card) {
+      card.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'nearest'
+      });
+    }
   }, 30);
 }
 


### PR DESCRIPTION
## Summary

This PR fixes the keyboard navigation scrolling issue in the Organizations section.

### What Changed
- Updated the card selection logic so the focused organization card is automatically scrolled into view during keyboard navigation.
- Removed the dependency on the missing `data-filtered-idx` attribute by locating the focused card from the rendered card list.
- Preserved existing keyboard navigation, search, filtering, and selection behavior.

### Related Issue
Fixes #2038

### Type of Change
- [x] Bug fix

### Testing
- Verified keyboard navigation using Arrow Up/Down/Left/Right.
- Confirmed the focused card scrolls into view automatically.
- Verified search and filters continue to work correctly.
- Checked that there are no console errors.

### Checklist
- [x] Code follows the project style.
- [x] Tested locally.
- [x] No unrelated changes included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/2041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

